### PR TITLE
Extended scalesMap for en, fixed typos in comments

### DIFF
--- a/core/src/main/scala/org/dbpedia/extraction/config/dataparser/GeoCoordinateParserConfig.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/config/dataparser/GeoCoordinateParserConfig.scala
@@ -10,14 +10,14 @@ object GeoCoordinateParserConfig
                                  //"coor dms/new", "coor dec", "coor/new", "coor dms/archive001",
                                  //"coord/conversion", "coord/templates", "location dec"
     
-    //map latitude letters used in languages to the ones used in English ("E" for East and "W" for West) 
+    //map longitude letters used in languages to the ones used in English ("E" for East and "W" for West) 
     val longitudeLetterMap = Map(
         "de" -> Map("E" -> "E", "O" -> "E", "W" -> "W"),
         "en" -> Map("E" -> "E", "W" -> "W"),
         "fr" -> Map("E" -> "E", "O" -> "W", "W" -> "W")
     )
 
-    //map longitude letters used in languages to the ones used in English ("N" for North and "S" for South)
+    //map latitude letters used in languages to the ones used in English ("N" for North and "S" for South)
     val latitudeLetterMap = Map(
         "en" -> Map("N" -> "N", "S" -> "S")
     )

--- a/core/src/main/scala/org/dbpedia/extraction/config/dataparser/ParserUtilsConfig.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/config/dataparser/ParserUtilsConfig.scala
@@ -6,6 +6,7 @@ object ParserUtilsConfig
 {
     val scalesMap = Map(
         "en" -> Map(
+            "hundred" ->2,
             "thousand" -> 3,
             "million" -> 6,
             "mio" -> 6,
@@ -13,7 +14,22 @@ object ParserUtilsConfig
             "billion" -> 9,
             "bln" -> 9,
             "trillion" -> 12,
-            "quadrillion" -> 15
+            "quadrillion" -> 15,
+            "quintillion" -> 18,
+            "sextillion" -> 21,
+            "septillion" -> 24,
+            "octillion" -> 27,
+            "nonillion" -> 30,
+            "decillion" -> 33,
+            "undecillion" -> 36,
+            "duodecillion" -> 39,
+            "tredecillion" -> 42,
+            "quindecillion" -> 48,
+            "sexdecillion" -> 51,
+            "octodecillion" -> 57,
+            "novemdecillion" -> 60,
+            "vigintillion" -> 63,
+            "centillion" -> 303
         ),
         // For "ar" configuration, rendering right-to-left may seems like a bug, but it's not.
         // Don't change this else if you know how it is done.


### PR DESCRIPTION
- Extended en scalesMap in ParserUtilsConfig.scala
- Fixed typos in comments in GeoCoordinateParserConfig.scala

 In reference to [this issue](https://github.com/dbpedia/GSoC/issues/9) mentioned for GSOC 2019.
