### PR TITLE
Issue #133: Image files copyright is not analysed

### DIFF
--- a/core/src/main/scala/org/dbpedia/extraction/mappings/ImageExtractor.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/mappings/ImageExtractor.scala
@@ -216,7 +216,7 @@ private object ImageExtractor
         val startTime = System.nanoTime
 
         for(page <- source if page.title.namespace == Namespace.File;
-            ImageExtractorConfig.ImageLinkRegex <- List(page.title.encoded) )
+            ImageExtractorConfig.ImageLinkRegex() <- List(page.title.encoded) )
         {
             ImageExtractorConfig.NonFreeRegex(wikiCode).findFirstIn(page.source) match
             {

--- a/core/src/test/scala/org/dbpedia/extraction/mappings/ImageExtractorTest.scala
+++ b/core/src/test/scala/org/dbpedia/extraction/mappings/ImageExtractorTest.scala
@@ -1,0 +1,30 @@
+package org.dbpedia.extraction.mappings
+
+import org.scalatest.{PrivateMethodTester, FlatSpec}
+import org.scalatest.matchers.ShouldMatchers
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import scala.collection.mutable.{Set => MutableSet, HashSet}
+import org.dbpedia.extraction.sources.{WikiPage, MemorySource}
+import org.dbpedia.extraction.wikiparser.{Namespace, WikiTitle}
+import org.dbpedia.extraction.util.Language
+
+/**
+ *
+ */
+@RunWith(classOf[JUnitRunner])
+class ImageExtractorTest extends FlatSpec with ShouldMatchers with PrivateMethodTester {
+
+  "ImageExtractor" must "load 1 free image" in {
+    val freeImages = new HashSet[String]()
+    val nonFreeImages = new HashSet[String]()
+
+    val loadImages = PrivateMethod[Unit]('loadImages)
+    val source = new MemorySource(new WikiPage(new WikiTitle("Test.png", Namespace.File, Language("en")), "{{Free screenshot|template=BSD}}"))
+    // def loadImages(source: Source, freeImages: MutableSet[String], nonFreeImages: MutableSet[String], wikiCode: String)
+    ImageExtractor invokePrivate loadImages(source, freeImages, nonFreeImages, "en")
+
+    freeImages should not be ('empty)
+    freeImages should have size (1)
+  }
+}


### PR DESCRIPTION
Due to a typo in a for loop the ImageLinkRegex was not unapplied
on file articles.
