### PR TITLE
changed the pom.xml file location to current directory

### DIFF
--- a/clean-install-run
+++ b/clean-install-run
@@ -10,4 +10,4 @@
 
 # if we're not on a terminal, use batch mode to avoid ugly log files
 [ ! -t 1 ] && BATCH="-B"
-mvn $BATCH -f ../pom.xml clean && . ../install-run "$@"
+mvn $BATCH -f ./pom.xml clean && . ../install-run "$@"


### PR DESCRIPTION
In `clean-install-run`, the location of the `pom.xml` was pointed to a prior directory instead of the `extraction-framework` directory.