### PR TITLE
IntermediateNode URI naming

### DIFF
--- a/core/src/main/scala/org/dbpedia/extraction/mappings/PageContext.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/mappings/PageContext.scala
@@ -57,7 +57,7 @@ private class UriGenerator
             text = WikiUtil.wikiEncode(text)
 
             //Test if the base URI ends with a prefix of text
-            var i = Math.max(baseUri.lastIndexOf('_'), baseUri.lastIndexOf('/')) - 1
+            var i = Math.max(baseUri.lastIndexOf('_'), baseUri.lastIndexOf('/')) + 1
             var done = false
             while(!done && i > 0 && baseUri.length - i < text.length)
             {


### PR DESCRIPTION
IntermediateNode URI naming excluded any part of the name that was included in the main resource.
e.g. http://dbpedia.org/page/Fredericksburg_Hotspur ended with 'r' and any name starting with 'r' was removed from the URI.
With this fix we start checking from the last word or the complete resource name

Fixes #292
