### PR TITLE
use more specific, child inconvertible datatype, not the parent one

### DIFF
--- a/core/src/main/scala/org/dbpedia/extraction/mappings/SimplePropertyMapping.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/mappings/SimplePropertyMapping.scala
@@ -243,9 +243,9 @@ extends PropertyMapping
         //Write generic property
         val stdValue = pr.unit match {
 
-          case Some(u) if u.isInstanceOf[InconvertibleUnitDatatype] => {
+          case Some(currentUnit) if currentUnit.isInstanceOf[InconvertibleUnitDatatype] => {
 
-            val quad = new Quad(language, DBpediaDatasets.OntologyPropertiesLiterals, subjectUri, ontologyProperty, pr.value.toString, sourceUri, unit)
+            val quad = new Quad(language, DBpediaDatasets.OntologyPropertiesLiterals, subjectUri, ontologyProperty, pr.value.toString, sourceUri, currentUnit)
             return Seq(quad)
           }
 


### PR DESCRIPTION
In inconvertible datatypes (currently only `Currency`), even though we were detecting the more specific datatype (e.g. `http://dbpedia.org/datatype/usDollar`) we were using the parent one (`http://dbpedia.org/datatype/Currency`).

e.g. instead of generating a triple like
```
<http://dbpedia.org/resource/Apple_Inc.> <http://dbpedia.org/ontology/revenue> "2.74515E11"^^<http://dbpedia.org/datatype/usDollar> .
```
we were creating the following which is missing needed information
```
<http://dbpedia.org/resource/Apple_Inc.> <http://dbpedia.org/ontology/revenue> "2.74515E11"^^<http://dbpedia.org/datatype/Currency> .
```
It has been like this for many years, most probably by mistake and this MR restores the intended behavior.

However this can be considered a breaking change for people who rely on the existing conventions