### PR TITLE
Update ArticleTemplatesExtractor.scala

### DIFF
--- a/core/src/main/scala/org/dbpedia/extraction/mappings/ArticleTemplatesExtractor.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/mappings/ArticleTemplatesExtractor.scala
@@ -22,9 +22,7 @@ class ArticleTemplatesExtractor(
     }
   ) extends PageNodeExtractor {
 
-  // FIXME: this uses the http://xx.dbpedia.org/property/ namespace, but the
-  // http://dbpedia.org/ontology/ namespace would probably make more sense.
-  private val usesTemplateProperty = context.language.propertyUri.append("wikiPageUsesTemplate")
+  private val usesTemplateProperty = context.ontology.classes("WikiPageUsesTemplate")
 
   override val datasets = Set(DBpediaDatasets.ArticleTemplates, DBpediaDatasets.ArticleTemplatesNested)
 


### PR DESCRIPTION
Correct "usesTemplateProperty" based on ontology not on  http://xx.dbpedia.org/property/ namespace