### PR TITLE
Reject long predicates

### DIFF
--- a/core/src/main/scala/org/dbpedia/extraction/destinations/formatters/UriPolicy.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/destinations/formatters/UriPolicy.scala
@@ -1,6 +1,6 @@
 package org.dbpedia.extraction.destinations.formatters
 
-import java.net.URI
+import java.net.{URISyntaxException, URI}
 import org.dbpedia.extraction.util.Language
 import scala.xml.Utility.{isNameChar,isNameStart}
 
@@ -30,6 +30,9 @@ object UriPolicy {
   
   // indicates that a predicate matches all positions
   val ALL = -1
+
+  // URI/IRI length
+  val MAX_URI_LENGTH = 512
   
   def uri(activeFor: Predicate): Policy = {
     
@@ -56,6 +59,18 @@ object UriPolicy {
       var frag = iri.getRawFragment
       
       uri(scheme, user, host, port, path, query, frag)
+    }
+    else {
+      iri
+    }
+  }
+
+  def validateUriLength(activeFor: Predicate): Policy = {
+
+    iri =>
+    if (activeFor(iri)) {
+      if (iri.toString.length > MAX_URI_LENGTH) throw new URISyntaxException(iri.toString, "URI/IRI is too long!")
+      else iri
     }
     else {
       iri

--- a/dump/src/main/scala/org/dbpedia/extraction/dump/extract/PolicyParser.scala
+++ b/dump/src/main/scala/org/dbpedia/extraction/dump/extract/PolicyParser.scala
@@ -38,7 +38,11 @@ object PolicyParser {
       ("xml-safe", 2, xmlSafe),
       ("generic", 3, generic)
     )
-    
+
+    val partialPolicies = Seq[(String, Int, Predicate => Policy, Seq[(String, Int)])] (
+      ("validate-uri-length", 4, validateUriLength, Seq(("-predicates", PREDICATE)))
+    )
+
     /**
      * Tuples of suffix and position code.
      */
@@ -54,8 +58,17 @@ object PolicyParser {
     val product = for ((prefix, prio, factory) <- policies; (suffix, position) <- positions) yield {
       prefix+suffix -> (prio, position, factory)
     }
-    
-    product.toMap
+
+    val partialPoliciesProduct =
+      for (
+        (prefix, prio, factory, positions) <- partialPolicies;
+        (suffix, position) <- positions
+      )
+      yield {
+      prefix+suffix -> (prio, position, factory)
+    }
+
+    (product ++ partialPoliciesProduct).toMap
   }
   
   val formatters = Map[String, Array[Policy] => Formatter] (


### PR DESCRIPTION
Implemented an extension of the UriPolicy which rejects predicates which length > 512 chars.
The UriPolicy property is called "validate-uri-length" and only accepts "-predicates" as suffix.

Fix for #29
