### PR TITLE
Issue #149: Read stats generation property from JVM system property

### DIFF
--- a/core/src/main/scala/org/dbpedia/extraction/config/mappings/InfoboxExtractorConfig.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/config/mappings/InfoboxExtractorConfig.scala
@@ -27,9 +27,13 @@ object InfoboxExtractorConfig
     
     // When you generate statistics, set the following to true. To get full coverage, you should
     // probably set most other parameters here to zero or empty values. 
-    val extractTemplateStatistics = false 
+    val extractTemplateStatistics =
+      try {
+        System.getProperty("extract.template.stats", "false").toBoolean
+      } catch {
+        case ex : Exception => false
+      }
 
     val minPropertyCount = 2
-
     val minRatioOfExplicitPropertyKeys = 0.75
 }

--- a/dump/pom.xml
+++ b/dump/pom.xml
@@ -68,6 +68,29 @@
                         </launcher>
 
                         <launcher>
+                            <id>stats-extraction</id>
+                            <mainClass>org.dbpedia.extraction.dump.extract.Extraction</mainClass>
+
+                            <jvmArgs>
+                                <jvmArg>-server</jvmArg>
+                                <!-- Request statistics -->
+                                <jvmArg>-Dextract.template.stats=true</jvmArg>
+                                <!--
+                                <jvmArg>-Xmx4096m</jvmArg>
+                                <jvmArg>-XX:+HeapDumpOnOutOfMemoryError</jvmArg>
+                                <jvmArg>-XX:+UseConcMarkSweepGC</jvmArg>
+                                <jvmArg>-XX:+PrintGC</jvmArg>
+                                <jvmArg>-XX:+PrintGCTimeStamps</jvmArg>
+                                <jvmArg>-Dhttp.proxyHost=proxy.server.com</jvmArg>
+                                <jvmArg>-Dhttp.proxyPort=80</jvmArg>
+                                <jvmArg>-Dhttp.proxyUser=user</jvmArg>
+                                <jvmArg>-Dhttp.proxyPassword=password</jvmArg>
+                                <jvmArg>-Dhttp.nonProxyHosts="localhost|127.0.0.1"</jvmArg>
+                                -->
+                            </jvmArgs>
+                        </launcher>
+
+                        <launcher>
                             <id>compress</id>
                             <mainClass>org.dbpedia.extraction.dump.compress.Compress</mainClass>
                             <jvmArgs>


### PR DESCRIPTION
- Decide whether to generate statistics by reading a JVM system property.
  By doing that it is possible to create stats without having to edit the code
  and recompile the framework.
- Add a Scala launcher in pom to start stats creation by setting the
  appropriate JVM system property
