### PR TITLE
HomepageExtractor config: return default empty values for undefined settings in a language

### DIFF
--- a/core/src/main/scala/org/dbpedia/extraction/config/mappings/HomepageExtractorConfig.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/config/mappings/HomepageExtractorConfig.scala
@@ -8,7 +8,7 @@ object HomepageExtractorConfig
     // For "ar" configuration, rendering right-to-left may seems like a bug, but it's not.
     // Don't change this else if you know how it is done.
 
-    val propertyNamesMap = Map(
+    private val propertyNamesMap = Map(
         "ar" -> Set("الموقع", "الصفحة الرسمية", "موقع", "الصفحة الرئيسية", "صفحة ويب", "موقع ويب"),
         "ca" -> Set("pàgina", "web", "lloc"),
         "de" -> Set("website", "homepage", "webpräsenz", "web", "site", "siteweb", "site web"),/*cleanup*/
@@ -26,9 +26,13 @@ object HomepageExtractorConfig
         "ru" -> Set("сайт")
     )
 
+    def propertyNames(lang : String) : Set[String] = {
+        propertyNamesMap.getOrElse(lang, Set())
+    }
+
     val supportedLanguages = propertyNamesMap.keySet
 
-    val externalLinkSectionsMap = Map(
+    private val externalLinkSectionsMap = Map(
         "ar" -> "وصلات خارجية",
         "ca" -> "(?:Enllaços externs|Enllaço extern)",
         "de" -> "Weblinks?",
@@ -46,7 +50,11 @@ object HomepageExtractorConfig
         "ru" -> "Ссылки"
     )
 
-    val officialMap = Map(
+    def externalLinkSections(lang : String) : String = {
+        externalLinkSectionsMap.getOrElse(lang, "")
+    }
+
+    private val officialMap = Map(
         "ar" -> "رسمي",
         "ca" -> "oficial",
         "de" -> "offizielle",
@@ -64,10 +72,14 @@ object HomepageExtractorConfig
         "ru" -> "официальный"
     )
 
+    def official(lang : String) : String = {
+        officialMap.getOrElse(lang, "")
+    }
+
     // Map(language -> Map(templateName -> templatePropertyKey))
-    val templateOfficialWebsite = Map(
+    private val templateOfficialWebsiteMap = Map(
         "ca" -> Map("Oficial" -> "1"),
-        "it" -> Map("Sito Ufficiale" -> "1"),
+        /* "it" -> Map("Sito Ufficiale" -> "1"), This does not exist, yet */
         "el" -> Map("Επίσημη ιστοσελίδα" -> "1"),
         "en" -> Map("Official website" -> "1"),
         "eo" -> Map("Oficiala_retejo" -> "1"),
@@ -77,5 +89,9 @@ object HomepageExtractorConfig
         "pt" -> Map("Oficial" -> "1"),
         "ru" -> Map("Официальный сайт" -> "1")
     )
+
+    def templateOfficialWebsite(lang : String) : Map[String, String] = {
+        templateOfficialWebsiteMap.getOrElse(lang, Map())
+    }
 
 }

--- a/core/src/main/scala/org/dbpedia/extraction/mappings/HomepageExtractor.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/mappings/HomepageExtractor.scala
@@ -22,11 +22,11 @@ extends PageNodeExtractor
 {
   private val language = context.language.wikiCode
 
-  private val propertyNames = HomepageExtractorConfig.propertyNamesMap(language)
+  private val propertyNames = HomepageExtractorConfig.propertyNames(language)
   
-  private val official = HomepageExtractorConfig.officialMap(language)
+  private val official = HomepageExtractorConfig.official(language)
   
-  private val externalLinkSections = HomepageExtractorConfig.externalLinkSectionsMap(language)
+  private val externalLinkSections = HomepageExtractorConfig.externalLinkSections(language)
 
   private val templateOfficialWebsite = HomepageExtractorConfig.templateOfficialWebsite(language)
 


### PR DESCRIPTION
Set default values in case any of the HomepageExtractor required config does not exist
for a specific language (e.g. there is no official website template in itwiki, but
there is an official keyword used in external links section).

Not using English as default because it looks like a strong assumption which is likely
to be either wrong or disruptive.
