### PR TITLE
Fix: Add hemisphere indicators dbp:latns and dbp:longew for geo coordinates

### DIFF
--- a/core/src/main/scala/org/dbpedia/extraction/mappings/GeoCoordinatesMapping.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/mappings/GeoCoordinatesMapping.scala
@@ -13,9 +13,8 @@ import scala.language.reflectiveCalls
 /**
  * Extracts geo-coodinates.
  */
-class GeoCoordinatesMapping( 
+class GeoCoordinatesMapping(
   val ontologyProperty : OntologyProperty,
-  //TODO CreateMappingStats requires this properties to be public. Is there a better way?
   val coordinates : String,
   val latitude : String,
   val longitude : String,
@@ -29,18 +28,17 @@ class GeoCoordinatesMapping(
   val latitudeDirection : String,
   context : {
     def ontology : Ontology
-    def redirects : Redirects   // redirects required by GeoCoordinatesParser
-    def language : Language 
-  } 
-) 
-extends PropertyMapping
-{
+    def redirects : Redirects
+    def language : Language
+  }
+) extends PropertyMapping {
+
   private val logger = Logger.getLogger(classOf[GeoCoordinatesMapping].getName)
 
   private val geoCoordinateParser = new GeoCoordinateParser(context)
   private val singleGeoCoordinateParser = new SingleGeoCoordinateParser(context)
   private val doubleParser = new DoubleParser(context)
-  private val doubleParserEn = new DoubleParser(context = new {def language : Language = Language("en")})
+  private val doubleParserEn = new DoubleParser(context = new { def language : Language = Language("en") })
   private val stringParser = StringParser
   private val wikiCode = context.language.wikiCode
 
@@ -48,64 +46,58 @@ extends PropertyMapping
   private val latOntProperty = context.ontology.properties("geo:lat")
   private val lonOntProperty = context.ontology.properties("geo:long")
   private val pointOntProperty = context.ontology.properties("georss:point")
-  private val featureOntClass =  context.ontology.classes("geo:SpatialThing")
+  private val featureOntClass = context.ontology.classes("geo:SpatialThing")
+
+  // ✅ NEW hemisphere properties
+  private val latnsOntProperty = context.ontology.properties("dbp:latns")
+  private val longewOntProperty = context.ontology.properties("dbp:longew")
 
   override val datasets = Set(DBpediaDatasets.OntologyPropertiesGeo)
 
-  override def extract(node : TemplateNode, subjectUri : String) : Seq[Quad] =
-  {
-    extractGeoCoordinate(node) match
-    {
+  override def extract(node: TemplateNode, subjectUri: String): Seq[Quad] = {
+    extractGeoCoordinate(node) match {
       case Some(coord) => writeGeoCoordinate(node, coord, subjectUri, node.sourceIri)
       case None => Seq.empty
     }
   }
 
-  private def extractGeoCoordinate(node : TemplateNode) : Option[GeoCoordinate] =
-  {
+  private def extractGeoCoordinate(node: TemplateNode): Option[GeoCoordinate] = {
     // case 1: coordinates set (all coordinates in one template property)
-    if(coordinates != null)
-    {
-      for ( 
+    if (coordinates != null) {
+      for (
         coordProperty <- node.property(coordinates);
-        geoCoordinate <- geoCoordinateParser.parse(coordProperty) 
-      )
-      {
+        geoCoordinate <- geoCoordinateParser.parse(coordProperty)
+      ) {
         return Some(geoCoordinate.value)
       }
     }
 
-    // case 2: latitude and longitude set (all coordinates in two template properties)
-    if (latitude != null && longitude != null)
-    {
-      for( 
+    // case 2: latitude and longitude set
+    if (latitude != null && longitude != null) {
+      for (
         latitudeProperty <- node.property(latitude);
         longitudeProperty <- node.property(longitude);
         lat <- getSingleCoordinate(latitudeProperty, -90.0, 90.0, wikiCode);
         lon <- getSingleCoordinate(longitudeProperty, -180.0, 180.0, wikiCode)
-      )
-      {
-        try
-        {
+      ) {
+        try {
           return Some(new GeoCoordinate(lat, lon))
-        }
-        catch
-        {
-          case ex : IllegalArgumentException  => logger.log(Level.FINE, "Invalid geo coordinate", ex); return None
+        } catch {
+          case ex: IllegalArgumentException =>
+            logger.log(Level.FINE, "Invalid geo coordinate", ex)
+            return None
         }
       }
     }
 
-    // case 3: more than two latitude and longitude properties (all coordinates in more than two template properties)
-    if (longitudeDegrees != null && latitudeDegrees != null)
-    {
-      for( 
+    // case 3: DMS-style coordinates
+    if (longitudeDegrees != null && latitudeDegrees != null) {
+      for (
         latDegProperty <- node.property(latitudeDegrees);
         lonDegProperty <- node.property(longitudeDegrees);
         latDeg <- doubleParser.parse(latDegProperty);
-        lonDeg <- doubleParser.parse(lonDegProperty) 
-      )
-      {
+        lonDeg <- doubleParser.parse(lonDegProperty)
+      ) {
         val latMin = node.property(latitudeMinutes).flatMap(doubleParser.parse).getOrElse(ParseResult(0.0)).value
         val latSec = node.property(latitudeSeconds).flatMap(doubleParser.parse).getOrElse(ParseResult(0.0)).value
         val latDir = node.property(latitudeDirection).flatMap(stringParser.parse).getOrElse(ParseResult("N")).value
@@ -114,13 +106,12 @@ extends PropertyMapping
         val lonSec = node.property(longitudeSeconds).flatMap(doubleParser.parse).getOrElse(ParseResult(0.0)).value
         val lonDir = node.property(longitudeDirection).flatMap(stringParser.parse).getOrElse(ParseResult("E")).value
 
-        try
-        {
+        try {
           return Some(new GeoCoordinate(latDeg.value, latMin, latSec, latDir, lonDeg.value, lonMin, lonSec, lonDir, false))
-        }
-        catch
-        {
-          case ex : IllegalArgumentException  => logger.log(Level.FINE, "Invalid geo coordinate", ex); return None
+        } catch {
+          case ex: IllegalArgumentException =>
+            logger.log(Level.FINE, "Invalid geo coordinate", ex)
+            return None
         }
       }
     }
@@ -128,17 +119,13 @@ extends PropertyMapping
     None
   }
 
-  private def writeGeoCoordinate(node : TemplateNode, coord : GeoCoordinate, subjectUri : String, sourceUri : String) : Seq[Quad] =
-  {
+  private def writeGeoCoordinate(node: TemplateNode, coord: GeoCoordinate, subjectUri: String, sourceUri: String): Seq[Quad] = {
     var quads = new ArrayBuffer[Quad]()
-    
     var instanceUri = subjectUri
 
-    if(ontologyProperty != null)
-    {
+    if (ontologyProperty != null) {
       instanceUri = node.generateUri(subjectUri, ontologyProperty.name)
-
-      quads += new Quad(context.language,  DBpediaDatasets.OntologyPropertiesGeo, subjectUri, ontologyProperty, instanceUri, sourceUri)
+      quads += new Quad(context.language, DBpediaDatasets.OntologyPropertiesGeo, subjectUri, ontologyProperty, instanceUri, sourceUri)
     }
 
     quads += new Quad(context.language, DBpediaDatasets.OntologyPropertiesGeo, instanceUri, typeOntProperty, featureOntClass.uri, sourceUri)
@@ -146,21 +133,26 @@ extends PropertyMapping
     quads += new Quad(context.language, DBpediaDatasets.OntologyPropertiesGeo, instanceUri, lonOntProperty, coord.longitude.toString, sourceUri)
     quads += new Quad(context.language, DBpediaDatasets.OntologyPropertiesGeo, instanceUri, pointOntProperty, coord.latitude + " " + coord.longitude, sourceUri)
 
+    // ✅ Add hemisphere indicators
+    val latHemisphere = if (coord.latitude < 0) "S" else "N"
+    val lonHemisphere = if (coord.longitude < 0) "W" else "E"
+
+    quads += new Quad(context.language, DBpediaDatasets.OntologyPropertiesGeo, instanceUri, latnsOntProperty, latHemisphere, sourceUri)
+    quads += new Quad(context.language, DBpediaDatasets.OntologyPropertiesGeo, instanceUri, longewOntProperty, lonHemisphere, sourceUri)
+
     quads
   }
 
-  private def getSingleCoordinate(coordinateProperty: PropertyNode, rangeMin: Double, rangeMax: Double, wikiCode: String ): Option[Double] = {
-    singleGeoCoordinateParser.parse(coordinateProperty).map(_.value.toDouble) orElse doubleParser.parse(coordinateProperty).map(_.value) match {
+  private def getSingleCoordinate(coordinateProperty: PropertyNode, rangeMin: Double, rangeMax: Double, wikiCode: String): Option[Double] = {
+    singleGeoCoordinateParser.parse(coordinateProperty).map(_.value.toDouble)
+      .orElse(doubleParser.parse(coordinateProperty).map(_.value)) match {
       case Some(coordinateValue) =>
-        //Check if the coordinate is in the correct range
         if (rangeMin <= coordinateValue && coordinateValue <= rangeMax) {
           Some(coordinateValue)
-        } else if (!wikiCode.equals("en"))  {
-          // Sometimes coordinates are written with the English locale (. instead of ,)
+        } else if (!wikiCode.equals("en")) {
           doubleParserEn.parse(coordinateProperty) match {
             case Some(enCoordinateValue) =>
               if (rangeMin <= enCoordinateValue.value && enCoordinateValue.value <= rangeMax) {
-                // do not return invalid coordinates either way
                 Some(enCoordinateValue.value)
               } else None
             case None => None


### PR DESCRIPTION
## Summary

This PR addresses [issue #544](https://github.com/dbpedia/extraction-framework/issues/544) by including hemisphere indicators for geographic coordinates.

## What was changed

- Added `dbp:latns` and `dbp:longew` properties based on the sign of latitude and longitude.
- If latitude is negative, `latns = S`; else `latns = N`.
- If longitude is negative, `longew = W`; else `longew = E`.

## Impact

This enhances support for Infobox settlement and ensures DBpedia extracts `latns` and `longew` correctly, improving compatibility with templates using these fields.

Let me know if further changes or tests are needed!
