### PR TITLE
Collect disambiguation pages from Wikipedia SQL files

### DIFF
--- a/core/src/main/scala/org/dbpedia/extraction/mappings/DisambiguationExtractor.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/mappings/DisambiguationExtractor.scala
@@ -11,8 +11,9 @@ import org.dbpedia.extraction.util.Language
  */
 class DisambiguationExtractor(
   context : {
-    def ontology : Ontology
-    def language : Language
+    def disambiguations : Disambiguations
+    def ontology        : Ontology
+    def language        : Language
   }
 )
 extends Extractor
@@ -27,7 +28,7 @@ extends Extractor
 
   override def extract(page : PageNode, subjectUri : String, pageContext : PageContext) : Seq[Quad] =
   {
-    if (page.title.namespace == Namespace.Main && page.isDisambiguation)
+    if (page.title.namespace == Namespace.Main && (page.isDisambiguation || context.disambiguations.isDisambiguation(page.id)))
     {
       val allLinks = collectInternalLinks(page)
       

--- a/core/src/main/scala/org/dbpedia/extraction/mappings/Disambiguations.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/mappings/Disambiguations.scala
@@ -1,0 +1,107 @@
+package org.dbpedia.extraction.mappings
+
+import java.util.logging.{Level, Logger}
+import java.io._
+import org.dbpedia.extraction.util.Language
+import org.dbpedia.extraction.util.RichReader._
+import collection.mutable.{HashSet}
+
+/**
+ */
+class Disambiguations(val set : Set[Long])
+{
+  /**
+   */
+  def isDisambiguation(id : Long) : Boolean =
+  {
+     set.contains(id)
+  }
+}
+
+/**
+ */
+object Disambiguations
+{
+  private val logger = Logger.getLogger(classOf[Disambiguations].getName)
+
+  /**
+   */
+  def load(reader : () => Reader, cache : File, lang : Language) : Disambiguations =
+  {
+    try
+    {
+      return loadFromCache(cache)
+    }
+    catch
+      {
+        case ex : Exception => logger.log(Level.INFO, "Will extract disambiguations from source for "+lang.wikiCode+" wiki, could not load cache file '"+cache+"': "+ex)
+      }
+
+    val disambiguations = loadFromFile(reader, lang)
+
+    val dir = cache.getParentFile
+    if (! dir.exists && ! dir.mkdirs) throw new IOException("cache dir ["+dir+"] does not exist and cannot be created")
+    val outputStream = new ObjectOutputStream(new FileOutputStream(cache))
+    try
+    {
+      outputStream.writeObject(disambiguations.set)
+    }
+    finally
+    {
+      outputStream.close()
+    }
+    logger.info(disambiguations.set.size + " disambiguations written to cache file " + cache)
+
+    disambiguations
+  }
+
+  /**
+   */
+  private def loadFromCache(cache : File) : Disambiguations =
+  {
+    logger.info("Loading disambiguations from cache file " + cache)
+    val inputStream = new ObjectInputStream(new FileInputStream(cache))
+    try
+    {
+      val disambiguations = new Disambiguations(inputStream.readObject().asInstanceOf[Set[Long]])
+
+      logger.info(disambiguations.set.size + " disambiguations loaded from cache file " + cache)
+      disambiguations
+    }
+    finally
+    {
+      inputStream.close()
+    }
+  }
+
+  /**
+   */
+  def loadFromFile(reader : () => Reader, lang : Language) : Disambiguations =
+  {
+    logger.info("Loading disambiguations from source (" + lang.wikiCode + ")")
+
+    val disambiguationsFinder = new DisambiguationsFinder(lang)
+
+    val disambiguations = new Disambiguations(disambiguationsFinder(reader))
+
+    logger.info("Disambiguations loaded from source ("+lang.wikiCode+")")
+    disambiguations
+  }
+
+  private class DisambiguationsFinder(lang : Language)
+  {
+    // (264534,'disambiguation','')
+    val regex = """\((\d+),'disambiguation',''\)""".r
+
+    def apply(reader : () => Reader): Set[Long]=
+    {
+      val d = HashSet[Long]()
+      val r = reader()
+      r.foreach { line =>
+        d ++= regex.findAllIn(line).matchData.map { m => m.group(1).toLong }.toSet
+      }
+      r.close()
+      d.toSet
+    }
+  }
+}

--- a/dump/src/main/scala/org/dbpedia/extraction/dump/extract/Config.scala
+++ b/dump/src/main/scala/org/dbpedia/extraction/dump/extract/Config.scala
@@ -29,6 +29,7 @@ extends ConfigParser(config)
   val requireComplete = config.getProperty("require-download-complete", "false").toBoolean
   
   val source = config.getProperty("source", "pages-articles.xml")
+  val disambiguations = config.getProperty("disambiguations", "page_props.sql.gz")
 
   val wikiName = config.getProperty("wikiName", "wiki")
 

--- a/dump/src/main/scala/org/dbpedia/extraction/dump/extract/ConfigLoader.scala
+++ b/dump/src/main/scala/org/dbpedia/extraction/dump/extract/ConfigLoader.scala
@@ -97,6 +97,14 @@ class ConfigLoader(config: Config)
             }
             
             def redirects : Redirects = _redirects
+
+            private val _disambiguations =
+            {
+              val cache = finder.file(date, "disambiguations-ids.obj")
+              Disambiguations.load(reader(finder.file(date, config.disambiguations)), cache, language)
+            }
+
+            def disambiguations : Disambiguations = if (_disambiguations != null) _disambiguations else new Disambiguations(Set[Long]())
         }
 
         //Extractors

--- a/dump/src/main/scala/org/dbpedia/extraction/dump/extract/DumpExtractionContext.scala
+++ b/dump/src/main/scala/org/dbpedia/extraction/dump/extract/DumpExtractionContext.scala
@@ -4,7 +4,7 @@ import org.dbpedia.extraction.ontology.Ontology
 import org.dbpedia.extraction.util.Language
 import org.dbpedia.extraction.sources.Source
 import org.dbpedia.extraction.wikiparser.PageNode
-import org.dbpedia.extraction.mappings.{Mappings, Redirects}
+import org.dbpedia.extraction.mappings.{Disambiguations, Mappings, Redirects}
 
 /**
  * TODO: remove this class. Different extractors need different resources. We should use some kind
@@ -35,5 +35,7 @@ trait DumpExtractionContext
     def articlesSource : Source
 
     def redirects : Redirects
+
+    def disambiguations : Disambiguations
 }
 


### PR DESCRIPTION
This reads a page props file as specified in the configuration file extracting pages which have the "disambiguation" page prop.
This set of pageids is stored in a file cache (as for the template redirects).
The DisambiguationExtractor will used this set of pageids, available through the extraction context, to discern disambiguation pages.
