### PR TITLE
Issue #70: Add duration template handling

### DIFF
--- a/core/src/main/scala/org/dbpedia/extraction/dataparser/UnitValueParser.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/dataparser/UnitValueParser.scala
@@ -231,6 +231,8 @@ class UnitValueParser( extractionContext : {
                 }
             } */
 
+            val defaultValue : PropertyNode = PropertyNode("", List(TextNode("0", 0)), 0)
+
             // Metre and foot/inch parameters cannot co-exist
             if (templateNode.property("m").isDefined) {
                 for (metres <- templateNode.property("m"))
@@ -246,8 +248,8 @@ class UnitValueParser( extractionContext : {
                 }
             }
             else {
-                for (feet <- templateNode.property("ft");
-                     inch <- templateNode.property("in"))
+                for (feet <- templateNode.property("ft").orElse(Some(defaultValue));
+                     inch <- templateNode.property("in").orElse(Some(defaultValue)))
                 {
                     try
                     {


### PR DESCRIPTION
About 10k articles are using Template:Duration to specify time durations (e.g. songs or albums).
Issue #70 collects some of those.

With this change Template:Duration is parsed and a time duration in seconds is generated.
