### PR TITLE
Select correct MIME type for server sample extraction response

### DIFF
--- a/server/src/main/scala/org/dbpedia/extraction/server/resources/Extraction.scala
+++ b/server/src/main/scala/org/dbpedia/extraction/server/resources/Extraction.scala
@@ -4,7 +4,7 @@ import java.net.{URL, URI}
 import org.dbpedia.extraction.destinations.formatters.TerseFormatter
 import org.dbpedia.extraction.util.Language
 import javax.ws.rs._
-import javax.ws.rs.core.Response
+import javax.ws.rs.core.{MediaType, Response}
 import java.util.logging.{Logger,Level}
 import scala.xml.Elem
 import scala.io.{Source,Codec}
@@ -91,8 +91,7 @@ class Extraction(@PathParam("lang") langCode : String)
      */
     @GET
     @Path("extract")
-    @Produces(Array("application/xml"))
-    def extract(@QueryParam("title") title: String, @QueryParam("revid") @DefaultValue("-1") revid: Long, @QueryParam("format") format: String) : String =
+    def extract(@QueryParam("title") title: String, @QueryParam("revid") @DefaultValue("-1") revid: Long, @QueryParam("format") format: String) : Response =
     {
         if (title == null && revid < 0) throw new WebApplicationException(new Exception("title or revid must be given"), Response.Status.NOT_FOUND)
         
@@ -113,8 +112,17 @@ class Extraction(@PathParam("lang") langCode : String)
         
         val destination = new WriterDestination(() => writer, formatter)
         Server.instance.extractor.extract(source, destination, language)
-        
-        writer.toString
+
+        Response.ok(writer.toString).`type`(selectContentType(format)).build()
+    }
+
+    private def selectContentType(format: String): String = {
+
+      format match
+      {
+        case "trix" => MediaType.APPLICATION_XML
+        case _ => MediaType.TEXT_PLAIN
+      }
     }
 
     /**


### PR DESCRIPTION
Currently the Server always responds with a "application/xml" MIME type
when trying to extract triples from a Wikipage, no matter which format
is selected in the form.

When it comes to formats which are not TriX, the rendering on modern
browser fails due to incorrect files w.r.t. the declared MIME type of the
HTTP response.

With this pull request, the "application/xml" MIME type is selected only if
TriX format is picked, otherwise "text/plain" is used.
