### PR TITLE
Fix HomepageExtractor issues

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -105,15 +105,15 @@
     <repositories>
 
         <repository>
-            <id>osr-public-releases</id>
-            <name>OSR Public Releases</name>
-            <url>http://mojo.informatik.uni-erlangen.de/nexus/content/repositories/public-releases</url>
+          <id>osr-public-releases</id>
+          <name>OSR Public Releases</name>
+          <url>http://mojo.informatik.uni-erlangen.de/nexus/content/repositories/public-releases</url>
         </repository>
 
         <repository>
-            <id>osr-public-snapshots</id>
-            <name>OSR Public snapshots</name>
-            <url>http://mojo.informatik.uni-erlangen.de/nexus/content/repositories/public-snapshots</url>
+          <id>osr-public-snapshots</id>
+          <name>OSR Public snapshots</name>
+          <url>http://mojo.informatik.uni-erlangen.de/nexus/content/repositories/public-snapshots</url>
         </repository>
 
     </repositories>

--- a/core/src/main/scala/org/dbpedia/extraction/config/mappings/HomepageExtractorConfig.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/config/mappings/HomepageExtractorConfig.scala
@@ -64,4 +64,17 @@ object HomepageExtractorConfig
         "ru" -> "официальный"
     )
 
+    // Map(language -> Map(templateName -> templatePropertyKey))
+    val templateOfficialWebsite = Map(
+        "ca" -> Map("Oficial" -> "1"),
+        "el" -> Map("Επίσημη ιστοσελίδα" -> "1"),
+        "en" -> Map("Official website" -> "1"),
+        "eo" -> Map("Oficiala_retejo" -> "1"),
+        "es" -> Map("Página_web" -> "1"),
+        "fr" -> Map("Site_officiel" -> "url"),
+        "ga" -> Map("Páxina_web" -> "1"),
+        "pt" -> Map("Oficial" -> "1"),
+        "ru" -> Map("Официальный сайт" -> "1")
+    )
+
 }

--- a/core/src/main/scala/org/dbpedia/extraction/mappings/HomepageExtractor.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/mappings/HomepageExtractor.scala
@@ -28,6 +28,8 @@ extends PageNodeExtractor
   
   private val externalLinkSections = HomepageExtractorConfig.externalLinkSectionsMap(language)
 
+  private val templateOfficialWebsite = HomepageExtractorConfig.templateOfficialWebsite(language)
+
   private val homepageProperty = context.ontology.properties("foaf:homepage")
 
   private val listItemStartRegex = ("""(?msiu).*^\s*\*\s*[^^]*(\b""" + official + """\b)?[^^]*\z""").r
@@ -35,37 +37,49 @@ extends PageNodeExtractor
   private val officialAndLineEndRegex = ("""(?msiu)[^$]*\b""" + official + """\b.*$.*""").r
   private val officialAndNoLineEndRegex = ("""(?msiu)[^$]*\b""" + official + """\b[^$]*""").r
   private val lineEndRegex = "(?ms).*$.+".r
+  // Similar to org.dbpedia.extraction.config.dataparser.DataParserConfig.splitPropertyNodeRegexLink - without '/' and ';'
+  private val splitPropertyNodeLinkStrict = """<br\s*\/?>|\n| and | or |,| """
 
   override val datasets = Set(DBpediaDatasets.Homepages)
 
   override def extract(page: PageNode, subjectUri: String, pageContext: PageContext): Seq[Quad] =
   {
     if(page.title.namespace != Namespace.Main) return Seq.empty
-    
-    val list = collectProperties(page).filter(p => propertyNames.contains(p.key.toLowerCase))
-    list.foreach((property) => {
-      property.children match
-      {
-        case (textNode @ TextNode(text, _)) :: _ =>
+
+    val list = collectProperties(page).filter(p => propertyNames.contains(p.key.toLowerCase)).flatMap {
+      NodeUtil.splitPropertyNode(_, splitPropertyNodeLinkStrict, true)
+    }
+
+    list.foreach((property) =>
+
+      // Find among children
+      for (child <- property.children) {
+        child match
         {
-          val url = if (!text.startsWith("http")) "http://" + text else text
-          val graph = generateStatement(subjectUri, pageContext, url, textNode)
-          if (!graph.isEmpty)
+          case (textNode @ TextNode(text, _)) =>
           {
-            return graph
+            val cleaned = cleanProperty(text)
+            if (cleaned.nonEmpty) { // do not proceed if the property value is not a valid candidate
+              val url = if (!cleaned.startsWith("http")) "http://" + cleaned else cleaned
+              val graph = generateStatement(subjectUri, pageContext, url, textNode)
+              if (!graph.isEmpty)
+              {
+                return graph
+              }
+            }
           }
-        }
-        case (linkNode @ ExternalLinkNode(destination, _, _, _)) :: _ =>
-        {
-          val graph = generateStatement(subjectUri, pageContext, destination.toString, linkNode)
-          if (!graph.isEmpty)
+          case (linkNode @ ExternalLinkNode(destination, _, _, _)) =>
           {
-            return graph
+            val graph = generateStatement(subjectUri, pageContext, destination.toString, linkNode)
+            if (!graph.isEmpty)
+            {
+              return graph
+            }
           }
+          case _ =>
         }
-        case _ =>
       }
-    })
+    )
 
     for(externalLinkSectionChildren <- collectExternalLinkSection(page.children))
     {
@@ -82,6 +96,18 @@ extends PageNodeExtractor
     }
 
     Seq.empty
+  }
+
+  private def cleanProperty(text: String) : String = {
+
+    val candidateUrl = text.stripLineEnd.trim // remove ending new line
+
+    // While it is perfectly legal to have hostnames without dots in URLs
+    // it is very unlikely that such URLs will be present in Wikipedia
+    // Most of the times such values represent texts inserted by editors
+    // to convey a "missing homepage" info, such as None, N/A, missing, down etc.
+    if (candidateUrl.matches(""".*\w\.\w.*""")) candidateUrl
+    else ""
   }
 
   private def generateStatement(subjectUri: String, pageContext: PageContext, url: String, node: Node): Seq[Quad] =
@@ -101,20 +127,50 @@ extends PageNodeExtractor
     Seq.empty
   }
 
+  private def extractUrlFromProperty(node: PropertyNode): Option[String] = {
+
+    /*
+    It could be:
+    1) {{template | key = example.com }}
+    2) {{template | key = http://example.com }}
+
+    In 1) => PropertyNode("key", List(TextNode("example.com", _))
+    In 2) => PropertyNode("key", List(ExternalLinkNode(URI("http://example.com"), ...)))
+     */
+    val url = node.children.collect {
+      case TextNode(t, _) => t
+      case ExternalLinkNode(destination, _, _, _) => destination.toString
+    }.mkString.trim
+
+    if (url.isEmpty) {
+      None
+    } else {
+      try {
+        val uri = new URI(url)
+        if (uri.getScheme == null) Some("http://" + uri.toString)
+        else Some(uri.toString)
+      } catch {
+        case _ : Exception => None
+      }
+    }
+  }
+
   private def findLinkTemplateInSection(nodes: List[Node]): Option[(String, Node)] =
   {
     // TODO: use for-loop instead of recursion
     nodes match
     {
-      // TODO: use language-specific name
-      case (templateNode @ TemplateNode(title, _, _, _)) :: _
-          if ((title.decoded == "Official") || ((context.redirects.map.contains(title.decoded)) && (context.redirects.map(title.decoded) == "Official"))) =>
+      case (templateNode @ TemplateNode(title, _, _, _)) :: tail =>
       {
-        templateNode.property("1") match
-        {
-          case Some(propertyNode) => propertyNode.retrieveText.map(url => (url, propertyNode))
-          case _ => None
+        val templateRedirect = context.redirects.resolve(title).decoded
+        if (templateOfficialWebsite.contains(templateRedirect)) {
+          templateNode.property(templateOfficialWebsite(templateRedirect)) match
+          {
+            case Some(propertyNode) => extractUrlFromProperty(propertyNode).map(url => (url, propertyNode))
+            case None => findLinkTemplateInSection(tail) // do not stop the recursion - there might be other templates
+          }
         }
+        else findLinkTemplateInSection(tail)
       }
       case head :: tail => findLinkTemplateInSection(tail)
       case Nil => None

--- a/core/src/test/scala/org/dbpedia/extraction/mappings/HomepageExtractorTest.scala
+++ b/core/src/test/scala/org/dbpedia/extraction/mappings/HomepageExtractorTest.scala
@@ -1,0 +1,186 @@
+package org.dbpedia.extraction.mappings
+
+import org.dbpedia.extraction.wikiparser._
+import org.dbpedia.extraction.sources.{WikiPage, XMLSource}
+import org.dbpedia.extraction.destinations.{QuadBuilder, Quad}
+import org.dbpedia.extraction.destinations.formatters.TerseFormatter
+import org.dbpedia.extraction.ontology.io.OntologyReader
+import io.Source
+import org.dbpedia.extraction.util.Language
+import java.io.{FilenameFilter, File}
+import scala.collection.mutable.ArrayBuffer
+import org.junit.Test
+import org.dbpedia.extraction.ontology.{OntologyProperty, Ontology}
+import org.scalatest.FlatSpec
+import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.junit.JUnitRunner
+import org.junit.runner.RunWith
+import org.dbpedia.extraction.dataparser.BooleanParser
+
+/**
+ *
+ */
+@RunWith(classOf[JUnitRunner])
+class HomepageExtractorTest extends FlatSpec with ShouldMatchers
+{
+  // Tests
+  "HomepageExtractor" should "return http://example.com from ExternalLink in External links section" in {
+
+    val lang = Language.English
+    val quad : Seq[Quad] = HomepageExtractorTest.datasets.toList.map(dataset =>
+      new Quad(lang, dataset, "TestPage", HomepageExtractorTest.homepageProperty, "http://example.com", null, null)
+    )
+
+    parse(
+      """
+        |==External links==
+        |
+        |* [http://example.com Official website]
+        |
+      """.stripMargin, "TestPage", lang) should equal (quad)
+  }
+
+  "HomepageExtractor" should """return http://example.com from Template 'Official website' in External links section""" in {
+
+    val lang = Language.English
+    val quad : Seq[Quad] = HomepageExtractorTest.datasets.toList.map(dataset =>
+      new Quad(lang, dataset, "TestPage", HomepageExtractorTest.homepageProperty, "http://example.com", null, null)
+    )
+
+    parse(
+      """
+        |==External links==
+        |
+        |* {{Official website|example.com}}
+        |
+      """.stripMargin, "TestPage", lang) should equal (quad)
+  }
+
+  it should """return http://correct.example.com from Template 'Official website' in External links section""" in {
+
+    val lang = Language.English
+    val quad : Seq[Quad] = HomepageExtractorTest.datasets.toList.map(dataset =>
+      new Quad(lang, dataset, "TestPage", HomepageExtractorTest.homepageProperty, "http://correct.example.com", null, null)
+    )
+
+    parse(
+      """
+        |==External links==
+        |
+        |* {{Official website|2=example.com}}
+        |* {{Official website|correct.example.com}}
+        |
+      """.stripMargin, "TestPage", lang) should equal (quad)
+  }
+
+  "HomepageExtractor" should """return http://example.com from Template 'Official' in External links section""" in {
+
+    val lang = Language.English
+    val quad : Seq[Quad] = HomepageExtractorTest.datasets.toList.map(dataset =>
+      new Quad(lang, dataset, "TestPage", HomepageExtractorTest.homepageProperty, "http://example.com", null, null)
+    )
+
+    parse(
+      """
+        |==External links==
+        |
+        |* {{Official|http://example.com}}
+        |
+      """.stripMargin, "TestPage", lang) should equal (quad)
+  }
+
+  "HomepageExtractor" should """return http://example.com from Template property 'website = example.com'""" in {
+
+    val lang = Language.English
+    val quad : Seq[Quad] = HomepageExtractorTest.datasets.toList.map(dataset =>
+      new Quad(lang, dataset, "TestPage", HomepageExtractorTest.homepageProperty, "http://example.com", null, null)
+    )
+
+    parse("""{{Infobox | website = example.com}}""", "TestPage", lang) should equal (quad)
+  }
+
+  "HomepageExtractor" should """return http://example.com from Template property 'website = http://example.com'""" in {
+
+    val lang = Language.English
+    val quad : Seq[Quad] = HomepageExtractorTest.datasets.toList.map(dataset =>
+      new Quad(lang, dataset, "TestPage", HomepageExtractorTest.homepageProperty, "http://example.com", null, null)
+    )
+
+    parse("""{{Infobox | website = http://example.com}}""", "TestPage", lang) should equal (quad)
+  }
+
+  "HomepageExtractor" should """return http://example.com from Template property 'website = http://example.com or http://or.com'""" in {
+
+    val lang = Language.English
+    val quad : Seq[Quad] = HomepageExtractorTest.datasets.toList.map(dataset =>
+      new Quad(lang, dataset, "TestPage", HomepageExtractorTest.homepageProperty, "http://example.com", null, null)
+    )
+
+    parse("""{{Infobox | website = http://example.com or http://or.com}}""", "TestPage", lang) should equal (quad)
+  }
+
+  it should """return Seq.empty from Template property 'website = N/A'""" in {
+
+    val lang = Language.English
+    val quad : Seq[Quad] = HomepageExtractorTest.datasets.toList.map(dataset =>
+      new Quad(lang, dataset, "TestPage", HomepageExtractorTest.homepageProperty, "http://example.com", null, null)
+    )
+
+    parse("""{{Infobox | website = N/A}}""", "TestPage", lang) should equal (Seq.empty)
+  }
+
+  // end of tests
+
+  private val parser = WikiParser.getInstance()
+
+  private def parse(input : String, title: String = "TestPage", lang: Language = Language.English) : Seq[Quad] =
+  {
+    val page = new WikiPage(WikiTitle.parse(title, lang), input)
+    val context = new {
+      def ontology = HomepageExtractorTest.ontology;
+      def language = lang;
+      def redirects = new Redirects(Map("Official" -> "Official website"))
+    }
+
+    val extractor = new HomepageExtractor(context)
+
+    extractor.extract(parser(page),"TestPage", new PageContext())
+  }
+}
+
+object HomepageExtractorTest {
+
+  // We need the OntologyProperty for "foaf:homepage"
+  private val homepageProperty = new OntologyProperty("Foaf:homepage", Map(Language.English -> "homepage"), Map(), null, null, false, Set())
+
+  /**
+   *   val classes : Map[String, OntologyClass],
+  val properties : Map[String, OntologyProperty],
+  val datatypes : Map[String, Datatype],
+  val specializations : Map[(OntologyClass, OntologyProperty), UnitDatatype],
+  val equivalentPropertiesMap : Map[OntologyProperty,Set[OntologyProperty]],
+  val equivalentClassesMap : Map[OntologyProperty,Set[OntologyProperty]]
+
+  name: String,
+  labels: Map[Language, String],
+  comments: Map[Language, String],
+  val domain: OntologyClass,
+  val range: OntologyType,
+  val isFunctional: Boolean,
+  val equivalentProperties: Set[OntologyProperty]
+   */
+  private val ontology = new Ontology(
+    Map(),
+    Map("foaf:homepage" -> homepageProperty),
+    Map(),
+    Map(),
+    Map(),
+    Map()
+  )
+
+  private val datasets = new HomepageExtractor(new {
+    def ontology = HomepageExtractorTest.ontology;
+    def language = Language.English;
+    def redirects = null
+  }).datasets
+}

--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,8 @@
                 <scope>test</scope>
             </dependency>
 
-        </dependencies>
+    </dependencies>
+
     </dependencyManagement>
 
     <distributionManagement>
@@ -179,3 +180,4 @@
     </distributionManagement>
 
 </project>
+


### PR DESCRIPTION
The HomepageExtractor was not able to correctly detect references to official webpages
when conveyed through templates placed in the External links section.
Only matches to Template:Official were considered and the URL extraction was failing
when the template property contained an ExternalLinkNode.

With this change:
- A map is provided to store info about official website templates, for different langs
- Template redirects are checked when looking for official websites
- URL is extracted also when the template property is an ExternalLinkNode

I was able to extract 550k homepages from enwiki-20130604 compared to about 505k items
without this patch (about 10% more).
