### PR TITLE
fix: IndexOutOfBoundsException when processing redirects with invalid …

### DIFF
--- a/server/src/main/scala/org/dbpedia/extraction/server/stats/MappingStatsHolder.scala
+++ b/server/src/main/scala/org/dbpedia/extraction/server/stats/MappingStatsHolder.scala
@@ -51,8 +51,19 @@ object MappingStatsHolder {
         }
       }
       
-      val redirects = wikiStats.redirects.filterKeys(title => templateMappings.contains(title.substring(templateNamespace.length))).map(_.swap)
-      
+       // Simple fix (commented out): just filter out invalid redirects silently
+      // val redirects = wikiStats.redirects.filterKeys(title => title.startsWith(templateNamespace) && templateMappings.contains(title.substring(templateNamespace.length))).map(_.swap)
+
+      // Better fix: filter out invalid redirects with warning logging
+      val redirects = wikiStats.redirects.filter { case (title, _) =>
+        if (title.startsWith(templateNamespace)) {
+          true
+        } else {
+          logger.warning(language.wikiCode + " redirect '" + title + "' does not start with '" + templateNamespace + "'")
+          false
+        }
+      }.filterKeys(title => templateMappings.contains(title.substring(templateNamespace.length))).map(_.swap)
+    
       val holder = new MappingStatsHolder(mappings, statistics.toList, redirects, ignoreList)
       
       logger.info("Updated "+language.wikiCode+" mapped statistics in "+prettyMillis(System.currentTimeMillis - millis))


### PR DESCRIPTION
…namespace

Problem: substring() was being called on redirect titles that didn't start with the expected template namespace, causing IndexOutOfBoundsException.

Solution: Added filter to validate titles start with templateNamespace before substring operation. Invalid redirects are now logged as warnings and excluded from processing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved redirect mapping validation and logging for better system diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->