### PR TITLE
Issue #23: Use template redirects on DBpedia server

### DIFF
--- a/server/src/main/scala/org/dbpedia/extraction/server/DynamicExtractionManager.scala
+++ b/server/src/main/scala/org/dbpedia/extraction/server/DynamicExtractionManager.scala
@@ -1,7 +1,7 @@
 package org.dbpedia.extraction.server
 
 import org.dbpedia.extraction.sources.WikiPage
-import org.dbpedia.extraction.mappings.{Mappings,RootExtractor}
+import org.dbpedia.extraction.mappings.{Redirects, Mappings, RootExtractor}
 import org.dbpedia.extraction.util.Language
 import org.dbpedia.extraction.ontology.Ontology
 import org.dbpedia.extraction.wikiparser.{PageNode, WikiTitle}
@@ -20,8 +20,8 @@ import scala.actors.Actor
  * mappingPageSource is called by loadMappings in the base class, 
  * ontologyPages is called by loadOntology in the base class.
  */
-class DynamicExtractionManager(update: (Language, Mappings) => Unit, languages : Seq[Language], paths: Paths) 
-extends ExtractionManager(languages, paths)
+class DynamicExtractionManager(update: (Language, Mappings) => Unit, languages : Seq[Language], paths: Paths, redirects: Map[Language, Redirects])
+extends ExtractionManager(languages, paths, redirects)
 {
     // TODO: remove this field. Clients should get the ontology pages directly from the
     // mappings wiki, not from here. We don't want to keep all ontology pages in memory.

--- a/server/src/main/scala/org/dbpedia/extraction/server/ExtractionManager.scala
+++ b/server/src/main/scala/org/dbpedia/extraction/server/ExtractionManager.scala
@@ -18,7 +18,7 @@ import java.net.URL
  * or they can support lazy loading of context parameters.
  */
 
-abstract class ExtractionManager(languages : Seq[Language], paths: Paths)
+abstract class ExtractionManager(languages : Seq[Language], paths: Paths, redirects: Map[Language, Redirects])
 {
   self =>
     
@@ -167,8 +167,9 @@ abstract class ExtractionManager(languages : Seq[Language], paths: Paths)
     {
       new RootExtractor(
         new CompositeExtractor(
-          new LabelExtractor(new {val ontology = self.ontology; val language = lang}), 
-          new MappingExtractor(new {val mappings = self.mappings(lang); val redirects = new Redirects(Map())})
+          new LabelExtractor(new {val ontology = self.ontology; val language = lang}),
+          new MappingExtractor(new {val mappings = self.mappings(lang);
+                                    val redirects = self.redirects.getOrElse(lang, new Redirects(Map()))})
         )
       )
     }

--- a/server/src/main/scala/org/dbpedia/extraction/server/StaticExtractionManager.scala
+++ b/server/src/main/scala/org/dbpedia/extraction/server/StaticExtractionManager.scala
@@ -12,8 +12,8 @@ import java.io.File
  * Is NOT able to update the ontology or the mappings.
  * This manager is good for testing locally.
  */
-class StaticExtractionManager(update: (Language, Mappings) => Unit, languages : Seq[Language], paths: Paths)
-extends ExtractionManager(languages, paths)
+class StaticExtractionManager(update: (Language, Mappings) => Unit, languages : Seq[Language], paths: Paths, redirects: Map[Language, Redirects])
+extends ExtractionManager(languages, paths, redirects)
 {
     @volatile private lazy val _ontologyPages : Map[WikiTitle, PageNode] = loadOntologyPages
 


### PR DESCRIPTION
With this change the Server will read template redirects information from the
Wiki statistics as extracted by the CreateStats script.
The Server only polishes the data a bit in order to remove the template namespace
from the WikiTitles. Redirects are then propagated to ExtractionManagers which add them
to the Extractors contexts.
