### PR TITLE
Do not raise exceptions with empty links from Wikidata

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ branches:
 install: /bin/true
 script: "mvn clean install"
 notifications:
+notifications:
   email:
     recipients:
       - dbpedia-developers@lists.sourceforge.net

--- a/core/src/main/scala/org/dbpedia/extraction/wikiparser/impl/json/JsonWikiParser.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/wikiparser/impl/json/JsonWikiParser.scala
@@ -46,7 +46,11 @@ class JsonWikiParser {
       case _ => throw new IllegalStateException("Invalid JSON representation!")
     }
 
-    val JObject(interLinks) = (jsonObjMap \ "links") //.getOrElse("links", Map[String, String]()).asInstanceOf[Map[String,String]]
+    val interLinks = (jsonObjMap \ "links") match {
+      case JObject(links) => links
+      case _ => List()
+    }
+
     val interLinksMap = collection.mutable.Map[String, String]()
 
     interLinks.foreach { interLink : JField =>


### PR DESCRIPTION
This should fix exceptions raised when parsing Wikidata pages with no links in them.
