### PR TITLE
feat: add multi-extractor support with improved UI

### DIFF
--- a/server/src/main/scala/org/dbpedia/extraction/server/resources/Extraction.scala
+++ b/server/src/main/scala/org/dbpedia/extraction/server/resources/Extraction.scala
@@ -3,7 +3,7 @@ package org.dbpedia.extraction.server.resources
 import java.net.{URI, URL}
 import java.io.IOException
 
-import org.dbpedia.extraction.destinations.formatters.{RDFJSONFormatter, TerseFormatter}
+import org.dbpedia.extraction.destinations.formatters.{Formatter, RDFJSONFormatter, TerseFormatter}
 import org.dbpedia.extraction.util.Language
 import javax.ws.rs._
 import javax.ws.rs.core.{Context, HttpHeaders, MediaType, Response}
@@ -13,10 +13,14 @@ import scala.xml.Elem
 import scala.io.{Codec, Source}
 import org.dbpedia.extraction.server.Server
 import org.dbpedia.extraction.wikiparser.WikiTitle
-import org.dbpedia.extraction.destinations.{DeduplicatingDestination, WriterDestination}
+import org.dbpedia.extraction.destinations.{DeduplicatingDestination, Destination, WriterDestination}
+import org.dbpedia.extraction.server.resources.Extraction.getClass
 import org.dbpedia.extraction.sources.{Source, WikiSource, XMLSource}
 import stylesheets.TriX
+import org.dbpedia.extraction.transform.Quad
+
 import java.io.StringWriter
+import scala.collection.mutable.ArrayBuffer
 
 object Extraction
 {
@@ -65,15 +69,14 @@ val extractors = Server.getInstance().getAvailableExtractorNames(language)
                   <option value="n-quads">N-Quads</option>
                   <option value="rdf-json">RDF/JSON</option>
                 </select><br/>
-                <select name="extractors">
-                <option value="mappings">Mappings Only</option>
-                <option value="custom">All Enabled Extractors </option>{
-                extractors.map(extractor =>
-                  <option value={extractor}>
-                    {extractor}
-                  </option>
-                )}
-                </select><br/>
+              Select Extractors:<br/>
+              <label for="mappings">Mappings Only <input type="checkbox" name="extractors" value="mappings" id="mappings"/></label><br/>
+              <label for="custom">All Enabled Extractors <input type="checkbox" name="extractors" value="custom" id="custom"/></label><br/>
+              {extractors.map(extractor =>
+                <span>
+                  <label for={extractor}>{extractor} <input type="checkbox" name="extractors" value={extractor} id={extractor}/></label><br/>
+                </span>
+              )}
               <input type="submit" value="Extract" />
             </form>
             </div>
@@ -129,39 +132,26 @@ val extractors = Server.getInstance().getAvailableExtractorNames(language)
     }
   }
 
-    /**
-     * Extracts a MediaWiki article
-     */
-    @GET
-    @Path("extract")
-  def extract(@QueryParam("title") title: String, @QueryParam("revid") @DefaultValue("-1") revid: Long, @QueryParam("format") format: String, @QueryParam("extractors") extractors: String, @QueryParam("xmlUrl") xmlUrl: String, @Context headers: HttpHeaders): Response = {
-    import scala.collection.JavaConverters._
-    if (title == null && revid < 0 && (xmlUrl == null || xmlUrl.isEmpty)) throw new WebApplicationException(new Exception("title, revid, or xmlUrl must be given"), Response.Status.BAD_REQUEST)
+  /**
+   * Custom destination that collects quads in memory
+   */
+  private class QuadCollectorDestination extends Destination {
+    val quads = new ArrayBuffer[Quad]()
 
-    val requestedTypesList = headers.getAcceptableMediaTypes.asScala.map(_.toString).toList
-    val browserMode = requestedTypesList.isEmpty || requestedTypesList.contains("text/html") || requestedTypesList.contains("application/xhtml+xml") || requestedTypesList.contains("text/plain")
+    override def open(): Unit = {}
 
-        val writer = new StringWriter
+    override def write(graph: Traversable[Quad]): Unit = {
+      quads ++= graph
+    }
 
-        var finalFormat = format
-        val acceptContentBest = requestedTypesList.map(selectFormatByContentType).headOption.getOrElse("unknownAcceptFormat")
+    override def close(): Unit = {}
+  }
 
-        if (!acceptContentBest.equalsIgnoreCase("unknownAcceptFormat") && !browserMode)
-          finalFormat = acceptContentBest
-        val contentType = if (browserMode) selectInBrowserContentType(finalFormat) else selectContentType(finalFormat)
-
-        val formatter = finalFormat match
-        {
-            case "turtle-triples" => new TerseFormatter(false, true)
-            case "turtle-quads" => new TerseFormatter(true, true)
-            case "n-triples" => new TerseFormatter(false, false)
-            case "n-quads" => new TerseFormatter(true, false)
-            case "rdf-json" => new RDFJSONFormatter()
-            case _ => TriX.writeHeader(writer, 2)
-        }
-    val extractorName = Option(extractors).getOrElse("mappings")
-
-        val source = if (xmlUrl != null && !xmlUrl.isEmpty) {
+  /**
+   * Helper method to create source from xmlUrl or fallback to WikiSource
+   */
+  private def createSource(xmlUrl: String, revid: Long, title: String): org.dbpedia.extraction.sources.Source = {
+    if (xmlUrl != null && !xmlUrl.isEmpty) {
           // Fetch XML from custom URL with user agent
           import org.apache.http.impl.client.HttpClients
           import org.apache.http.client.methods.HttpGet
@@ -198,21 +188,133 @@ val extractors = Server.getInstance().getAvailableExtractorNames(language)
           if (revid >= 0) WikiSource.fromRevisionIDs(List(revid), new URL(language.apiUri), language)
           else WikiSource.fromTitles(List(WikiTitle.parse(title, language)), new URL(language.apiUri), language)
         }
+  }
 
-        // See https://github.com/dbpedia/extraction-framework/issues/144
-        // We should mimic the extraction framework behavior
-        val destination = new DeduplicatingDestination(new WriterDestination(() => writer, formatter))
+    /**
+     * Extracts a MediaWiki article
+     */
+    @GET
+    @Path("extract")
+def extract(@QueryParam("title") title: String, @QueryParam("revid") @DefaultValue("-1") revid: Long, @QueryParam("format") format: String, @QueryParam("extractors") extractors: String, @QueryParam("xmlUrl") xmlUrl: String, @Context headers: HttpHeaders): Response = {    import scala.collection.JavaConverters._
+    import java.io.IOException
+
+    if (title == null && revid < 0 && (xmlUrl == null || xmlUrl.isEmpty))
+      throw new WebApplicationException(new Exception("title, revid, or xmlUrl must be given"), Response.Status.BAD_REQUEST)
+
+    val requestedTypesList = headers.getAcceptableMediaTypes.asScala.map(_.toString).toList
+    val browserMode = requestedTypesList.isEmpty || requestedTypesList.contains("text/html") || requestedTypesList.contains("application/xhtml+xml") || requestedTypesList.contains("text/plain")
+
+    var finalFormat = format
+    val acceptContentBest = requestedTypesList.map(selectFormatByContentType).headOption.getOrElse("unknownAcceptFormat")
+
+    if (!acceptContentBest.equalsIgnoreCase("unknownAcceptFormat") && !browserMode)
+      finalFormat = acceptContentBest
+    val contentType = if (browserMode) selectInBrowserContentType(finalFormat) else selectContentType(finalFormat)
+
+    // Keep as string, will be parsed later if it contains commas
+val extractorName = Option(extractors).getOrElse("mappings")
 
     try {
       extractorName match {
         case "mappings" =>
+          val writer = new StringWriter
+          val formatter = createFormatter(finalFormat, writer)
+          val destination = new DeduplicatingDestination(new WriterDestination(() => writer, formatter))
+
+          val source = createSource(xmlUrl, revid, title)
+
           Server.getInstance().extractor.extract(source, destination, language, false)
 
+          Response.ok(writer.toString)
+            .header(HttpHeaders.CONTENT_TYPE, contentType + "; charset=UTF-8")
+            .build()
+
         case "custom" =>
+          val writer = new StringWriter
+          val formatter = createFormatter(finalFormat, writer)
+          val destination = new DeduplicatingDestination(new WriterDestination(() => writer, formatter))
+
+          val source = createSource(xmlUrl, revid, title)
+
           Server.getInstance().extractor.extract(source, destination, language, true)
 
+          Response.ok(writer.toString)
+            .header(HttpHeaders.CONTENT_TYPE, contentType + "; charset=UTF-8")
+            .build()
+
+        case specificExtractor if specificExtractor.contains(",") =>
+          // Handle comma-separated list of extractors
+          val extractorNames = specificExtractor.split(",").map(_.trim).filter(_.nonEmpty)
+
+          logger.info(s"Processing ${extractorNames.length} extractors: ${extractorNames.mkString(", ")}")
+
+          // Accumulate errors instead of swallowing them
+          val errors = new ArrayBuffer[String]()
+          val collector = new QuadCollectorDestination()
+
+          for (name <- extractorNames) {
+            try {
+              logger.info(s"Processing extractor: $name")
+
+              val freshSource = createSource(xmlUrl, revid, title)
+
+              Server.getInstance().extractWithSpecificExtractor(freshSource, collector, language, name)
+              logger.info(s"Completed extractor: $name")
+            } catch {
+              case e: IllegalArgumentException =>
+                val errorMsg = s"Extractor '$name' not found"
+                logger.warning(s"$errorMsg: ${e.getMessage}")
+                errors += errorMsg
+              case e: Exception =>
+                val errorMsg = s"Failed to extract with '$name': ${e.getMessage}"
+                logger.severe(errorMsg)
+                e.printStackTrace()
+                errors += errorMsg
+            }
+          }
+
+          // If any errors occurred, fail the request with detailed error message
+          if (errors.nonEmpty) {
+            val errorMessage = if (errors.size == 1) {
+              errors.head
+            } else {
+              s"Multiple extractor errors:\n${errors.mkString("\n")}"
+            }
+
+            // Determine appropriate status code
+            val statusCode = if (errors.exists(_.contains("not found"))) {
+              Response.Status.BAD_REQUEST // 400 for invalid extractor names
+            } else {
+              Response.Status.INTERNAL_SERVER_ERROR // 500 for processing failures
+            }
+
+            throw new WebApplicationException(new Exception(errorMessage), statusCode)
+          }
+
+          val writer = new StringWriter
+          val formatter = createFormatter(finalFormat, writer)
+          val finalDestination = new DeduplicatingDestination(new WriterDestination(() => writer, formatter))
+
+          finalDestination.open()
+          finalDestination.write(collector.quads)
+          finalDestination.close()
+
+          Response.ok(writer.toString)
+            .header(HttpHeaders.CONTENT_TYPE, contentType + "; charset=UTF-8")
+            .build()
+
         case specificExtractor =>
+          val writer = new StringWriter
+          val formatter = createFormatter(finalFormat, writer)
+          val destination = new DeduplicatingDestination(new WriterDestination(() => writer, formatter))
+
+          val source = createSource(xmlUrl, revid, title)
+
           Server.getInstance().extractWithSpecificExtractor(source, destination, language, specificExtractor)
+
+          Response.ok(writer.toString)
+            .header(HttpHeaders.CONTENT_TYPE, contentType + "; charset=UTF-8")
+            .build()
       }
     } catch {
       case e: IllegalArgumentException =>
@@ -231,13 +333,22 @@ val extractors = Server.getInstance().getAvailableExtractorNames(language)
         Extraction.logger.severe("Full stack trace:\n" + sw.toString())
         throw new WebApplicationException(new Exception(errorMsg, e), 500)
     }
+  }
 
-    val result = writer.toString
-
-    Response.ok(result)
-          .header(HttpHeaders.CONTENT_TYPE, contentType +"; charset=UTF-8" )
-          .build()
-    }
+/**
+ * Helper method to create formatter based on format type
+ */
+private def createFormatter(finalFormat: String, writer: StringWriter): Formatter = {
+  finalFormat match {
+    case "turtle-triples" => new TerseFormatter(false, true)
+    case "turtle-quads" => new TerseFormatter(true, true)
+    case "n-triples" => new TerseFormatter(false, false)
+    case "n-quads" => new TerseFormatter(true, false)
+    case "rdf-json" => new RDFJSONFormatter()
+    case "trix" => TriX.writeHeader(writer, 2) // Returns TriXFormatter
+    case _ => TriX.writeHeader(writer, 2) // Default to TriX
+  }
+}
 
   // map
   private def selectFormatByContentType(format: String): String = {
@@ -292,49 +403,105 @@ val extractors = Server.getInstance().getAvailableExtractorNames(language)
         val requestedTypesList = headers.getAcceptableMediaTypes.asScala.map(_.toString).toList
         val browserMode = requestedTypesList.isEmpty || requestedTypesList.contains("text/html") || requestedTypesList.contains("application/xhtml+xml") || requestedTypesList.contains("text/plain")
 
-        val writer = new StringWriter
-
         val acceptContentBest = requestedTypesList.map(selectFormatByContentType).headOption.getOrElse("unknownAcceptFormat")
         val finalFormat = if (!acceptContentBest.equalsIgnoreCase("unknownAcceptFormat") && !browserMode) acceptContentBest else "trix"
         val contentType = if (browserMode) selectInBrowserContentType(finalFormat) else selectContentType(finalFormat)
-
-        val formatter = finalFormat match
-        {
-            case "turtle-triples" => new TerseFormatter(false, true)
-            case "turtle-quads" => new TerseFormatter(true, true)
-            case "n-triples" => new TerseFormatter(false, false)
-            case "n-quads" => new TerseFormatter(true, false)
-            case "rdf-json" => new RDFJSONFormatter()
-            case _ => TriX.writeHeader(writer, 2)
-        }
-
-        val source = XMLSource.fromXML(xml, language)
-        val destination = new WriterDestination(() => writer, formatter)
 
         val extractorName = Option(extractors).getOrElse("mappings")
 
         extractorName match {
           case "mappings" =>
+            val writer = new StringWriter
+            val formatter = createFormatter(finalFormat, writer)
+            val destination = new DeduplicatingDestination(new WriterDestination(() => writer, formatter))
+            val source = XMLSource.fromXML(xml, language)
             Server.getInstance().extractor.extract(source, destination, language, false)
 
+            Response.ok(writer.toString)
+              .header(HttpHeaders.CONTENT_TYPE, contentType + "; charset=UTF-8")
+              .build()
+
           case "custom" =>
+            val writer = new StringWriter
+            val formatter = createFormatter(finalFormat, writer)
+            val destination = new DeduplicatingDestination(new WriterDestination(() => writer, formatter))
+            val source = XMLSource.fromXML(xml, language)
             Server.getInstance().extractor.extract(source, destination, language, true)
+
+            Response.ok(writer.toString)
+              .header(HttpHeaders.CONTENT_TYPE, contentType + "; charset=UTF-8")
+              .build()
 
           case specificExtractor if specificExtractor.contains(",") =>
             // Handle comma-separated list of extractors
             val extractorNames = specificExtractor.split(",").map(_.trim).filter(_.nonEmpty)
+
+            logger.info(s"POST: Processing ${extractorNames.length} extractors: ${extractorNames.mkString(", ")}")
+
+            // Accumulate errors instead of swallowing them
+            val errors = new ArrayBuffer[String]()
+            val collector = new QuadCollectorDestination()
+
             extractorNames.foreach { name =>
-              Server.getInstance().extractWithSpecificExtractor(source, destination, language, name)
+              try {
+                logger.info(s"POST: Processing extractor: $name")
+                val freshSource = XMLSource.fromXML(xml, language)
+                Server.getInstance().extractWithSpecificExtractor(freshSource, collector, language, name)
+                logger.info(s"POST: Completed extractor: $name")
+              } catch {
+                case e: IllegalArgumentException =>
+                  val errorMsg = s"Extractor '$name' not found"
+                  logger.warning(s"POST: $errorMsg: ${e.getMessage}")
+                  errors += errorMsg
+                case e: Exception =>
+                  val errorMsg = s"Failed to extract with '$name': ${e.getMessage}"
+                  logger.severe(s"POST: $errorMsg")
+                  e.printStackTrace()
+                  errors += errorMsg
+              }
             }
 
-          case specificExtractor =>
-            Server.getInstance().extractWithSpecificExtractor(source, destination, language, specificExtractor)
-        }
+            // If any errors occurred, fail the request with detailed error message
+            if (errors.nonEmpty) {
+              val errorMessage = if (errors.size == 1) {
+                errors.head
+              } else {
+                s"Multiple extractor errors:\n${errors.mkString("\n")}"
+              }
 
-        val result = writer.toString
+              // Determine appropriate status code
+              val statusCode = if (errors.exists(_.contains("not found"))) {
+                Response.Status.BAD_REQUEST // 400 for invalid extractor names
+              } else {
+                Response.Status.INTERNAL_SERVER_ERROR // 500 for processing failures
+              }
 
-        Response.ok(result)
-              .header(HttpHeaders.CONTENT_TYPE, contentType +"; charset=UTF-8" )
+              throw new WebApplicationException(new Exception(errorMessage), statusCode)
+            }
+
+            // Write all collected quads at once
+            val writer = new StringWriter
+            val formatter = createFormatter(finalFormat, writer)
+            val finalDestination = new DeduplicatingDestination(new WriterDestination(() => writer, formatter))
+
+            finalDestination.open()
+            finalDestination.write(collector.quads)
+            finalDestination.close()
+
+            Response.ok(writer.toString)
+              .header(HttpHeaders.CONTENT_TYPE, contentType + "; charset=UTF-8")
               .build()
+
+          case specificExtractor =>
+            val writer = new StringWriter
+            val formatter = createFormatter(finalFormat, writer)
+            val destination = new DeduplicatingDestination(new WriterDestination(() => writer, formatter))
+            val source = XMLSource.fromXML(xml, language)
+            Server.getInstance().extractWithSpecificExtractor(source, destination, language, specificExtractor)
+
+            Response.ok(writer.toString)
+              .header(HttpHeaders.CONTENT_TYPE, contentType + "; charset=UTF-8")
+              .build()
+        }
     }
 }


### PR DESCRIPTION
**Summary**
Adds multi-extractor support with an improved checkbox-based UI for the WikiApi.
Enables running multiple extractors simultaneously, improves error handling, and refactors redundant logic.

**Key Changes**
Replaced dropdown with checkbox-based extractor selection
Updated API to accept multiple extractors
Implemented error reporting and result aggregation
Applied logic to both GET and POST endpoints

**Testing**
Tested locally via curl and UI; verified correct results and error handling for valid/invalid extractors.
_Test multi-extractor_
curl "http://localhost:9999/server/extraction/en/extract?title=Berlin&extractors=LabelExtractor,PageIdExtractor"