### PR TITLE
Move File.exists logic in Config into the closure

### DIFF
--- a/dump/src/main/scala/org/dbpedia/extraction/dump/extract/Config.scala
+++ b/dump/src/main/scala/org/dbpedia/extraction/dump/extract/Config.scala
@@ -15,8 +15,12 @@ class Config(config: Properties)
   // TODO: get rid of all config file parsers, use Spring
 
   /** Dump directory */
-  val dumpDir = getValue(config, "base-dir", true)(new File(_))
-  if (! dumpDir.exists) throw error("dir "+dumpDir+" does not exist")
+  val dumpDir = getValue(config, "base-dir", true){
+    x =>
+      val dir = new File(x)
+      if (! dir.exists) throw error("dir "+dir+" does not exist")
+      dir
+  }
 
   val requireComplete = config.getProperty("require-download-complete", "false").toBoolean
 


### PR DESCRIPTION
This allows the dumpDir field to be easily overriden. Here is why:

The pull request to distributed-extraction-framework https://github.com/dbpedia/distributed-extraction-framework/pull/26 needs this. Take a look at https://github.com/dbpedia/distributed-extraction-framework/commit/70c90f19ba69e76b297431a513be493d7d943c6c#diff-ca3c67cce9806e13ddceb818917a5fdaR134 :

`override val dumpDir: File = null` makes dumpDir null, but overriding it does not stop `if (! dumpDir.exists) throw error("dir "+dumpDir+" does not exist")` (existing Config) to throw a NullPointerException.
