### PR TITLE
Make Config public

### DIFF
--- a/dump/src/main/scala/org/dbpedia/extraction/dump/extract/Config.scala
+++ b/dump/src/main/scala/org/dbpedia/extraction/dump/extract/Config.scala
@@ -15,7 +15,7 @@ import org.dbpedia.extraction.util.ConfigUtils.{LanguageRegex,RangeRegex,toRange
 import org.dbpedia.extraction.util.RichString.wrapString
 import scala.io.Codec
 
-private class Config(config: Properties)
+class Config(config: Properties)
 {
   // TODO: get rid of all config file parsers, use Spring
 


### PR DESCRIPTION
Re: distributed-extraction-framework: Testing DistRedirects will require instantiating a Config object. Other than that future stuff may require it too.
