### PR TITLE
Make the directory/file vals lazy so that they don't throw up errors in distributed framework

### DIFF
--- a/dump/src/main/scala/org/dbpedia/extraction/dump/extract/Config.scala
+++ b/dump/src/main/scala/org/dbpedia/extraction/dump/extract/Config.scala
@@ -15,7 +15,7 @@ class Config(config: Properties)
   // TODO: get rid of all config file parsers, use Spring
 
   /** Dump directory */
-  val dumpDir = getValue(config, "base-dir", true){
+  lazy val dumpDir = getValue(config, "base-dir", true){
     x =>
       val dir = new File(x)
       if (! dir.exists) throw error("dir "+dir+" does not exist")
@@ -33,10 +33,10 @@ class Config(config: Properties)
   val parser = config.getProperty("parser", "simple")
 
   /** Local ontology file, downloaded for speed and reproducibility */
-  val ontologyFile = getValue(config, "ontology", false)(new File(_))
+  lazy val ontologyFile = getValue(config, "ontology", false)(new File(_))
 
   /** Local mappings files, downloaded for speed and reproducibility */
-  val mappingsDir = getValue(config, "mappings", false)(new File(_))
+  lazy val mappingsDir = getValue(config, "mappings", false)(new File(_))
 
   val formats = parseFormats(config, "uri-policy", "format")
 


### PR DESCRIPTION
These vals are overriden in DistConfig.ExtractionConfig. These need to be lazy or else things like `if (! dir.exists) throw error("dir "+dir+" does not exist")` or File initialization errors can mess with the initialization of DistConfig (which prevent distributed extraction from starting).

This mainly occurs if a path like `hdfs:///somepath/somefile` is given to `base-dir` in spark-config.properties, and the `base-dir` in the general config.properties is omitted, or set to `hdfs:///somepath/somefile`.
