### PR TITLE
Add a profile to select incremental compilation (zinc)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,9 +161,7 @@
                 <version>${scalatest.version}</version>
                 <scope>test</scope>
             </dependency>
-
-    </dependencies>
-
+        </dependencies>
     </dependencyManagement>
 
     <distributionManagement>
@@ -179,5 +177,27 @@
         </snapshotRepository>
     </distributionManagement>
 
+    <profiles>
+        <profile>
+            <id>incremental</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>net.alchim31.maven</groupId>
+                        <artifactId>scala-maven-plugin</artifactId>
+
+                        <configuration>
+                            <!-- Enable incremental compilation -->
+                            <recompileMode>incremental</recompileMode>
+                            <!-- Use an external Zinc server for compilation.
+                            If there is no Zinc server currently running then the plugin falls back to regular incremental compilation.
+                            Seems pretty safe. -->
+                            <useZincServer>true</useZincServer>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>
 


### PR DESCRIPTION
Incremental compilation can be enabled using the -P switch, e.g. mvn compile -P incremental.
It can be used also with an external zinc server, having it run on the default port (3030).
If no zinc server is found, the scala plugin will use its incremental compiler.

Please note that it might be required to increase the memory available to maven with MAVEN_OPTS, e.g. `export MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=128m"`
