### PR TITLE
Generate revision-uris dataset with oldid URIs again

### DIFF
--- a/core/src/main/scala/org/dbpedia/extraction/mappings/ProvenanceExtractor.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/mappings/ProvenanceExtractor.scala
@@ -26,6 +26,6 @@ extends WikiPageExtractor
   private val quad = QuadBuilder.stringPredicate(context.language, DBpediaDatasets.RevisionUris, derivedFromProperty, null) _
 
   override def extract(page: WikiPage, subjectUri: String, pageContext: PageContext): Seq[Quad] = {
-    Seq(quad(subjectUri, page.title.pageIri, page.sourceUri))
+    Seq(quad(subjectUri, page.sourceUri, page.sourceUri))
   }
 }


### PR DESCRIPTION
revision-uris triple datasets were generated with article IRIs but without the direct reference to the revision at the time of the extraction (using the oldid parameter). This change reintroduces the oldid URIs into the triple datasets.
