### PR TITLE
Change WikiApi parameter from "&apfrom=" to "&apcontinue="

### DIFF
--- a/core/src/main/scala/org/dbpedia/extraction/util/WikiApi.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/util/WikiApi.scala
@@ -53,7 +53,7 @@ class WikiApi(url: URL, language: Language)
         // -> "generator" instead of "list" and "gapnamespace" instead of "apnamespace" ("gap" is for "generator all pages")
  
         //Retrieve list of pages
-        val response = query("?action=query&continue=&format=xml&list=allpages&apfrom=" + URLEncoder.encode(fromPage, "UTF-8") + "&aplimit=" + pageListLimit + "&apnamespace=" + namespace.code)
+        val response = query("?action=query&continue=&format=xml&list=allpages&apcontinue=" + URLEncoder.encode(fromPage, "UTF-8") + "&aplimit=" + pageListLimit + "&apnamespace=" + namespace.code)
 
         //Extract page ids
         val pageIds = for(p <- response \ "query" \ "allpages" \ "p") yield (p \ "@pageid").head.text.toLong
@@ -62,7 +62,7 @@ class WikiApi(url: URL, language: Language)
         retrievePagesByPageID(pageIds).foreach(f)
 
         //Retrieve remaining pages
-        for(continuePage <- response \ "query-continue" \ "allpages" \ "@apfrom" headOption)
+        for(continuePage <- response \ "query-continue" \ "allpages" \ "@apcontinue" headOption)
         {
             // TODO: use iteration instead of recursion
             retrievePagesByNamespace(namespace, f, continuePage.text)


### PR DESCRIPTION
The XML output of retrieving all pages from dbpedia has changed. Fix the parameter so that I can get all required Ontology files. 

Ex: http://mappings.dbpedia.org/api.php?action=query&format=xml&list=allpages&apfrom=&aplimit=500&apnamespace=202
