### PR TITLE
Added redirect parsing to XMLSource.fromXML and made it more consistent.

### DIFF
--- a/core/src/main/scala/org/dbpedia/extraction/sources/XMLSource.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/sources/XMLSource.scala
@@ -136,14 +136,16 @@ private class XMLSource(xml : Elem, language: Language) extends Source
                 case e: NumberFormatException => throw new IllegalArgumentException("Cannot parse content of element [ns] as int", e)
             }
 
-            if(title != null && title.namespace.code != nsCode) {
+            if(title != null && title.namespace.code != nsCode)
+            {
                 val expected: Namespace = Namespace.values.apply(nsCode)
                 //logger.log(Level.WARNING, "Error parsing title: found namespace " + title.namespace + ", expected " + expected + " in title " + titleStr)
                 title.otherNamespace = expected
             }
 
             //Skip bad titles
-            if(title != null) {
+            if(title != null)
+            {
                 val _redirect = (page \ "redirect" \ "@title").text match
                 {
                   case "" => null


### PR DESCRIPTION
I need to use `XMLSource.fromXML` for a Spark mapper to parse the raw page strings in parallel. Instead of the sequential `XMLSource.fromReaders` approach, this one is used along with the new XmlInputFormat approach.

Added redirect reading from XML. Now outputs from [distributed-extraction-framework](https://github.com/dbpedia/distributed-extraction-framework/) match with that of [extraction-framework](https://github.com/dbpedia/extraction-framework) when using XmlInputFormat.

Using pattern matching instead of if-else: saves re-computing of xml elements, looks cleaner. Also, this change makes the parsing more similar to `WikipediaDumpParser.readPage()` for consistency by checking for `null` titles and matching namespaces.
