### PR TITLE
stats for redirected templates and deprecated properties

### DIFF
--- a/server/src/main/scala/org/dbpedia/extraction/server/resources/TemplateStatistics.scala
+++ b/server/src/main/scala/org/dbpedia/extraction/server/resources/TemplateStatistics.scala
@@ -143,7 +143,8 @@ class   TemplateStatistics(@PathParam("lang") langCode: String, @QueryParam("p")
           <tr>
             <th>occurrences</th> <th colspan="2">template (with link to property statistics)</th>
             <th>num properties</th> <th>mapped properties (%)</th>
-            <th>num property occurrences</th> <th>mapped property occurrences (%)</th> <th class="sorter-false"></th>
+            <th>num property occurrences</th> <th>mapped property occurrences (%)</th> 
+            <th>num properties mapped but unused</th> <th class="sorter-false"></th>
           </tr>
           </thead>
           <tbody>
@@ -170,7 +171,7 @@ class   TemplateStatistics(@PathParam("lang") langCode: String, @QueryParam("p")
             var redirectMsg = ""
             for (redirect <- targetRedirect) {
               if (mappingStat.isMapped) {
-                  //redirectMsg = " NOTE: the mapping for " + wikiDecode(redirect, language).substring(createMappingStats.templateNamespace.length()) + " is redundant!"
+                  redirectMsg = " NOTE: the mapping for " + redirect.substring(manager.templateNamespace.length) + " is redundant!"
               } else {
                   mappingsWikiLink = mappingUrlPrefix + redirect.substring(manager.templateNamespace.length)
                   backgroundClass = renameInfoClass
@@ -209,6 +210,7 @@ class   TemplateStatistics(@PathParam("lang") langCode: String, @QueryParam("p")
           <td align="right">{percentMappedProps}</td>
           <td align="right">{mappingStat.propertyUseCount}</td>
           <td align="right">{percentMappedPropOccur}</td>
+          <td align="right">{mappingStat.mappedPropertyUnuseCount}</td>
           { if (Server.instance.adminRights(password)) {
           <td>
             <a href={"../../ignore/"+langCode+"/template/?ignore="+(! isIgnored)+"&template="+wikiEncode(mappingStat.templateName)+cookieQuery('&', show)}>

--- a/server/src/main/scala/org/dbpedia/extraction/server/resources/TemplateStatistics.scala
+++ b/server/src/main/scala/org/dbpedia/extraction/server/resources/TemplateStatistics.scala
@@ -144,7 +144,7 @@ class   TemplateStatistics(@PathParam("lang") langCode: String, @QueryParam("p")
             <th>occurrences</th> <th colspan="2">template (with link to property statistics)</th>
             <th>num properties</th> <th>mapped properties (%)</th>
             <th>num property occurrences</th> <th>mapped property occurrences (%)</th> 
-            <th>num properties mapped but unused</th> <th class="sorter-false"></th>
+            <th>num properties not found</th> <th class="sorter-false"></th>
           </tr>
           </thead>
           <tbody>
@@ -201,7 +201,7 @@ class   TemplateStatistics(@PathParam("lang") langCode: String, @QueryParam("p")
           <td>
             <a href={"../../templatestatistics/"+langCode+"/?template="+wikiEncode(mappingStat.templateName)+cookieQuery('&')}>
               {mappingStat.templateName}
-            </a>
+            </a><br/>
             {redirectMsg}
           </td>
           } }

--- a/server/src/main/scala/org/dbpedia/extraction/server/stats/MappingStats.scala
+++ b/server/src/main/scala/org/dbpedia/extraction/server/stats/MappingStats.scala
@@ -24,23 +24,28 @@ class MappingStats(templateStats: TemplateStats, val templateName: String, val i
    * @param all count all properties or only the ones that are mapped
    * @param use count property use in wikipedia articles or just the definition in template
    */
-  private def count(all: Boolean, use: Boolean) = {
+  private def count(all: Boolean, use: Boolean, invalid:Boolean) = {
     var sum = 0
     for ((name, (count, mapped)) <- properties) {
       if (all || mapped) {
-        if (count != InvalidTarget && ! ignoreList.isPropertyIgnored(templateName, name)) {
-          sum += (if (use) count else 1)
+        if (invalid) {
+          sum += (if (count == InvalidTarget) 1 else 0)
+        } else {
+          if (count != InvalidTarget && ! ignoreList.isPropertyIgnored(templateName, name)) {
+            sum += (if (use) count else 1)
+          }
         }
       }
     }
     sum
   }
 
-  val propertyCount = count(true, false)
-  val mappedPropertyCount = count(false, false) 
+  val propertyCount = count(true, false, false)
+  val mappedPropertyCount = count(false, false, false) 
 
-  val propertyUseCount = count(true, true)
-  val mappedPropertyUseCount = count(false, true) 
+  val propertyUseCount = count(true, true, false)
+  val mappedPropertyUseCount = count(false, true, false) 
+  val mappedPropertyUnuseCount = count(false, false, true) 
 
   val mappedPropertyRatio = mappedPropertyCount.toDouble / propertyCount.toDouble
   val mappedPropertyUseRatio = mappedPropertyUseCount.toDouble / propertyUseCount.toDouble

--- a/server/src/main/scala/org/dbpedia/extraction/server/stats/MappingStats.scala
+++ b/server/src/main/scala/org/dbpedia/extraction/server/stats/MappingStats.scala
@@ -21,10 +21,11 @@ class MappingStats(templateStats: TemplateStats, val templateName: String, val i
   val templateCount = templateStats.templateCount
 
   /**
-   * @param all count all properties or only the ones that are mapped
-   * @param use count property use in wikipedia articles or just the definition in template
+   * @param all: count all properties or only the ones that are mapped
+   * @param use: count property use in wikipedia articles or just the definition in template
+   * @param invalid: count only non-existant properties if set
    */
-  private def count(all: Boolean, use: Boolean, invalid:Boolean) = {
+  private def count(all: Boolean, use: Boolean, invalid:Boolean = false) = {
     var sum = 0
     for ((name, (count, mapped)) <- properties) {
       if (all || mapped) {
@@ -40,12 +41,12 @@ class MappingStats(templateStats: TemplateStats, val templateName: String, val i
     sum
   }
 
-  val propertyCount = count(true, false, false)
-  val mappedPropertyCount = count(false, false, false) 
+  val propertyCount = count(true, false)
+  val mappedPropertyCount = count(false, false) 
 
-  val propertyUseCount = count(true, true, false)
-  val mappedPropertyUseCount = count(false, true, false) 
-  val mappedPropertyUnuseCount = count(false, false, true) 
+  val propertyUseCount = count(true, true)
+  val mappedPropertyUseCount = count(false, true) 
+  val mappedPropertyUnuseCount = count(false, false, invalid = true) 
 
   val mappedPropertyRatio = mappedPropertyCount.toDouble / propertyCount.toDouble
   val mappedPropertyUseRatio = mappedPropertyUseCount.toDouble / propertyUseCount.toDouble

--- a/server/src/main/scala/org/dbpedia/extraction/server/stats/MappingStatsHolder.scala
+++ b/server/src/main/scala/org/dbpedia/extraction/server/stats/MappingStatsHolder.scala
@@ -51,7 +51,7 @@ object MappingStatsHolder {
         }
       }
       
-      val redirects = wikiStats.redirects.filterKeys(title => templateMappings.contains(title)).map(_.swap)
+      val redirects = wikiStats.redirects.filterKeys(title => templateMappings.contains(title.substring(templateNamespace.length))).map(_.swap)
       
       val holder = new MappingStatsHolder(mappings, statistics.toList, redirects, ignoreList)
       


### PR DESCRIPTION
- fixed existing code for highlighting mapped templates that have been removed or have redundant mappings between redirected templates: bug [here] (https://github.com/Nono314/extraction-framework/commit/5c872f0ed3d0841c876790c4268c8c5a93d14b2a#diff-e373dc402eec9969c2d9027bca28464dL54) (the intersection was always empty since redirects hold templates with namespace while mappings has them without).
- added a new column to display for each template the number of mapped properties that are not found
