### PR TITLE
various template pre-processing / transformation tweaks & bug-fixes

### DIFF
--- a/core/src/main/resources/templatetransform.json
+++ b/core/src/main/resources/templatetransform.json
@@ -22,7 +22,7 @@
     },
     "-":{
       "transformer":"textNode",
-      "replace": "<br />"
+      "replace": " - "
     },
     "Clr":{
       "transformer":"textNode",
@@ -50,22 +50,20 @@
     "Flatlist":{
       "transformer":"extractChildren",
       "keys": ["class", "style", "indent"],
-      "whileList":false
+      "whileList":false,
+      "additionalSplitString": "*"
     },
-    "Plainlist":{
+    "Plainlist|Plain list":{
       "transformer":"extractChildren",
       "keys": ["class", "style", "indent"],
-      "whileList":false
-    },
-    "Plain list":{
-      "transformer":"extractChildren",
-      "keys": ["class", "style", "indent"],
-      "whileList":false
+      "whileList":false,
+      "additionalSplitString": "*"
     },
     "Hlist":{
       "transformer":"extractChildren",
       "keys": ["class", "style", "list_style", "item_style", "indent", "item1_style", "item2_style", "item3_style", "item4_style", "item5_style", "item6_style", "item7_style", "item8_style", "item9_style", "item10_style", "item11_style", "item12_style", "item13_style", "item14_style", "item15_style", "item16_style", "item17_style", "item18_style", "item19_style", "item20_style", "item21_style", "item22_style", "item23_style", "item24_style", "item25_style"],
-      "whileList":false
+      "whileList":false,
+      "additionalSplitString": "*"
     },
     "Unbulleted list":{
       "transformer":"extractChildren",
@@ -75,7 +73,8 @@
     "Collapsible list":{
       "transformer":"extractChildren",
       "keys": ["expand", "frame_style", "title_style", "framestyle", "titlestyle", "list_style", "title", "liststyle", "hlist", "bullets"],
-      "whileList":false
+      "whileList":false,
+      "additionalSplitString": "*"
     },
     "ICD9":{
       "transformer":"extractChildren",
@@ -96,8 +95,84 @@
     "Official website":{
       "transformer":"externalLinkNode"
     },
-    "URL":{
+    "URL|url":{
       "transformer":"externalLinkNode"
+    },
+    "Currency":{
+      "transformer":"textNode",
+      "replace": "<br /> $(2||) $(1||)<br />"
+    },
+    "US$":{
+      "transformer":"textNode",
+      "replace": "<br /> USD $(1||)<br />"
+    },
+    "GB£":{
+      "transformer":"textNode",
+      "replace": "<br /> GBP $(1||)<br />"
+    },
+    "AUD":{
+      "transformer":"textNode",
+      "replace": "<br /> AUD $(1||)<br />"
+    },
+    "CAD":{
+      "transformer":"textNode",
+      "replace": "<br /> CAD $(1||)<br />"
+    },
+    "CNY":{
+      "transformer":"textNode",
+      "replace": "<br /> CNY $(1||)<br />"
+    },
+    "BDT":{
+      "transformer":"textNode",
+      "replace": "<br /> BDT $(1||)<br />"
+    },
+    "INR":{
+      "transformer":"textNode",
+      "replace": "<br /> INR $(1||)<br />"
+    },
+    "JPY":{
+      "transformer":"textNode",
+      "replace": "<br /> JPY $(1||)<br />"
+    },
+    "ISIN":{
+      "transformer":"textNode",
+      "replace": "$(1||)"
+    },
+    "New York Stock Exchange|NYSE|nyse|NYSE was|NYSE link":{
+      "transformer":"textNode",
+      "replace": "NYSE:$(1||)"
+    },
+    "NYSE American|AMEX|amex|AMEX link|AMEX was":{
+      "transformer":"textNode",
+      "replace": "AMEX:$(1||)"
+    },
+    "NASDAQ|nasdaq|NASDAQ was|NASDAQ link":{
+      "transformer":"textNode",
+      "replace": "NASDAQ:$(1||)"
+    },
+    "NASDAQ Dubai":{
+      "transformer":"textNode",
+      "replace": "NASDAQ Dubai:$(1||)"
+    },
+    "Frankfurt Stock Exchange|FWB|fwb|FWB link|FWB was":{
+      "transformer":"textNode",
+      "replace": "FWB:$(1||)"
+    },
+    "Euronext|Euronext link|Euronext was":{
+      "transformer":"textNode",
+      "replace": "Euronext:$(1||)"
+    },
+    "Luxembourg Stock Exchange":{
+      "transformer":"textNode",
+      "replace": "LuxSE:$(1||)"
+    },
+    "London Stock Exchange|LSE|lse|LSE link|LSE was":{
+      "transformer":"textNode",
+      "replace": "LSE:$(1||)"
+    },
+    "Hong Kong Stock Exchange|SEHK|SEHK link|SEHK was|Hkse|HKEX":{
+      "transformer":"textNode",
+      "replace": "SEHK:$(1||)"
     }
   },
   "commons":{

--- a/core/src/main/scala/org/dbpedia/extraction/config/dataparser/DateTimeParserConfig.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/config/dataparser/DateTimeParserConfig.scala
@@ -99,7 +99,9 @@ object DateTimeParserConfig
         "en" -> Map(
             "birth date and age"  -> Map ("year" -> "1", "month"-> "2", "day" -> "3"), //"Birth date and age"
             "birth date and age2" -> Map ("year" -> "1", "month"-> "2", "day" -> "3"), //"Birth date and age2"
+            "start date and age" -> Map ("year" -> "1", "month"-> "2", "day" -> "3"), //"Birth date and age2"
             "death date and age"  -> Map ("year" -> "1", "month"-> "2", "day" -> "3"), //"Death date and age"
+            "end date and age"  -> Map ("year" -> "1", "month"-> "2", "day" -> "3"), //"Death date and age"
             "birth date"          -> Map ("year" -> "1", "month"-> "2", "day" -> "3"), //"Birth date"
             "death date"          -> Map ("year" -> "1", "month"-> "2", "day" -> "3"), //"Death date"
             "bda"                 -> Map ("year" -> "1", "month"-> "2", "day" -> "3"), //"Bda"

--- a/core/src/main/scala/org/dbpedia/extraction/config/transform/TemplateTransformConfig.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/config/transform/TemplateTransformConfig.scala
@@ -1,14 +1,15 @@
 package org.dbpedia.extraction.config.transform
 
+import java.util.regex.Pattern
+
 import com.fasterxml.jackson.databind.node.ArrayNode
 import org.dbpedia.extraction.wikiparser._
-import org.dbpedia.extraction.util.{JsonConfig, Language}
+import org.dbpedia.extraction.util.{JsonConfig, Language, WikiUtil}
 import org.dbpedia.extraction.wikiparser.TextNode
-import org.dbpedia.iri.UriUtils
+import org.dbpedia.iri.{IRI, UriUtils}
 
 import scala.collection.mutable.ArrayBuffer
 import scala.util.{Failure, Success}
-
 import scala.collection.convert.decorateAsScala._
 import scala.language.postfixOps
 
@@ -41,20 +42,22 @@ object TemplateTransformConfig {
         val keys = if (trans._2.get("keys") != null) trans._2.get("keys").asInstanceOf[ArrayNode].iterator().asScala.toList.map(_.asText()) else null
         val contains = if (trans._2.get("whileList") != null) trans._2.get("whileList").asBoolean() else false
         val replace = if (trans._2.get("replace") != null) trans._2.get("replace").asText() else null
-        template -> (trans._2.get("transformer").asText() match {
+        val additionalSplitString = if (trans._2.get("additionalSplitString") != null) trans._2.get("additionalSplitString").asText() else null
+        val templateSynonyms = template.split("\\|").map(WikiUtil.cleanSpace).map(_.capitalize).distinct
+        templateSynonyms.map(templateSynonym => templateSynonym -> (trans._2.get("transformer").asText() match {
           case "externalLinkNode" => externalLinkNode _
           case "unwrapTemplates" => unwrapTemplates { p => if (contains) keys.contains(p.key) else !keys.contains(p.key) } _
-          case "extractChildren" => extractAndReplace(p => if (contains) keys.contains(p.key) else !keys.contains(p.key), replace) _
-          case "getLangText" => getLangText(p => if (contains) keys.contains(p.key) else !keys.contains(p.key), template.substring(5)) _
+          case "extractChildren" => extractAndReplace(p => if (contains) keys.contains(p.key) else !keys.contains(p.key), replace, additionalSplitString) _
+          case "getLangText" => getLangText(p => if (contains) keys.contains(p.key) else !keys.contains(p.key), templateSynonym.substring(5)) _
           case "textNode" => textNode {
             Option(replace) match {
               case Some(s) => s
               case None => ""
             }
           } _
-        })
+        }))
       }
-    }).flatten.toMap
+    }).flatten.flatten.toMap
   }).toMap
 
   private def extractTextFromPropertyNode(node: Option[PropertyNode], prefix : String = "", suffix : String = "") : String = {
@@ -70,6 +73,15 @@ object TemplateTransformConfig {
     }
   }
 
+  private def extractFirstExternalLinkNode(node: Option[PropertyNode]) : Option[ExternalLinkNode] = {
+    node
+      .flatMap(_.children
+        .filter(c => c.isInstanceOf[ExternalLinkNode])
+        .map(_.asInstanceOf[ExternalLinkNode])
+        .headOption
+      )
+  }
+
   // General functions
   private def textNode(text: String)(node: TemplateNode, lang:Language) : List[TextNode] = {
     val resolved = textNodeParamsRegex.replaceAllIn(text, repl =>
@@ -79,7 +91,7 @@ object TemplateTransformConfig {
 
   // General functions
   private def getLangText(filter: PropertyNode => Boolean, stringLang: String)(node: TemplateNode, lang:Language) : List[Node] = {
-    val children = extractChildren(filter, split = false)(node, lang)
+    val children = extractChildren(filter, split = false)(node, lang).flatten
     val text = children.headOption match{
       case Some(t) => t.toPlainText
       case None => ""
@@ -93,7 +105,7 @@ object TemplateTransformConfig {
   /**
    * Extracts all the children of the PropertyNode's in the given TemplateNode
    */
-  private def extractChildren(filter: PropertyNode => Boolean, split : Boolean = true)(node: TemplateNode, lang:Language) : List[Node] = {
+  private def extractChildren(filter: PropertyNode => Boolean, split : Boolean = true, additionalSplitString: String = null)(node: TemplateNode, lang:Language) : List[List[Node]] = {
     // We have to reverse because flatMap prepends to the final list
     // while we want to keep the original order
     val children : List[Node] = node.children.filter(filter)
@@ -108,16 +120,29 @@ object TemplateTransformConfig {
     if (split && splitChildren.nonEmpty) {
       splitChildren += TextNode(splitTxt, 0)
     }
-    splitChildren.map(x => {
-      if(x.children.nonEmpty)
-        x.children.head
+    val finalList = splitChildren.map(x => {
+      if (x.children.nonEmpty)
+        x.children.reverse
       else
-        x
+        List(x)
     }).toList
+
+    if (split && additionalSplitString != null) {
+     finalList.map(list => {
+      list.map(item => {
+        item match {
+          case textNode: TextNode => TextNode(textNode.text.replaceAll(Pattern.quote(additionalSplitString), splitTxt), textNode.line)
+          case _: Node => item
+        }
+      })
+     }).toList
+    } else {
+      finalList
+    }
   }
 
-  private def extractAndReplace(filter: PropertyNode => Boolean, replace: String = null)(node: TemplateNode, lang:Language) : List[Node] = {
-    val children = extractChildren(filter, replace == null)(node, lang)
+  private def extractAndReplace(filter: PropertyNode => Boolean, replace: String = null, additionalSplitString: String = null)(node: TemplateNode, lang:Language) : List[Node] = {
+    val children = extractChildren(filter, replace == null, additionalSplitString)(node, lang)
     if(replace != null) {
       //in this case we replace the position variables of a given replace-string with the children of the same number
       //also we frame the results in line breaks to create multiple triples
@@ -126,14 +151,14 @@ object TemplateTransformConfig {
           val ind = x.group(1).toInt - 1
           if (children.size > ind)
           // prefix  +  main replacement         +  postfix
-            x.group(2) + children(ind).toPlainText + x.group(3)
+            x.group(2) + children(ind).map(_.toPlainText).map(_.trim).mkString(" ") + x.group(3)
           else
             ""
         }))(node, lang) :::
         textNode("<br />")(node, lang)
     }
     else
-      children
+      children.flatten
   }
 
   private def identity(node: TemplateNode, lang:Language) : List[Node] = List(node)
@@ -149,8 +174,11 @@ object TemplateTransformConfig {
       // The first parameter is parsed to see if it takes the form of a complete URL.
       // If it doesn't start with a URI scheme (such as "http:", "https:", or "ftp:"),
       // an "http://" prefix will be prepended to the specified generated target URL of the link.
-      UriUtils.createURI(extractTextFromPropertyNode(node.property("1"))) match{
-        case Success(u) => {
+    val uri: Option[IRI] = extractFirstExternalLinkNode(node.property("1"))
+        .map(_.destination)
+
+    uri match{
+        case Some(u) => {
           val iri = if (u.getScheme == null)
             UriUtils.createURI("http://" + u.toString).get
           else u
@@ -164,7 +192,7 @@ object TemplateTransformConfig {
           )
         }
         // In case there are problems with the URL/URI just bail and return the original node
-        case Failure(f) => List(node)
+        case None => List(node)
       }
   }
 
@@ -180,7 +208,7 @@ object TemplateTransformConfig {
    *    - https://commons.wikimedia.org/wiki/Template:PD-art
    */
   private def unwrapTemplates(filter: PropertyNode => Boolean)(node: TemplateNode, lang:Language):List[Node] =
-      node :: toTemplateNodes(extractChildren(filter)(node, lang), lang) 
+      node :: toTemplateNodes(extractChildren(filter)(node, lang).flatten, lang)
 
   /**
    * Stores the Template namespace to avoid querying Namespace.template in a loop.
@@ -214,7 +242,9 @@ object TemplateTransformConfig {
 
      val mapKey = if (transformerMap.contains(lang)) lang else Language.English
 
-     val transformation = transformerMap(mapKey).get(node.title.decoded) match{
+    val stringToFunction = transformerMap(mapKey)
+    val maybeFunction = stringToFunction.get(node.title.decoded)
+    val transformation = maybeFunction match{
        case Some(trans) => trans
        case None =>
          //TODO record un-transformed template to have statistics about which template to cover!

--- a/core/src/main/scala/org/dbpedia/extraction/wikiparser/LinkNode.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/wikiparser/LinkNode.scala
@@ -32,7 +32,7 @@ extends LinkNode(children, line)
 case class ExternalLinkNode(destination : IRI, override val children : List[Node], override val line : Int, destinationNodes : List[Node] = List[Node]())
 extends LinkNode(children, line)
 {
-    def toWikiText = "[" + destination.toString + " " + children.map(_.toWikiText).mkString + "]"
+    def toWikiText = "[" + (destination.toString + " " + children.map(_.toWikiText).mkString).trim + "]"
 }
 
 /**

--- a/core/src/test/scala/org/dbpedia/extraction/wikiparser/TemplateTransformParser.scala
+++ b/core/src/test/scala/org/dbpedia/extraction/wikiparser/TemplateTransformParser.scala
@@ -1,0 +1,67 @@
+package org.dbpedia.extraction.wikiparser
+
+
+import org.dbpedia.extraction.mappings.Redirects
+import org.dbpedia.extraction.ontology.datatypes.UnitDatatype
+import org.dbpedia.extraction.wikiparser._
+import org.dbpedia.extraction.sources.MemorySource
+import org.dbpedia.extraction.util.Language
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
+import org.scalatest.matchers.{BeMatcher, MatchResult}
+
+import scala.math._
+import org.dbpedia.extraction.ontology.{Ontology, OntologyDatatypes}
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class TemplateTransformParser extends FlatSpec with Matchers
+{
+
+
+  it should "unwrap {{Unbulleted list | [[Arthur D. Levinson]] ([[Chairman]]) }}" in
+    {
+      parse("en", "{{Unbulleted list | [[Arthur D. Levinson]] ([[Chairman]])}}") should be (Some("<br />[[Arthur D. Levinson|Arthur D. Levinson]] ([[Chairman|Chairman]])<br />"))
+    }
+
+  it should "unwrap {{FlattList...}}" in
+    {
+      parse("en",
+        """{{Plainlist|
+          |*[[item1]]
+          |**[[Item 11]]
+          |*Item 1 string
+          |*[[item1]]
+          |*Item 3 string
+          |}}
+          |""".stripMargin.trim) should be (Some(
+        """
+          |<br /><br />[[Item1|item1]]
+          |<br /><br />[[Item 11|Item 11]]
+          |<br />Item 1 string
+          |<br />[[Item1|item1]]
+          |<br />Item 3 string
+          |<br />
+          |""".stripMargin.trim))
+
+    }
+
+
+  it should "unwrap {{URL|https://www.dji.com DJI.com}}" in
+    {
+      parse("en", "{{url|https://www.dji.com DJI.com}}") should be (Some("[https://www.dji.com]"))
+    }
+
+
+  private val wikiParser = WikiParser.getInstance()
+
+  private def parse(language : String, input : String, inconvertible : Boolean = false) : Option[String] =
+  {
+    val lang = Language(language)
+
+
+    val page = new WikiPage(WikiTitle.parse("TestPage", lang), input)
+    wikiParser(page).map(_.toWikiText)
+  }
+}

--- a/core/src/test/scala/org/dbpedia/extraction/wikiparser/TemplateTransformParserTest.scala
+++ b/core/src/test/scala/org/dbpedia/extraction/wikiparser/TemplateTransformParserTest.scala
@@ -16,7 +16,7 @@ import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
-class TemplateTransformParser extends FlatSpec with Matchers
+class TemplateTransformParserTest extends FlatSpec with Matchers
 {
 
 


### PR DESCRIPTION
This MR
 * fixes a bug in the template transformation code that was ignoring multiple values
 * adds extra splitting options for templates like `Flatlist` where users use `*` for separating values
 * adds a few more transformation templates in the configuration
 * adds tests for the new functionality