### PR TITLE
Issue #106: builders for template property value

### DIFF
--- a/core/src/main/scala/org/dbpedia/extraction/mappings/GeoCoordinatesMapping.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/mappings/GeoCoordinatesMapping.scala
@@ -7,6 +7,7 @@ import java.util.logging.{Logger, Level}
 import org.dbpedia.extraction.ontology.{Ontology, OntologyProperty}
 import org.dbpedia.extraction.util.Language
 import scala.collection.mutable.ArrayBuffer
+import org.dbpedia.extraction.mappings.template.PropertyValueBuilder
 
 /**
  * Extracts geo-coodinates.
@@ -14,17 +15,17 @@ import scala.collection.mutable.ArrayBuffer
 class GeoCoordinatesMapping( 
   ontologyProperty : OntologyProperty,
   //TODO CreateMappingStats requires this properties to be public. Is there a better way?
-  val coordinates : String,
-  val latitude : String,
-  val longitude : String,
-  val longitudeDegrees : String,
-  val longitudeMinutes : String,
-  val longitudeSeconds : String,
-  val longitudeDirection : String,
-  val latitudeDegrees : String,
-  val latitudeMinutes : String,
-  val latitudeSeconds : String,
-  val latitudeDirection : String,
+  val coordinates : PropertyValueBuilder,
+  val latitude : PropertyValueBuilder,
+  val longitude : PropertyValueBuilder,
+  val longitudeDegrees : PropertyValueBuilder,
+  val longitudeMinutes : PropertyValueBuilder,
+  val longitudeSeconds : PropertyValueBuilder,
+  val longitudeDirection : PropertyValueBuilder,
+  val latitudeDegrees : PropertyValueBuilder,
+  val latitudeMinutes : PropertyValueBuilder,
+  val latitudeSeconds : PropertyValueBuilder,
+  val latitudeDirection : PropertyValueBuilder,
   context : {
     def ontology : Ontology
     def redirects : Redirects   // redirects required by GeoCoordinatesParser

--- a/core/src/main/scala/org/dbpedia/extraction/mappings/template/ConstantValueBuilder.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/mappings/template/ConstantValueBuilder.scala
@@ -1,0 +1,14 @@
+package org.dbpedia.extraction.mappings.template
+
+import org.dbpedia.extraction.wikiparser.{TextNode, PropertyNode, TemplateNode}
+
+/**
+ *
+ */
+class ConstantValueBuilder(val property : String, val value : String) extends PropertyValueBuilder {
+
+  override def apply(node: TemplateNode) : Option[PropertyNode] = {
+
+    Some(PropertyNode(property, List(TextNode(value, node.line)), node.line))
+  }
+}

--- a/core/src/main/scala/org/dbpedia/extraction/mappings/template/DefaultValueBuilder.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/mappings/template/DefaultValueBuilder.scala
@@ -1,0 +1,16 @@
+package org.dbpedia.extraction.mappings.template
+
+import org.dbpedia.extraction.wikiparser.{TextNode, PropertyNode, TemplateNode}
+
+/**
+ *
+ */
+class DefaultValueBuilder(val property : String, val default : String)  extends PropertyValueBuilder {
+
+  override def apply(node: TemplateNode): Option[PropertyNode] = {
+    node.property(property) match {
+      case None => Some(PropertyNode(property, List(TextNode(default, node.line)), node.line))
+      case propertyNode => propertyNode
+    }
+  }
+}

--- a/core/src/main/scala/org/dbpedia/extraction/mappings/template/IdentityValueBuilder.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/mappings/template/IdentityValueBuilder.scala
@@ -1,0 +1,11 @@
+package org.dbpedia.extraction.mappings.template
+
+import org.dbpedia.extraction.wikiparser.{PropertyNode, TemplateNode}
+
+/**
+ *
+ */
+class IdentityValueBuilder(val property: String) extends PropertyValueBuilder {
+
+  override def apply(node: TemplateNode): Option[PropertyNode] = { node.property(property) }
+}

--- a/core/src/main/scala/org/dbpedia/extraction/mappings/template/PropertyValueBuilder.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/mappings/template/PropertyValueBuilder.scala
@@ -1,0 +1,19 @@
+package org.dbpedia.extraction.mappings.template
+
+import org.dbpedia.extraction.wikiparser.{PropertyNode, TemplateNode}
+
+/**
+ *
+ */
+trait PropertyValueBuilder {
+
+  val property : String
+
+  def apply(node: TemplateNode) : Option[PropertyNode]
+}
+
+object PropertyValueBuilder {
+
+  implicit def propertyValueBuilder2String(p: PropertyValueBuilder) = p.property
+}
+

--- a/core/src/main/scala/org/dbpedia/extraction/wikiparser/TemplateNode.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/wikiparser/TemplateNode.scala
@@ -1,6 +1,7 @@
 package org.dbpedia.extraction.wikiparser
 
 import org.dbpedia.extraction.config.transform.TemplateTransformConfig
+import org.dbpedia.extraction.mappings.template.PropertyValueBuilder
 
 /**
  * Represents a template.
@@ -29,6 +30,8 @@ case class TemplateNode (
     {
         return propertyMap.get(key);
     }
+
+    def property(builder: PropertyValueBuilder) : Option[PropertyNode] = builder(this)
 
     def keySet :  scala.collection.Set[String] = propertyMap.keySet
 

--- a/server/src/main/scala/org/dbpedia/extraction/server/stats/MappingStatsHolder.scala
+++ b/server/src/main/scala/org/dbpedia/extraction/server/stats/MappingStatsHolder.scala
@@ -6,6 +6,7 @@ import org.dbpedia.extraction.mappings._
 import org.dbpedia.extraction.util.StringUtils.prettyMillis
 import org.dbpedia.extraction.wikiparser.{Namespace,TemplateNode}
 import MappingStats.InvalidTarget
+import org.dbpedia.extraction.mappings.template.PropertyValueBuilder._ // implicit wrappers
 
 object MappingStatsHolder {
   


### PR DESCRIPTION
There are cases in which it is more appropriate to assign pre-computed
values to template properties mapping instead of reading them from the
actual template used in a Wikipedia articles.

E.g. Infobox_Australian_place let editors specify lat/long values for geopoints
but hardcodes directions (latDir and longDir) in the template definition.
Since the property value is built using GeoCoordinateMapping it is impossible
to define a constant value for latDir and longDir with the current language.
(In the case of SimplePropertyMappings it is still possible to use ConstantMapping).

With this commit an extension of the framework is provided to let editors
have better control of how a template property is mapped into an ontology property.

Future enhancements of this approach could be:
- selection in a list of values (currently the only way to do that is in SimplePropertyMapping
  using the select property)
- prefix/suffix handling with template property value
- internal/external link generation from string values (e.g. imdbId to ExternalLink("http://imdb.com/id/imdbId"))
