### PR TITLE
Removed failedPagesLog file creation from AbstractExtractor

### DIFF
--- a/core/src/main/scala/org/dbpedia/extraction/mappings/AbstractExtractor.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/mappings/AbstractExtractor.scala
@@ -46,8 +46,10 @@ extends PageNodeExtractor
   protected val publicParames = abstractParams.getMap("publicParams")
   protected val protectedParams = abstractParams.getMap("protectedParams")
 
-  protected val failLogFile = new File(publicParames.get("failedPagesLog").get.asText())
-  failLogFile.createNewFile()
+  /*
+    protected val failLogFile = new File(publicParames.get("failedPagesLog").get.asText())
+    failLogFile.createNewFile()
+  */
 
   protected def apiUrl: URL = new URL(publicParames.get("apiUrl").get.asText())
   require(Try{apiUrl.openConnection().connect()} match {case Success(x)=> true case Failure(e) => false}, "can not connect to the apiUrl")


### PR DESCRIPTION
AbstractExtractor was creating an empty file with path specified with "failedPagesLog" parameter of "mediawikiconfig.json" file. That file was not used in any part of the code, and an incorrect path in the "failedPagesLog" parameter was causing the server to fail while starting.

I commented the code that creates the file.
