### PR TITLE
Adjust live default config

### DIFF
--- a/live/live.default.ini
+++ b/live/live.default.ini
@@ -10,10 +10,10 @@ timezone = Etc/UTC
 uploaded_dump_date = 2012-04-01T15:00:00Z
 
 ; The place where application temporary files will be written (not public files)
-working_directory = /path/to/live/data/
+working_directory = /path/to/live/data
 
 ; path to save the created triples
-publishDiffRepoPath=/path/to/live/data/
+publishDiffRepoPath=/path/to/live/data
 
 ;annotations are created
 ;works with SimpleDumpdestination and LiveUpdateDestination
@@ -23,8 +23,8 @@ generateOWLAxiomAnnotations = true
 validateExtractors = false
 
 
-logpath = log/
-;rdfapi_include_dir =  api/
+logpath = log
+;rdfapi_include_dir =  api
 
 
 ; Default extraction processing threads
@@ -131,8 +131,8 @@ linkeddataresourceprefix = http://dbpedia2.openlinksw.com:8895/resource/
 sleepinterval = 5
 currentArticleFile = files/current.record
 ;this is where new articles should be placed by the harvester
-; default : oaiRecords = liveextraction/oairecords/
-oaiRecords = liveextraction/oairecords/
+; default : oaiRecords = liveextraction/oairecords
+oaiRecords = liveextraction/oairecords
 ;if there are many files in the oairecord dir use true here
 fastFileHandling = true
 ;turns of article count, because it is slow, if lots of articles are queued
@@ -152,4 +152,4 @@ sequenceNumber = 1
 ;***********************************
 ; OPTIONS FOR PUBLISHING STATISTICS*
 ;***********************************
-statisticsFilePath = /home/mohamed/publishdata/instancesstats.txt
+statisticsFilePath = /path/to/statistics/data

--- a/live/live.default.ini
+++ b/live/live.default.ini
@@ -4,7 +4,7 @@
 ; overwritten by file dbpedia.ini not checked into the svn
 ; copy one of the dist.ini to dbpedia.ini
 ;*******************
-timezone = Europe/Berlin
+timezone = Etc/UTC
 
 ; This will be used to setup the default min date for the feeders
 uploaded_dump_date = 2012-04-01T15:00:00Z
@@ -48,36 +48,36 @@ mappingsBaseWikiUri = http://mappings.dbpedia.org/wiki/
 ; FEEDERS
 ;*********************
 
-feeder.rcstream.enabled=true
-feeder.rcstream.room=en.wikipedia.org
+feeder.rcstream.enabled = true
+feeder.rcstream.room = en.wikipedia.org
 ; Specify the namespace code of events you want to be processed
 ; Full list available at https://en.wikipedia.org/wiki/Wikipedia:Namespace
 ; Add at least namespace 6 "File:" to process files on commons.wikimedia.org
-feeder.rcstream.allowedNamespaces=0,10,14
+feeder.rcstream.allowedNamespaces = 0,10,14
 
-feeder.live.enabled=true
-feeder.live.pollInterval=3000
-feeder.live.sleepInterval=1000
+feeder.live.enabled = true
+feeder.live.pollInterval = 3000
+feeder.live.sleepInterval = 1000
 
-feeder.mappings.enabled=true
-feeder.mappings.pollInterval=2000
-feeder.mappings.sleepInterval=1000
+feeder.mappings.enabled = true
+feeder.mappings.pollInterval = 2000
+feeder.mappings.sleepInterval = 1000
 
-feeder.unmodified.enabled=true
-feeder.unmodified.pollInterval=2000
-feeder.unmodified.sleepInterval=1000
+feeder.unmodified.enabled = true
+feeder.unmodified.pollInterval = 2000
+feeder.unmodified.sleepInterval = 1000
 
-feeder.unmodified.minDaysAgo=30
-feeder.unmodified.chunk=5000
-feeder.unmodified.threshold=500
-feeder.unmodified.sleepTime=30000
+feeder.unmodified.minDaysAgo = 30
+feeder.unmodified.chunk = 5000
+feeder.unmodified.threshold = 500
+feeder.unmodified.sleepTime = 30000
 
 ;*********************
 ; OPTIONS FOR LANGUAGE
 ;*********************
 
 ; URI Policy
-uri-policy.main=uri:en; generic:en; xml-safe-predicates:*
+uri-policy.main = uri:en; generic:en; xml-safe-predicates:*
 
 ;the language option might be included, but I'm not sure about it
 language = en
@@ -109,12 +109,12 @@ cache.pw    = mysqlPass
 
 
 ;dryRun doesn't update the store, but instead prints out the sparul
-dryRun=false
+dryRun = false
 ;additionally the sparul can be written to files
 ;if you want files only turn dryRun to true
 ;doesnot have any effect currently
 writeSPARULtoFiles = false
-outputdirs[]=files/SPARUL
+outputdirs[] = files/SPARUL
 
 ;********Statistics, can't live without it ************
 ;print statistics after n pages
@@ -132,7 +132,7 @@ sleepinterval = 5
 currentArticleFile = files/current.record
 ;this is where new articles should be placed by the harvester
 ; default : oaiRecords = liveextraction/oairecords/
-oaiRecords  = liveextraction/oairecords/
+oaiRecords = liveextraction/oairecords/
 ;if there are many files in the oairecord dir use true here
 fastFileHandling = true
 ;turns of article count, because it is slow, if lots of articles are queued
@@ -142,14 +142,14 @@ noglob = false
 ;**********************************
 ;**OPTIONS FOR PUBLISHING UPDATES**
 ;**********************************
-osmReplicationConfigPath=./live
-tmpPath=/tmp/lgd
-sleepInterval=60
-sequenceNumber=1
+osmReplicationConfigPath = ./live
+tmpPath = /tmp/lgd
+sleepInterval = 60
+sequenceNumber = 1
 ;***********************************
 
 
 ;***********************************
 ; OPTIONS FOR PUBLISHING STATISTICS*
 ;***********************************
-statisticsFilePath=/home/mohamed/publishdata/instancesstats.txt
+statisticsFilePath = /home/mohamed/publishdata/instancesstats.txt


### PR DESCRIPTION
This PR slightly changes the live.default.ini including some bug fixes:

- Changing the time zone to UTC in order to solve issues with the wrong time zone (Thanks for @mgns for these changes including adding the whitespaces!)
- Removing the trailing slashes from paths as they are added later during the extraction (if running with the old version, you might notice outputs such as Writing diff: `./tmp//2016/12/09/000000.added.nt.gz`)