### PR TITLE
Issue #36: Transform and replace template nodes

### DIFF
--- a/core/src/main/scala/org/dbpedia/extraction/config/transform/TemplateTransformConfig.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/config/transform/TemplateTransformConfig.scala
@@ -1,0 +1,100 @@
+package org.dbpedia.extraction.config.transform
+
+import org.dbpedia.extraction.wikiparser._
+import org.dbpedia.extraction.util.Language
+import org.dbpedia.extraction.wikiparser.TextNode
+import java.net.URI
+import scala.collection.mutable.ArrayBuffer
+import scala.collection.immutable
+
+/**
+ * Template transformations.
+ *
+ * Could be useful to analyse
+ *
+ * http://en.wikipedia.org/wiki/Wikipedia:Template_messages
+ *
+ * and collect transformations for the commonly used templates
+ */
+object TemplateTransformConfig {
+
+  private def extractTextFromPropertyNode(node: Option[PropertyNode], prefix : String = "", suffix : String = "") : String = {
+    node match {
+      case Some(p) =>
+        val propertyText = p.children.collect { case TextNode(t, _) => t }.mkString.trim
+        if (propertyText.nonEmpty) prefix + propertyText + suffix else ""
+      case None => ""
+    }
+  }
+
+  // General functions
+  private def textNode(text: String)(node: TemplateNode) : List[TextNode] = List(TextNode(text, node.line))
+
+  /**
+   * Extracts all the children of the PropertyNode's in the given TemplateNode
+   */
+  private def extractChildren(filter: PropertyNode => Boolean)(node: TemplateNode) : List[Node] = {
+    // We have to reverse because flatMap prepends to the final list
+    // while we want to keep the original order
+    node.children.filter(filter).flatMap(_.children).reverse
+  }
+
+  private def identity(node: TemplateNode) : List[Node] = List(node)
+
+  private def externalLinkNode(node: TemplateNode) : List[Node] = {
+
+    try {
+
+      def defaultLinkTitle(node: Node) : PropertyNode = {
+        PropertyNode("link-title", List(TextNode("", node.line)), node.line)
+      }
+
+      List(
+        ExternalLinkNode(
+          new URI(extractTextFromPropertyNode(node.property("1"))),
+          node.property("2").getOrElse(defaultLinkTitle(node)).children,
+          node.line
+        )
+      )
+    } catch {
+      // In case there are problems with the URL/URI just bail and return the original node
+      case _ => List(node)
+    }
+  }
+
+  private val transformMap : Map[String, Map[String, (TemplateNode) => List[Node]]] = Map(
+
+    "en" -> Map(
+      "-" -> textNode("<br />") _ ,
+      "Clr" -> textNode("<br />") _ ,
+      "Flatlist" -> extractChildren { p : PropertyNode => !(Set("class", "style", "indent").contains(p.key)) }  _,
+      "Plainlist" -> extractChildren { p : PropertyNode => !(Set("class", "style", "indent").contains(p.key)) } _ ,
+      "Hlist" ->  extractChildren { p : PropertyNode => !(Set("class", "style", "ul_style", "li_style", "indent").contains(p.key)) } _ ,
+      "Unbulleted list" -> extractChildren { p : PropertyNode => !(Set("class", "style", "ul_style", "li_style", "indent").contains(p.key)) } _ ,
+
+      "URL" -> externalLinkNode _ ,
+
+      // http://en.wikipedia.org/wiki/Template:ICD10
+      // See https://github.com/dbpedia/extraction-framework/issues/40
+      "ICD10" ->
+        ((node: TemplateNode) =>
+          List(
+            new TextNode(extractTextFromPropertyNode(node.property("1")) +
+                         extractTextFromPropertyNode(node.property("2")) +
+                         extractTextFromPropertyNode(node.property("3"), "."), node.line)
+          )
+        )
+      ,
+      // http://en.wikipedia.org/wiki/Template:ICD9
+      // See https://github.com/dbpedia/extraction-framework/issues/40
+      "ICD9" -> extractChildren { p : PropertyNode => p.key == "1" } _
+    )
+  )
+
+  def apply(node: TemplateNode, lang: Language) : List[Node] = {
+
+     val mapKey = if (transformMap.contains(lang.wikiCode)) lang.wikiCode else "en"
+
+     transformMap(mapKey).get(node.title.decoded).getOrElse(identity _)(node)
+  }
+}

--- a/core/src/main/scala/org/dbpedia/extraction/wikiparser/TemplateNode.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/wikiparser/TemplateNode.scala
@@ -1,5 +1,7 @@
 package org.dbpedia.extraction.wikiparser
 
+import org.dbpedia.extraction.config.transform.TemplateTransformConfig
+
 /**
  * Represents a template.
  *
@@ -7,7 +9,12 @@ package org.dbpedia.extraction.wikiparser
  * @param children The properties of this template
  * @param line The source line number of this property
  */
-case class TemplateNode(title : WikiTitle, override val children : List[PropertyNode], override val line : Int, titleParsed : List[Node] = List()) extends Node(children, line)
+case class TemplateNode (
+    title : WikiTitle,
+    override val children : List[PropertyNode],
+    override val line : Int,
+    titleParsed : List[Node] = List())
+  extends Node(children, line)
 {
     private val propertyMap : Map[String, PropertyNode] = Map.empty ++ (for(property <- children) yield (property.key, property))
     
@@ -29,4 +36,15 @@ case class TemplateNode(title : WikiTitle, override val children : List[Property
     
     // templates are skipped for plain text
     def toPlainText = ""
+}
+
+/**
+ *
+ */
+object TemplateNode {
+
+    def transform(node: TemplateNode) : List[Node] = {
+
+      TemplateTransformConfig(node, node.title.language)
+    }
 }

--- a/core/src/main/scala/org/dbpedia/extraction/wikiparser/impl/simple/SimpleWikiParser.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/wikiparser/impl/simple/SimpleWikiParser.scala
@@ -192,7 +192,7 @@ final class SimpleWikiParser extends WikiParser
                     try
                     {
                          //Parse new node
-                         val newNode = createNode(source, level + 1)
+                         val newNode = createNodes(source, level + 1)
 
                          //Add text node
                          if(!currentText.isEmpty)
@@ -202,7 +202,7 @@ final class SimpleWikiParser extends WikiParser
                          }
 
                          //Add new node
-                         nodes ::= newNode
+                         nodes :::= newNode
                     }
                     catch
                     {
@@ -248,29 +248,29 @@ final class SimpleWikiParser extends WikiParser
         //else we found "/>"
     }
     
-    private def createNode(source : Source, level : Int) : Node =
+    private def createNodes(source : Source, level : Int) : List[Node] =
     {
         if(source.lastTag("[") || source.lastTag("http"))
         {
-            parseLink(source, level)
+            List(parseLink(source, level))
         }
         else if(source.lastTag("{{"))
         {
             if (source.pos < source.length && source.getString(source.pos, source.pos+1) == "{")
             {
                 source.pos = source.pos+1   //advance 1 char
-                return parseTemplateParameter(source, level)
+                return List(parseTemplateParameter(source, level))
             }
 
             parseTemplate(source, level)
         }
         else if(source.lastTag("{|"))
         {
-            parseTable(source, level)
+            List(parseTable(source, level))
         }
         else if(source.lastTag("\n="))
         {
-            parseSection(source)
+            List(parseSection(source))
         }
         else
             throw new WikiParserException("Unknown element type", source.line, source.findLine(source.line));
@@ -431,7 +431,7 @@ final class SimpleWikiParser extends WikiParser
         new TemplateParameterNode(key, nodes, line)
     }
 
-    private def parseTemplate(source : Source, level : Int) : Node =
+    private def parseTemplate(source : Source, level : Int) : List[Node] =
     {
         val startLine = source.line
         var title : WikiTitle = null;
@@ -454,7 +454,7 @@ final class SimpleWikiParser extends WikiParser
                 val decodedName = WikiUtil.cleanSpace(templateName).capitalize(source.language.locale)
                 if(source.lastTag(":"))
                 {
-                    return parseParserFunction(decodedName, source, level)
+                    return List(parseParserFunction(decodedName, source, level))
                 }
                 title = new WikiTitle(decodedName, Namespace.Template, source.language)
             }
@@ -472,7 +472,8 @@ final class SimpleWikiParser extends WikiParser
             //Reached template end?
             if(source.lastTag("}}"))
             {
-                return TemplateNode(title, properties.reverse, startLine)
+                // TODO: Find a way to leverage template redirects!!!!
+                return TemplateNode.transform(new TemplateNode(title, properties.reverse, startLine))
             }
         }
         

--- a/core/src/main/scala/org/dbpedia/extraction/wikiparser/impl/sweble/SwebleWrapper.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/wikiparser/impl/sweble/SwebleWrapper.scala
@@ -144,8 +144,8 @@ final class SwebleWrapper extends WikiParser
                 val name : String = nodeList2string(t.getName) 
                 val nameClean = WikiUtil.cleanSpace(name)
                 val title = new WikiTitle(nameClean, Namespace.Template, language)
-                val tpl = new TemplateNode(title, properties, line, transformNodes(t.getName))
-                List(tpl)
+                val tpl = TemplateNode.transform(new TemplateNode(title, properties, line, transformNodes(t.getName)))
+                tpl
             }
             case tn : Text => List(new TextNode(tn.getContent, line))
             case ws : Whitespace => List(new TextNode(ws.getContent.get(0).asInstanceOf[Text].getContent, line)) //as text


### PR DESCRIPTION
- Add TemplateNode.transform function which converts a TemplateNode into a List[Node],
  applying a set of transformations
- Make SimpleWikiParser and SwebleWrapper call TemplateNode.transform at parsing time
- Implement transformation for some templates
