### PR TITLE
GenderExtractor: Replace hardcoded URI strings with ontology lookups

### DIFF
--- a/core/src/main/scala/org/dbpedia/extraction/mappings/GenderExtractor.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/mappings/GenderExtractor.scala
@@ -51,11 +51,12 @@ class GenderExtractor(
       super.extract(node, subjectUri)
 
     /** Check if entity is a dbo:Person */
-    val isPerson: Boolean =
-      mappingGraph.exists(q =>
-        q.predicate == typeProperty &&
-        q.value == personClass
-      )
+   val isPerson: Boolean =
+  mappingGraph.exists(q =>
+    q.predicate.uri == typeProperty.uri &&
+    q.value.uri == personClass.uri
+  )
+
 
     if (!isPerson) return Seq.empty
 


### PR DESCRIPTION
Summary:
This PR refactors GenderExtractor to remove hardcoded RDF/FOAF URI strings and replace them with ontology lookups provided by the DBpedia extraction framework, aligning with the extraction framework design.

Changes:

Replaced hardcoded URIs with ontology-based lookups:

context.ontology.properties("foaf:gender")
context.ontology.properties("rdf:type")
context.ontology.classes("Person")


Fixed isPerson comparison to check URIs:

val isPerson: Boolean =
  mappingGraph.exists(q =>
    q.predicate.uri == typeProperty.uri &&
    q.value.uri == personClass.uri
  )


No other files or unrelated commits are included — PR is focused and clean.


Issue:
Fixes #810

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced gender extraction logic with improved ontology-driven lookups and language-based context handling for more reliable and robust extraction results.
  * Optimized extraction flow with threshold-based logic to better handle edge cases and improve accuracy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->