### PR TITLE
Aduna repo now found correctly (recently migrated into Maven)

### DIFF
--- a/wiktionary/pom.xml
+++ b/wiktionary/pom.xml
@@ -39,16 +39,6 @@
         </dependency>
       </dependencies>
 
-      <repositories>
-
-          <repository>
-              <id>aduna</id>
-              <name>Aduna Software</name>
-              <url>http://repo.aduna-software.org/maven2/releases/</url>
-          </repository>
-
-      </repositories>
-
 
       <build>
       <plugins>


### PR DESCRIPTION
This is following a suggestion from Marco Fossati on the dbpedia-developers mailing list.
