### PR TITLE
Issue #151: URL encode wikititle in sample page extraction

### DIFF
--- a/core/src/main/scala/org/dbpedia/extraction/util/WikiApi.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/util/WikiApi.scala
@@ -119,7 +119,7 @@ class WikiApi(url: URL, language: Language)
         {
             for(titleGroup <- titles.grouped(pageDownloadLimit))
             {
-                val response = query("?action=query&format=xml&prop=revisions&titles=" + titleGroup.map(_.encodedWithNamespace).mkString("|") + "&rvprop=ids|content|timestamp|user|userid")
+                val response = query("?action=query&format=xml&prop=revisions&titles=" + titleGroup.map(t => URLEncoder.encode(t.encodedWithNamespace, "UTF-8")).mkString("|") + "&rvprop=ids|content|timestamp|user|userid")
                 processPages(response, proc)
             }
         }


### PR DESCRIPTION
Wiki title normalization is correct, as per [1], but the query paramater "titles" must be encoded.

[1] https://www.mediawiki.org/wiki/API:Query
