### PR TITLE
Simplify FileLike's generic type to T

### DIFF
--- a/core/src/main/scala/org/dbpedia/extraction/util/FileLike.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/util/FileLike.scala
@@ -5,7 +5,7 @@ import java.io.{InputStream,OutputStream}
 /**
  * Allows common handling of java.io.File and java.nio.file.Path
  */
-abstract class FileLike[T <% FileLike[T]] {
+abstract class FileLike[T] {
   
   /**
    * @return full path


### PR DESCRIPTION
Change generic type of `FileLike` as per discussion on https://github.com/dbpedia/distributed-extraction-framework/pull/22#discussion-diff-13780837

This is more accurate because `FileLike` doesn't need the implicit conversion (view bounding).

I've tested with `mvn clean install` and running an extraction on the liwiki dump.
