### PR TITLE
Load only explicitly declared languages 

### DIFF
--- a/dump/src/main/scala/org/dbpedia/extraction/dump/extract/Config.scala
+++ b/dump/src/main/scala/org/dbpedia/extraction/dump/extract/Config.scala
@@ -68,11 +68,8 @@ private class Config(config: Properties)
     val classes = new HashMap[Language, List[Class[_ <: Extractor[_]]]]()
 
     /*
-    TODO: maybe we should check in the first loop if property "extractors."+language.wikiCode
-    exists and if it does, add its specific extractors. Better: refactor the whole config mess.
-    Currently, the "languages" property just defines for which languages the default extractors
-    should be loaded. It does not define which languages should be processed in general,
-    all the "extractors.xx" properties are independent from the "languages" property.
+    TODO: Refactor the whole config mess.
+    The languages property defines which languages should be processed in general,
     It should be possible to say: run extractors A,B,C for languages xx,yy,zz. That
     would make the configuration much simpler, less repetitive and more flexible.
     */


### PR DESCRIPTION
Load only explicitly declared languages
if an extractor.xx existed but xx was not declared in languages, xx was added in the extraction list
