### PR TITLE
Handle parts files for parallelization

### DIFF
--- a/core/src/main/scala/org/dbpedia/extraction/util/FileLike.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/util/FileLike.scala
@@ -27,6 +27,8 @@ abstract class FileLike[T <% FileLike[T]] {
   
   def delete(recursive: Boolean = false): Unit
 
+  def size(): Long
+
   def isFile: Boolean
 
   def isDirectory: Boolean

--- a/core/src/main/scala/org/dbpedia/extraction/util/Finder.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/util/Finder.scala
@@ -74,4 +74,17 @@ class Finder[T](val baseDir: T, val language: Language, val wikiNameGiven: Strin
    * "baseDir/enwiki/20120403/enwiki-20120403-pages-articles.xml"
    */
   def file(date: String, suffix: String) = directory(date).resolve(wikiName+'-'+date+'-'+suffix)
+
+  /**
+   * Files which match the supplied pattern in data directory for language.
+   * Files are sorted by size (descending)
+   *
+   * @param date
+   * @param pattern
+   * @return
+   */
+  def matchFiles(date: String, pattern: String): List[T] = {
+    val regex = (wikiName + "-" + date + "-" + pattern).r
+    directory(date).list.sortBy(_.size()).reverse.map(_.name).filter(regex.findAllIn(_).matchData.nonEmpty).map(directory(date).resolve(_))
+  }
 }

--- a/core/src/main/scala/org/dbpedia/extraction/util/RichFile.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/util/RichFile.scala
@@ -43,7 +43,9 @@ class RichFile(file: File) extends FileLike[File] {
     if (list == null) throw new IOException("failed to list files in ["+file+"]")
     list.toList
   } 
-  
+
+  override def size: Long = file.length()
+
   // TODO: more efficient type than List?
   override def list: List[File] = list(null) 
   

--- a/core/src/main/scala/org/dbpedia/extraction/util/RichPath.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/util/RichPath.scala
@@ -82,7 +82,9 @@ class RichPath(path: Path) extends FileLike[Path] {
     val stream = Files.newDirectoryStream(path, glob)
     try stream.toList finally stream.close
   }
-  
+
+  override def size: Long = Files.size(path)
+
   override def isFile: Boolean = Files.isRegularFile(path)
   
   override def isDirectory: Boolean = Files.isDirectory(path)

--- a/dump/download.minimal.properties
+++ b/dump/download.minimal.properties
@@ -8,6 +8,8 @@ base-dir=/path/to/download/folder
 
 # Replace xx by your language.
 download=xx:pages-articles.xml.bz2
+# To download parts files
+# download=xx:@pages-articles\d+\.xml-p\d+p\d+\.bz2
 
 # Only needed for the ImageExtractor
 # download=commons:pages-articles.xml.bz2

--- a/dump/extraction.default.properties
+++ b/dump/extraction.default.properties
@@ -12,6 +12,9 @@ base-dir=/home/release/wikipedia
 # source=pages-articles.xml.bz2
 # source=pages-articles.xml.gz
 
+# To extract from parts files
+# source=@pages-articles\\d+\\.xml-p\\d+p\\d+\\.bz2
+
 # use only directories that contain a 'download-complete' file? Default is false.
 require-download-complete=true
 

--- a/dump/src/main/scala/org/dbpedia/extraction/dump/download/Download.scala
+++ b/dump/src/main/scala/org/dbpedia/extraction/dump/download/Download.scala
@@ -55,7 +55,7 @@ object Download extends DownloadConfig
       for (((from, to), files) <- ranges; wiki <- wikis; if (from <= wiki.pages && wiki.pages <= to))
       {
         // ...add files for this range to files for this language
-        languages.getOrElseUpdate(wiki.language, new HashSet[String]) ++= files
+        languages.getOrElseUpdate(wiki.language, new HashSet[(String, Boolean)]) ++= files
       }
     }
     

--- a/dump/src/main/scala/org/dbpedia/extraction/dump/download/DownloadConfig.scala
+++ b/dump/src/main/scala/org/dbpedia/extraction/dump/download/DownloadConfig.scala
@@ -14,10 +14,14 @@ class DownloadConfig
   var baseUrl: URL = null
   
   var baseDir: File = null
-  
-  val languages = new HashMap[Language, Set[String]]
-  
-  val ranges = new HashMap[(Int,Int), Set[String]]
+
+  // Files to download for each language
+  // lang -> Set(filename, isRegex)
+  val languages = new HashMap[Language, Set[(String, Boolean)]]
+
+  // Ranges to download for each language
+  // (start,end) -> Set(filename, isRegex)
+  val ranges = new HashMap[(Int,Int), Set[(String, Boolean)]]
   
   var dateRange = ("00000000","99999999")
   
@@ -48,7 +52,7 @@ class DownloadConfig
    */
   def parse(dir: File, args: TraversableOnce[String]): Unit = {
     
-    val DownloadFiles = new TwoListArg("download", ":", ",")
+    val DownloadFiles = new TwoListArg("download", ":", ",", "@")
     
     for (a <- args; arg = a.trim) arg match
     {
@@ -67,7 +71,7 @@ class DownloadConfig
         if (! file.isFile) throw Usage("Invalid file "+file, arg)
         parse(file)
       case DownloadFiles(keys, files) =>
-        if (files.exists(_ isEmpty)) throw Usage("Invalid file name", arg)
+        if (files.exists(_._1 isEmpty)) throw Usage("Invalid file name", arg)
         for (key <- keys) key match {
           // FIXME: copy & paste in ConfigUtils and extract.Config
           case "@mappings" => for (language <- Namespace.mappings.keySet) add(languages, language, files)
@@ -79,8 +83,8 @@ class DownloadConfig
     }
   }
   
-  private def add[K](map: Map[K,Set[String]], key: K, values: Array[String]) = 
-    map.getOrElseUpdate(key, new HashSet[String]) ++= values
+  private def add[K](map: Map[K,Set[(String, Boolean)]], key: K, values: Array[(String, Boolean)]) =
+    map.getOrElseUpdate(key, new HashSet[(String, Boolean)]) ++= values
   
   private def toBoolean(s: String, arg: String): Boolean =
     if (s == "true" || s == "false") s.toBoolean else throw Usage("Invalid boolean value", arg) 
@@ -161,8 +165,9 @@ download=en,zh-yue,1000-2000,...:file1,file2,...
   code, or a range. In the latter case, languages with a matching number of articles will be used. 
   If the start of the range is omitted, 0 is used. If the end of the range is omitted, 
   infinity is used. For each language, a new sub-directory is created in the target directory.
-  Each file is a file name like 'pages-articles.xml.bz2', to which a prefix like 
-  'enwiki-20120307-' will be added. This argument can be used multiple times, for example 
+  Each file is a file name like 'pages-articles.xml.bz2' or a regex if it starts with a '@' (useful for
+  multiple files processing, i.e. multiple parts of the same file) to which a prefix like
+ 'enwiki-20120307-' will be added. This argument can be used multiple times, for example
   'download=en:foo.xml download=de:bar.xml'. '@mappings' means all languages that have a 
    mapping namespace on http://mappings.dbpedia.org.
 retry-max=5
@@ -175,21 +180,24 @@ pretty=true
   Should progress printer reuse one line? Doesn't work with log files, so default is false.
 Order is relevant - for single-value parameters, values read later overwrite earlier values.
 Empty arguments or arguments beginning with '#' are ignored.
-""" /* empty line */ 
+""" /* empty line */
     println(usage)
     
     new Exception(message, cause)
   }
 }
 
-class TwoListArg(key: String, sep1: String, sep2: String)
+class TwoListArg(key: String, sep1: String, sep2: String, partsIndicator: String)
 {
-  def unapply(arg: String): Option[(Array[String],Array[String])] = {
+  def unapply(arg: String): Option[(Array[String],Array[(String, Boolean)])] = {
     val index = arg.indexOf('=')
     if (index == -1 || arg.substring(0, index).trim != key) return None
     val parts = arg.substring(index + 1).trim.split(sep1, -1)
     if (parts.length != 2) return None
-    Some(parts(0).split(sep2, -1).map(_.trim), parts(1).split(sep2, -1).map(_.trim))
+
+    Some(parts(0).split(sep2, -1).map(_.trim), parts(1).split(sep2, -1).map { s =>
+      (if (s.trim.startsWith(partsIndicator)) s.trim.substring(partsIndicator.length()) else s.trim, s.trim.startsWith(partsIndicator))
+    })
   }
 }
 

--- a/dump/src/main/scala/org/dbpedia/extraction/dump/extract/ConfigLoader.scala
+++ b/dump/src/main/scala/org/dbpedia/extraction/dump/extract/ConfigLoader.scala
@@ -80,12 +80,16 @@ class ConfigLoader(config: Config)
                 MappingsLoader.load(this)
             }
             def mappings : Mappings = _mappings
-    
+
             private val _articlesSource =
             {
-                XMLSource.fromReader(reader(finder.file(date, config.source)), language,                    
-                    title => title.namespace == Namespace.Main || title.namespace == Namespace.File ||
-                             title.namespace == Namespace.Category || title.namespace == Namespace.Template)
+              val readers = if (config.source.startsWith("@")) {
+                finder.matchFiles(date, config.source.substring(1)).map(reader(_))
+              } else List(reader(finder.file(date, config.source)))
+
+              XMLSource.fromReaders(readers, language,
+                title => title.namespace == Namespace.Main || title.namespace == Namespace.File ||
+                  title.namespace == Namespace.Category || title.namespace == Namespace.Template)
             }
             
             def articlesSource = _articlesSource


### PR DESCRIPTION
- Download multiple files by specifying a regex in the config file
- Process multiple files by specifying a regex in the extraction config file
- Set a multiple xml readers source with matching files
- Process multiple source with an ExecutorService
