### PR TITLE
Dutch coordinates are written with the English locale and GeoCoordinatesMapping produces illegal triples

### DIFF
--- a/core/src/test/scala/org/dbpedia/extraction/dataparser/DoubleParserTest.scala
+++ b/core/src/test/scala/org/dbpedia/extraction/dataparser/DoubleParserTest.scala
@@ -15,6 +15,8 @@ class DoubleParserTest extends TestCase
         testParse("de", "1.234,5", Some(1234.5))
         testParse("en", ".12345", Some(0.12345))
         testParse("de", ",12345", Some(0.12345))
+        testParse("nl", "1,234", Some(1.234))
+        testParse("nl", ",12345", Some(0.12345))
     }
 
     private def testParse( lang : String, value : String, expect : Option[Double] ) : Unit =


### PR DESCRIPTION
Dutch coordinates are written with the English locale and GeoCoordinatesMapping produces illegal triples
e.g. 52304 instead of 52.304 (for 52.304 value)