### PR TITLE
Make constructor arg context public

### DIFF
--- a/core/src/main/scala/org/dbpedia/extraction/dataparser/ParserUtils.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/dataparser/ParserUtils.scala
@@ -11,7 +11,7 @@ import scala.language.reflectiveCalls
  * Utility functions used by the data parsers.
  */
 //TODO test after re-factor
-class ParserUtils( context : { def language : Language } )
+class ParserUtils( val context : { def language : Language } )
 {
     private val scales = ParserUtilsConfig.scalesMap.getOrElse(context.language.wikiCode, ParserUtilsConfig.scalesMap("en"))
 


### PR DESCRIPTION
Needed by ParserUtilsSerializer in distributed-extraction-framework.

Re: https://github.com/dbpedia/distributed-extraction-framework/commit/fae11c170b53f548cf92fcacc39c93af5be3c17e
