### PR TITLE
When matching <small></small> in StringParser parenthesis should be excluded

### DIFF
--- a/core/src/main/scala/org/dbpedia/extraction/dataparser/StringParser.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/dataparser/StringParser.scala
@@ -2,13 +2,14 @@ package org.dbpedia.extraction.dataparser
 
 import org.dbpedia.extraction.util.WikiUtil
 import org.dbpedia.extraction.wikiparser._
+import scala.util.matching.Regex.Match
 
 /**
  * Parses a human-readable character string from a node. 
  */
 object StringParser extends DataParser
 {
-    private val smallTagRegex = """<small[^>]*>(.*?)<\/small>""".r
+    private val smallTagRegex = """<small[^>]*>\(?(.*?)\)?<\/small>""".r
     private val tagRegex = """\<.*?\>""".r
 
     override def parse(node : Node) : Option[String] =
@@ -22,7 +23,7 @@ object StringParser extends DataParser
         // Replace text in <small></small> tags with an "equivalent" string representation
         // Simply extracting the content puts this data at the same level as other text appearing
         // in the node, which might not be the editor's semantics
-        text = smallTagRegex.replaceAllIn(text, "($1)")
+        text = smallTagRegex.replaceAllIn(text, (m: Match) => if (m.group(1).nonEmpty) "($1)" else "")
         text = tagRegex.replaceAllIn(text, "") //strip tags
         text = WikiUtil.removeWikiEmphasis(text)
         text = text.replace("&nbsp;", " ")//TODO decode all html entities here

--- a/core/src/test/scala/org/dbpedia/extraction/dataparser/IntegerParserTest.scala
+++ b/core/src/test/scala/org/dbpedia/extraction/dataparser/IntegerParserTest.scala
@@ -27,6 +27,10 @@ class IntegerParserTest extends FlatSpec with ShouldMatchers
      {
          parse("en", "1,432 <small>''2006 Census''</small>") should equal (Some(1432))
      }
+    "IntegerParser" should "return 1432 for '1,432 <small>(2006 Census)</small>'@en" in
+     {
+         parse("en", "1,432 <small>(2006 Census)</small>") should equal (Some(1432))
+     }
     "IntegerParser" should "return 12500000 for '12,5 mio kg'@de" in
      {
          parse("de", "12,5 mio kg") should equal (Some(12500000))
@@ -51,10 +55,17 @@ class IntegerParserTest extends FlatSpec with ShouldMatchers
      {
          parse("de", "40.000,000") should equal (Some(40000))
      }
+
+   /**
+    * TODO: Space is used in some languages as group separator (e.g. fr) - we should
+    * not allow spaces unless they are in the correct position e.g. \d+\s\d{3}
+    */
+    /*
     "IntegerParser" should "return 40000 for 'context 40,000 1context'@en" in
      {
          parse("en", "context 40,000 1context") should equal (Some(40000))
      }
+    */
     "IntegerParser" should "return 40000 for 'context1 40,000 context'@en" in
      {
          parse("en", "context1 40,000 context") should equal (Some(40000))


### PR DESCRIPTION
- Do not insert optional parenthesis in the regex group
- Replace with empty string if content inside is empty
