### PR TITLE
fix geo coordinates bug

### DIFF
--- a/core/src/main/scala/org/dbpedia/extraction/dataparser/GeoCoordinateParser.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/dataparser/GeoCoordinateParser.scala
@@ -119,17 +119,15 @@ class GeoCoordinateParser(
             //{{coord|latitude|longitude|coordinate parameters|template parameters}}
             case latitude :: longitude :: _ =>
             {
-              val latitudeDeg = singleCoordParser.parseSingleCoordinate(latitude) match{
+              val lat = singleCoordParser.parseSingleCoordinate(latitude) match{
                 case Some(d) => d.toDouble
                 case None => latitude.toDouble
               }
-              val longitudeDeg = singleCoordParser.parseSingleCoordinate(longitude) match{
+              val lon = singleCoordParser.parseSingleCoordinate(longitude) match{
                 case Some(d) => d.toDouble
                 case None => longitude.toDouble
               }
-                Some(new GeoCoordinate( latDeg = latitudeDeg,
-                                        lonDeg = longitudeDeg,
-                                        belongsToArticle = belongsToArticle))
+                Some(new GeoCoordinate( lat, lon, belongsToArticle))
             }
             case _ => None
         }
@@ -143,7 +141,7 @@ class GeoCoordinateParser(
            case Coordinate(latDeg, latMin, latSec, latDir, lonDeg, lonMin, lonSec, lonDir) =>
            {
                Some(new GeoCoordinate( latDeg.toDouble, latMin.toDouble, if(latSec != null) latSec.toDouble else 0.0, latDir,
-                                       lonDeg.toDouble, lonMin.toDouble, if(lonSec != null) lonSec.toDouble else 0.0, lonDir ))
+                                       lonDeg.toDouble, lonMin.toDouble, if(lonSec != null) lonSec.toDouble else 0.0, lonDir , false))
            }
            case _ => None
        }

--- a/core/src/main/scala/org/dbpedia/extraction/dataparser/coordinate/GeoCoordinate.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/dataparser/coordinate/GeoCoordinate.scala
@@ -5,21 +5,21 @@ package org.dbpedia.extraction.dataparser
  *
  * @throws IllegalArgumentException if the given parameters do not denote a valid coordinate
  */
-class GeoCoordinate( lat : Latitude,
-                     long : Longitude,
+class GeoCoordinate( val latitude : Double,
+                     val longitude : Double,
                      val belongsToArticle : Boolean = false )
 {
+  def this( lat : Latitude,
+            long : Longitude,
+            belongsToArticle : Boolean
+            )= this( lat.toDouble, long.toDouble, belongsToArticle)
   def this(
       latDeg : Double = 0.0, latMin : Double = 0.0, latSec : Double = 0.0, latHem : String = "N",
       lonDeg : Double = 0.0, lonMin : Double = 0.0, lonSec : Double = 0.0, lonHem : String = "E",
-      belongsToArticle : Boolean = false
+      belongsToArticle : Boolean
         )= this(
-            new Latitude(latDeg, latMin, latSec, latHem, true), 
+            new Latitude(latDeg, latMin, latSec, latHem, true),
             new Longitude(lonDeg, lonMin, lonSec, lonHem),
-            belongsToArticle
-            )
-            
-   val latitude = lat.toDouble
-   val longitude = long.toDouble
-            
+            belongsToArticle )
+
 }

--- a/core/src/main/scala/org/dbpedia/extraction/mappings/GeoCoordinatesMapping.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/mappings/GeoCoordinatesMapping.scala
@@ -84,7 +84,7 @@ extends PropertyMapping
       {
         try
         {
-          return Some(new GeoCoordinate(latDeg = lat, lonDeg = lon))
+          return Some(new GeoCoordinate(lat, lon))
         }
         catch
         {
@@ -113,7 +113,7 @@ extends PropertyMapping
 
         try
         {
-          return Some(new GeoCoordinate(latDeg, latMin, latSec, latDir, lonDeg, lonMin, lonSec, lonDir))
+          return Some(new GeoCoordinate(latDeg, latMin, latSec, latDir, lonDeg, lonMin, lonSec, lonDir, false))
         }
         catch
         {


### PR DESCRIPTION
When a template provides simple double coordinates we did not use them as is but instantiate only the lat/lon degree (without minutes)
