### PR TITLE
add rdf:Property as type on object and datatype properties

### DIFF
--- a/core/src/main/scala/org/dbpedia/extraction/ontology/io/OntologyOWLWriter.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/ontology/io/OntologyOWLWriter.scala
@@ -91,7 +91,8 @@ class OntologyOWLWriter(writeSpecificProperties : Boolean = true)
     {
         val xml = new scala.xml.NodeBuffer()
 
-        //Type
+        //Type  (add rdf:Property as well, we already do it for the class instances)
+        xml += <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property" />
         if (property.isFunctional)
         {
              xml += <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty" />


### PR DESCRIPTION
add rdf:Property as type on object and datatype properties
We already do this on the instance types, why not here as well?
