### PR TITLE
Fix issues with extracting data from multiple files (part files)

### DIFF
--- a/core/src/main/scala/org/dbpedia/extraction/sources/XMLSource.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/sources/XMLSource.scala
@@ -47,7 +47,8 @@ object XMLSource
     }
 
     def fromReaders(sources: List[() => Reader], language: Language, filter: WikiTitle => Boolean = (_ => true)) : Source = {
-      new MultipleXMLReaderSource(sources, language, filter)
+      if (sources.size == 1) fromReader(sources.head, language, filter) // no need to create an ExecutorService
+      else new MultipleXMLReaderSource(sources, language, filter)
     }
 
     /**

--- a/core/src/main/scala/org/dbpedia/extraction/util/Finder.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/util/Finder.scala
@@ -39,10 +39,11 @@ class Finder[T](val baseDir: T, val language: Language, val wikiNameGiven: Strin
    * May be null, in which case we just look for date directories.
    * @return dates in ascending order
    */
-  def dates(suffix: String = null, required: Boolean = true): List[String] = {
+  def dates(suffix: String = null, required: Boolean = true, isSuffixRegex: Boolean = false): List[String] = {
     
     val suffixFilter = 
       if (suffix == null) {date: String => true} 
+      else if (isSuffixRegex) {date: String => matchFiles(date, suffix).nonEmpty}
       else {date: String => file(date, suffix).exists}
     
     val dates = wikiDir.names.filter(dateFilter).filter(suffixFilter).sortBy(_.toInt)

--- a/dump/download.minimal.properties
+++ b/dump/download.minimal.properties
@@ -8,7 +8,18 @@ base-dir=/path/to/download/folder
 
 # Replace xx by your language.
 download=xx:pages-articles.xml.bz2
-# To download parts files
+
+###### Download part files ######
+#
+# Please make sure that the regex actually matches the format used for xx dumps
+# by checking http://dumps.wikimedia.org/xxwiki/yyyymmdd
+#
+# Example:
+# enwiki => enwiki-20131120-pages-articles1.xml-p000000010p000010000.bz2 hence @pages-articles\d+\.xml-p\d+p\d+\.bz2 matches
+# frwiki => frwiki-20131120-pages-articles1.xml.bz2 hence @pages-articles\d+\.xml\.bz2 matches (the previous regex does not!)
+# commonswiki => it does not have part files! This is true for other wikis as well. In this case xx:pages-articles.xml.bz2
+# shoud be used (e.g. commons:pages-articles.xml.bz2 or cowiki:pages-articles.xml.bz2)
+#
 # download=xx:@pages-articles\d+\.xml-p\d+p\d+\.bz2
 
 # Only needed for the ImageExtractor

--- a/dump/extraction.default.properties
+++ b/dump/extraction.default.properties
@@ -12,7 +12,21 @@ base-dir=/home/release/wikipedia
 # source=pages-articles.xml.bz2
 # source=pages-articles.xml.gz
 
-# To extract from parts files
+###### Extract from part files ######
+#
+# Please make sure that the regex actually matches the format used by ALL the wikis you are going to extract from!!!!
+# One that should work in all cases is
+# source=@pages-articles\\d*\\.xml(-p\\d+p\\d+)?\\.bz2
+#
+# NOTE: when using the above regex you should make sure you do not have part files AND regular dump files together
+# for the same wiki, e.g. frwiki-20131120-pages-articles1.xml.bz2 and frwiki-20131120-pages-articles.xml.bz2, as they
+# BOTH will match and that will result in duplicate output data
+#
+# Example:
+# enwiki => enwiki-latest-pages-articles1.xml-p000000010p000010000.bz2 hence @pages-articles\\d+\\.xml-p\\d+p\\d+\\.bz2 matches
+# frwiki => frwiki-latest-pages-articles1.xml.bz2 hence @pages-articles\\d+\\.xml\\.bz2 matches (the previous regex does not!)
+# commonswiki => it does not have part files! This is true for other wikis as well.
+#
 # source=@pages-articles\\d+\\.xml-p\\d+p\\d+\\.bz2
 
 # use only directories that contain a 'download-complete' file? Default is false.

--- a/dump/src/main/scala/org/dbpedia/extraction/dump/extract/Config.scala
+++ b/dump/src/main/scala/org/dbpedia/extraction/dump/extract/Config.scala
@@ -27,7 +27,8 @@ extends ConfigParser(config)
   if (! dumpDir.exists) throw error("dir "+dumpDir+" does not exist")
   
   val requireComplete = config.getProperty("require-download-complete", "false").toBoolean
-  
+
+  // Watch out, this could be a regex
   val source = config.getProperty("source", "pages-articles.xml")
   val disambiguations = config.getProperty("disambiguations", "page_props.sql.gz")
 


### PR DESCRIPTION
- Fixed some errors when references to config.source in the code
  was not handled correctly in case of regular expressions (errors
  reported by @jpluorange in #90)
- Add comments to the default download and extraction config files
  to clarify when and how to use regular expressions
