### PR TITLE
FlagTemplateParser: support full country name templates + perf improvements

### DIFF
--- a/core/src/main/scala/org/dbpedia/extraction/config/dataparser/FlagTemplateParserConfig.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/config/dataparser/FlagTemplateParserConfig.scala
@@ -1,6 +1,7 @@
 package org.dbpedia.extraction.config.dataparser
 
 import java.util.Locale
+import scala.collection.mutable
 
 
 object FlagTemplateParserConfig
@@ -2611,7 +2612,7 @@ object FlagTemplateParserConfig
 
     def getCodeMap(language : String) : Map[String, String] =
     {
-        storedLangCodeMap.getOrElseUpdate(language, internalGetCodeMap(language))
+        synchronized { storedLangCodeMap.getOrElseUpdate(language, internalGetCodeMap(language)) }
     }
 
     // handle languages where we need full country name templates eg {{France}} not just {{FRA}}
@@ -2619,13 +2620,13 @@ object FlagTemplateParserConfig
     {
         language match
         {
-          case "fr" => cachedCountryNames.getOrElseUpdate(language, getCodeMap(language).values.toSet)
+          case "fr" => synchronized { cachedCountryNames.getOrElseUpdate(language, getCodeMap(language).values.toSet) }
           case _ => Set[String]()
         }
     }
  
-    private val storedLangCodeMap = scala.collection.mutable.Map[String,Map[String,String]]();
-    private val cachedCountryNames = scala.collection.mutable.Map[String,Set[String]]();
+    private val storedLangCodeMap = mutable.Map[String,Map[String,String]]();
+    private val cachedCountryNames = mutable.Map[String,Set[String]]();
 
    //for major languages (e.g fr, de, ...) maybe similar to "en", see
     //http://download.oracle.com/javase/1.4.2/docs/api/java/util/Locale.html

--- a/core/src/main/scala/org/dbpedia/extraction/dataparser/FlagTemplateParser.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/dataparser/FlagTemplateParser.scala
@@ -20,7 +20,7 @@ class FlagTemplateParser( extractionContext : { def language : Language } ) exte
             {
                 val templateName = templateNode.title.decoded
 
-                if(templates.contains(templateName.toLowerCase))
+                if (templates.contains(templateName.toLowerCase))
                 {
                     for (countryNameNode <- templateNode.property("1"))
                     {
@@ -39,10 +39,19 @@ class FlagTemplateParser( extractionContext : { def language : Language } ) exte
                 }
 
                 //template name is actually country code for flagicon template
-                else if((templateName.length == 2 || templateName.length == 3) && (templateName == templateName.toUpperCase))
+                else if ((templateName.length == 2 || templateName.length == 3) && (templateName == templateName.toUpperCase))
                 {
                     val langCodeMap = FlagTemplateParserConfig.getCodeMap(extractionContext.language.wikiCode)
                     langCodeMap.get(templateName).foreach(countryName => return Some(new WikiTitle(countryName, Namespace.Main, extractionContext.language)))
+                }
+                
+                else
+                {
+                    val fullCountryNames = FlagTemplateParserConfig.getFullCountryNames(extractionContext.language.wikiCode)
+                    if (fullCountryNames.contains(templateName))
+                    {
+                        return Some(new WikiTitle(templateName, Namespace.Main, extractionContext.language))
+                    }
                 }
 
                 None

--- a/core/src/test/scala/org/dbpedia/extraction/dataparser/FlagTemplateParserTest.scala
+++ b/core/src/test/scala/org/dbpedia/extraction/dataparser/FlagTemplateParserTest.scala
@@ -60,7 +60,35 @@ class FlagTemplateParserTest extends FlatSpec with ShouldMatchers
     {
         parse("en", "{{EU}}") should equal (Some("European Union"))
     }
+    "FlagTemplateParser" should "return France@fr" in
+    {
+        parse("fr", "{{France}}") should equal (Some("France"))
+    }
+    "FlagTemplateParser" should "return Afrique du Sud@fr" in
+    {
+        parse("fr", "{{Afrique du Sud}}") should equal (Some("Afrique du Sud"))
+    }
 
+/*  Performance tests for different cases
+  
+    "FlagTemplateParser" should "return United States@en (x100000)" in
+    {
+        1 to 100000 foreach { i => parse("en", "{{flag|United States}}") }
+    }
+    "FlagTemplateParser" should "return France@en (x100000)" in
+    {
+        1 to 100000 foreach { i => parse("en", "{{flag|FRA}}") }
+    }
+    "FlagTemplateParser" should "return France@fr (x100000)" in
+    {
+        1 to 100000 foreach { i => parse("fr", "{{FRA}}") }
+    }
+    "FlagTemplateParser" should "return Afrique du Sud@fr (x100000)" in
+    {
+        1 to 100000 foreach { i => parse("fr", "{{Afrique du Sud}}") }
+    }
+*/
+  
     private val parser = WikiParser.getInstance()
 
     private def parse(language : String, input : String) : Option[String] =


### PR DESCRIPTION
- support full country name templates eg {{France}} not just {{FRA}}, used in `fr`
- performance improvements by caching code-generated config

second part of issue #360 