### PR TITLE
Update DisambiguationExtractorConfig.scala

### DIFF
--- a/core/src/main/scala/org/dbpedia/extraction/config/mappings/DisambiguationExtractorConfig.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/config/mappings/DisambiguationExtractorConfig.scala
@@ -27,6 +27,7 @@ object DisambiguationExtractorConfig
          "pl" -> " (ujednoznacznienie)",
          "pt" -> " (desambiguação)",
          "ru" -> " (значения)",
+         "sk" -> " (Rozlišovacia stránka)",
          "sr" -> " (Višeznačna odrednica)"  //TODO make it a Set() for multiple “sr” -> " (вишезначна одредница)"
     )
 }


### PR DESCRIPTION
Updated configuration, so that it can now parse disambiguation pages of SK Wikipedia.
