### PR TITLE
Patch 403 error

### DIFF
--- a/core/src/main/scala/org/dbpedia/extraction/util/Language.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/util/Language.scala
@@ -9,6 +9,9 @@ import org.dbpedia.extraction.ontology.{DBpediaNamespace, RdfNamespace}
 import scala.collection.mutable.HashMap
 import scala.io.{Codec, Source}
 
+import org.apache.http.impl.client.HttpClients
+import org.apache.http.client.methods.HttpGet
+
 /**
  * Represents a MediaWiki instance and the language used on it. Initially, this class was
  * only used for xx.wikipedia.org instances, but now we also use it for mappings.dbpedia.org

--- a/core/src/main/scala/org/dbpedia/extraction/util/Language.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/util/Language.scala
@@ -100,7 +100,7 @@ object Language extends (String => Language)
 
     val customUserAgentEnabled : Boolean =
       try{
-        System.getProperty("extract.wikiapi.customUserAgent.enabled", "false")
+        System.getProperty("extract.wikiapi.customUserAgent.enabled", "false").toBoolean
       }
       catch{
         case _: Exception => false

--- a/core/src/main/scala/org/dbpedia/extraction/util/Language.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/util/Language.scala
@@ -103,8 +103,9 @@ object Language extends (String => Language)
         System.getProperty("extract.wikiapi.customUserAgent.enabled", "false").toBoolean
       }
       catch{
-        case _: Exception => false
-        logger.log(Level.WARNING, "Could not read system property extract.wikiapi.customUserAgent.enabled, using default value false")
+        case _: Exception => 
+          logger.log(Level.WARNING, "Could not read system property extract.wikiapi.customUserAgent.enabled, using default value false")
+          false
       }
     
     val customUserAgentText: String =
@@ -113,8 +114,8 @@ object Language extends (String => Language)
       }
       catch { 
         case _: Exception =>
-          "DBpedia-Extraction-Framework/1.0 (https://github.com/dbpedia/extraction-framework; dbpedia@infai.org)"
           logger.log(Level.WARNING, "Could not read system property extract.wikiapi.customUserAgent.text, using default value DBpedia-Extraction-Framework/1.0 (https://github.com/dbpedia/extraction-framework; dbpedia@infai.org)")
+          "DBpedia-Extraction-Framework/1.0 (https://github.com/dbpedia/extraction-framework; dbpedia@infai.org)"
       }
 
     // Apply User-Agent conditionally

--- a/core/src/main/scala/org/dbpedia/extraction/util/Language.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/util/Language.scala
@@ -98,9 +98,9 @@ object Language extends (String => Language)
     val request = new HttpGet(wikipediaLanguageUrl)
     //request.setHeader("User-Agent", "curl/8.6.0") 
 
-    val customUserAgentEnabled := Boolean =
+    val customUserAgentEnabled : Boolean =
       try{
-        System.getProperty("extract.wikiapi.customUserAgent.enabled", false)
+        System.getProperty("extract.wikiapi.customUserAgent.enabled", "false")
       }
       catch{
         case _: Exception => false

--- a/core/src/main/scala/org/dbpedia/extraction/util/Language.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/util/Language.scala
@@ -91,8 +91,13 @@ object Language extends (String => Language)
     }
 
     val languages = new HashMap[String,Language]
-    val source = Source.fromURL(wikipediaLanguageUrl)(Codec.UTF8)
-    val wikiLanguageCodes = try source.getLines.toList finally source.close
+    val client = HttpClients.createDefault()
+    val request = new HttpGet(wikipediaLanguageUrl)
+    request.setHeader("User-Agent", "curl/8.6.0") 
+
+    val response = client.execute(request)
+    val stream = response.getEntity.getContent
+    val wikiLanguageCodes = try Source.fromInputStream(stream).getLines().toList finally{ stream.close; client.close() }
 
     val specialLangs: JsonConfig = new JsonConfig(this.getClass.getClassLoader.getResource("addonlangs.json"))
 


### PR DESCRIPTION
Created a User Agent behaviour in the `Language.scala` which bypasses the 403 error when retrieving the langlist file from `https://noc.wikimedia.org/conf/langlist`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None.
- Bug Fixes
  - Improved reliability and reduced intermittent failures/timeouts when fetching the list of supported languages.
- Refactor
  - Language list retrieval reworked to use an explicit HTTP fetch with stronger resource management and optional custom User-Agent handling for better compatibility and error resilience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->