### PR TITLE
Allow to explicitly exclude languages from processing

### DIFF
--- a/core/src/main/scala/org/dbpedia/extraction/util/ConfigUtils.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/util/ConfigUtils.scala
@@ -59,6 +59,7 @@ object ConfigUtils {
     var keys = for(arg <- args; key <- arg.split("[,\\s]"); if (key.nonEmpty)) yield key
         
     var languages = SortedSet[Language]()
+    var excludedLanguages = SortedSet[Language]()
     
     val ranges = new HashSet[(Int,Int)]
   
@@ -66,6 +67,7 @@ object ConfigUtils {
       case "@mappings" => languages ++= Namespace.mappings.keySet
       case RangeRegex(from, to) => ranges += toRange(from, to)
       case LanguageRegex(language) => languages += Language(language)
+      case ExcludedLanguageRegex(language) => excludedLanguages += Language(language)
       case other => throw new IllegalArgumentException("Invalid language / range '"+other+"'")
     }
     
@@ -87,6 +89,8 @@ object ConfigUtils {
         languages += wiki.language
       }
     }
+
+    languages --= excludedLanguages
     
     languages.toArray
   }
@@ -97,6 +101,11 @@ object ConfigUtils {
    * lower-case letters and dash, but there are also dumps for "wikimania2005wiki" etc.
    */
   val LanguageRegex = """([a-z][a-z0-9-]+)""".r
+
+  /**
+   * Regex used for excluding languages from the import.
+   */
+  val ExcludedLanguageRegex = """!([a-z][a-z0-9-]+)""".r
     
   /**
    * Regex for numeric range, both limits optional


### PR DESCRIPTION
By adding the language code prefixed with an exclamation mark, it is possible to exclude the given language from the processing. This is active for all tools which use the ConfigUtils.parseLanguages method for retrieving the set of relevant languages (e.g., importing the Wikipedia dumps).

Example:
the arguments "10000-,!en,!de" would lead to processing of all languages with at least 10000 articles except for the English and the German Wikipedia.
