### PR TITLE
Multiple templates

### DIFF
--- a/core/src/main/scala/org/dbpedia/extraction/mappings/TemplateMapping.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/mappings/TemplateMapping.scala
@@ -73,17 +73,21 @@ extends Mapping[TemplateNode]
     {
         val pageClasses = node.root.getAnnotation(TemplateMapping.CLASS_ANNOTATION) match {
           case Some(classes) => classes
-          case None => return
+          case None => Seq.empty
         }
 
-        // Compute missing types, i.e. the set difference between
+        // Compute missing types, i.e. the set difference between the page classes and this TemplateMapping relatedClasses
         val (mainSet, secondarySet) =
           if (mapToClass.relatedClasses.size >=  pageClasses.size) (mapToClass.relatedClasses, pageClasses)
           else (pageClasses, mapToClass.relatedClasses)
 
         val diffSet = mainSet.diff(secondarySet)
 
-        // Set missing annotations
+        // Set annotations
+        node.setAnnotation(TemplateMapping.CLASS_ANNOTATION, mapToClass.relatedClasses);
+        node.setAnnotation(TemplateMapping.INSTANCE_URI_ANNOTATION, uri);
+
+        // Set missing annotations in the PageNode
         node.root.setAnnotation(TemplateMapping.CLASS_ANNOTATION, pageClasses ++ diffSet)
 
         // Create missing type statements


### PR DESCRIPTION
Please accept this contribution for multiple templates handling.
I have added some code to manage secondary TemplateNode annotations for which no new URI is created. Please confirm everything is ok.
Tested also with mapToClass = owl:Thing and everything is working as expected.
