### PR TITLE
Fixed ignorelist formatting

### DIFF
--- a/server/src/main/scala/org/dbpedia/extraction/server/resources/Extraction.scala
+++ b/server/src/main/scala/org/dbpedia/extraction/server/resources/Extraction.scala
@@ -4,7 +4,7 @@ import java.net.{URL, URI}
 import org.dbpedia.extraction.destinations.formatters.{RDFJSONFormatter, TerseFormatter}
 import org.dbpedia.extraction.util.Language
 import javax.ws.rs._
-import javax.ws.rs.core.{MediaType, Response}
+import javax.ws.rs.core.{HttpHeaders, MediaType, Response}
 import java.util.logging.{Logger,Level}
 import scala.xml.Elem
 import scala.io.{Source,Codec}
@@ -130,7 +130,9 @@ class Extraction(@PathParam("lang") langCode : String)
         val destination = new DeduplicatingDestination(new WriterDestination(() => writer, formatter))
         Server.instance.extractor.extract(source, destination, language, customExtraction)
 
-        Response.ok(writer.toString).`type`(selectContentType(format)).build()
+        Response.ok(writer.toString)
+          .header(HttpHeaders.CONTENT_TYPE, selectContentType(format)+"; charset=UTF-8" )
+          .build()
     }
 
     private def selectContentType(format: String): String = {

--- a/server/src/main/statistics/ignorelist_bg.txt
+++ b/server/src/main/statistics/ignorelist_bg.txt
@@ -38,3 +38,4 @@ image
 style
 plain
 embed
+

--- a/server/src/main/statistics/ignorelist_ca.txt
+++ b/server/src/main/statistics/ignorelist_ca.txt
@@ -51,3 +51,4 @@ body3
 rightarm3
 shorts3
 socks3
+

--- a/server/src/main/statistics/ignorelist_en.txt
+++ b/server/src/main/statistics/ignorelist_en.txt
@@ -320,6 +320,7 @@ Refbegin
 Official website
 Col-begin
 
+
 properties|24
 
 template|Taxobox
@@ -543,3 +544,4 @@ image
 style
 plain
 embed
+

--- a/server/src/main/statistics/ignorelist_ga.txt
+++ b/server/src/main/statistics/ignorelist_ga.txt
@@ -66,3 +66,4 @@ template|Ie baile infobox
 properties|2
 íomhá an chírín
 sfx cóor
+


### PR DESCRIPTION
The server was crashing on launch when using the default config. Full stacktrace:
```
Exception in thread "main" java.lang.Exception: missing empty line
	at org.dbpedia.extraction.server.util.CollectionReader.readEmpty(CollectionReader.scala:22)
	at org.dbpedia.extraction.server.stats.IgnoreList.<init>(IgnoreList.scala:51)
	at org.dbpedia.extraction.server.stats.MappingStatsManager.<init>(MappingStatsManager.scala:15)
	at org.dbpedia.extraction.server.Server$$anonfun$1.apply(Server.scala:24)
	at org.dbpedia.extraction.server.Server$$anonfun$1.apply(Server.scala:24)
	at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:245)
	at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:245)
	at scala.collection.IndexedSeqOptimized$class.foreach(IndexedSeqOptimized.scala:33)
	at scala.collection.mutable.WrappedArray.foreach(WrappedArray.scala:35)
	at scala.collection.TraversableLike$class.map(TraversableLike.scala:245)
	at scala.collection.AbstractTraversable.map(Traversable.scala:104)
	at org.dbpedia.extraction.server.Server.<init>(Server.scala:24)
	at org.dbpedia.extraction.server.Server$.main(Server.scala:74)
	at org.dbpedia.extraction.server.Server.main(Server.scala)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at com.intellij.rt.execution.application.AppMain.main(AppMain.java:134)
```