### PR TITLE
Bug Fix for Date Time Parser.

### DIFF
--- a/core/src/main/scala/org/dbpedia/extraction/dataparser/DateTimeParser.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/dataparser/DateTimeParser.scala
@@ -68,7 +68,7 @@ class DateTimeParser ( context : {
 
     private val MonthYearRegex = ("""(?iu)""" + prefix + """("""+monthRegex+""")\]?\]?,?\s*\[?\[?([0-9]{1,4})\s*(""" + eraRegex + """)?""" + postfix).r
 
-    private val YearRegex = ("""(?iu)""" + prefix + """(?<![\d\pL\w])(\d{1,4})(?!\d)\s*(""" + eraRegex + """)?""" + postfix).r
+    private val YearRegex = ("""(?iu)""" + prefix + """(?<![\d\pL\w])(-?\d{1,4})(?!\d)\s*(""" + eraRegex + """)?""" + postfix).r
 
 
     override def parse(node : Node) : Option[Date] =
@@ -164,6 +164,7 @@ class DateTimeParser ( context : {
                     catch
                     {
                         case e : IllegalArgumentException =>
+                        case e : MatchError => 
                     }
                 }
             }

--- a/core/src/test/scala/org/dbpedia/extraction/dataparser/DateTimeParserTest.scala
+++ b/core/src/test/scala/org/dbpedia/extraction/dataparser/DateTimeParserTest.scala
@@ -535,7 +535,11 @@ class DateTimeParserTest extends FlatSpec with ShouldMatchers
     {
         parse("fr", "xsd:date", "15 mars 44") should equal (Some("1944-03-15"))
     }
-    /*"DataParser" should "return date (Jully the 13th of the year 100 before J.-C.)" in
+    "DataParser" should "return date (January the 1st of the year -711)" in
+    {
+        parse("fr", "xsd:date", "{{Date de naissance|1|1|-711}}") should equal (Some("-0711-01-01"))
+    }
+    /*"DataParser" should "return date (July the 13th of the year 100 before J.-C.)" in
     {
         parse("fr", "xsd:date", "13 juillet -100 av. J.-C.") should equal (Some("-0100-07-13"))
     }*/


### PR DESCRIPTION
Small fix after pull request #74.

A regex matching error was raised for negative dates in templates
- modified the regex
- added corresponding test
