### PR TITLE
adapted wikidata extraction to wikidata dump changes

### DIFF
--- a/core/src/main/scala/org/dbpedia/extraction/mappings/WikidataMappedFactsExtractor.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/mappings/WikidataMappedFactsExtractor.scala
@@ -45,7 +45,7 @@ class WikidataMappedFactsExtractor(
 
     //for each parser method exists a children node, you can differentiate between them through the Tiples property
     //for example :  skos:label  >> for labels extractor
-    //               owl:sameas >> for  Language links
+    //owl:sameas >> for  Language links
     for (n <- page.children) {
 
       n match {
@@ -130,9 +130,10 @@ class WikidataMappedFactsExtractor(
 
   def getDBpediaSameasProperties(property:String) : Set[OntologyProperty] =
   {
+    val p = property.replace("http://www.wikidata.org/entity/","http://wikidata.dbpedia.org/resource/")
     var properties = Set[OntologyProperty]()
     context.ontology.equivalentPropertiesMap.foreach({map =>
-      if (map._1.toString.matches(property))
+      if (map._1.toString.matches(p))
       {
         map._2.foreach{mappedProp =>
           properties += mappedProp

--- a/core/src/main/scala/org/dbpedia/extraction/ontology/RdfNamespace.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/ontology/RdfNamespace.scala
@@ -61,7 +61,7 @@ object RdfNamespace {
   val SKOS = ns("skos", "http://www.w3.org/2004/02/skos/core#")
   val SCHEMA = ns("schema", "http://schema.org/", false) 
   val BIBO = ns("bibo", "http://purl.org/ontology/bibo/", false)
-  val WIKIDATA = ns("wikidata", "http://www.wikidata.dbpedia.org/resource/", false)
+  val WIKIDATA = ns("wikidata", "http://wikidata.dbpedia.org/resource/", false)
   val MAPPINGS = ns("mappings", "http://mappings.dbpedia.org/wiki/", false)
   
   /**


### PR DESCRIPTION
adapted Wikidata extraction process to latest Wikidata dump changes release changes in 20140226 dump [1] . 

extracted DBpedia triples from this dump can be found at [2]

1- http://dumps.wikimedia.org/wikidatawiki/20140226/
2- http://wiktionary.dbpedia.org/wikidata_tmp/v.0.3/
