### PR TITLE
Change isni relation to owl:sameAs

### DIFF
--- a/core/src/main/resources/wikidatar2r.json
+++ b/core/src/main/resources/wikidatar2r.json
@@ -543,7 +543,7 @@
     ],
     "P213": [
         {
-            "rdfs:seeAlso": "http://isni.org/isni/$1"
+            "owl:sameAs": "https://isni.org/isni/$1"
         }
     ],
     "P220": [


### PR DESCRIPTION
The relation for ISNI is a owl:sameAs realtion. In addition it should be a https URI.