### PR TITLE
Fix Travis CI build failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ jdk:
 branches:
   only:
     - master
+install: /bin/true
+script: "mvn clean install"
 notifications:
   email:
     recipients:


### PR DESCRIPTION
Added explicit commands for the install and build targets.
See
https://travis-ci.org/ninniuz/extraction-framework/builds/5776573
