### PR TITLE
Fix template text extraction for Lang, Native name, and Nihongo templates

### DIFF
--- a/core/src/main/resources/templatetransform.json
+++ b/core/src/main/resources/templatetransform.json
@@ -44,6 +44,18 @@
       "transformer":"textNode",
       "replace": "$(2||)"
     },
+    "Langx":{
+      "transformer":"textNode",
+      "replace": "$(2||)"
+    },
+    "Script":{
+      "transformer":"textNode",
+      "replace": "$(2||)"
+    },
+    "Transliteration":{
+      "transformer":"textNode",
+      "replace": "$(2||)"
+    },
     "Marriage":{
       "transformer":"extractChildren",
       "keys": ["end", "()"],

--- a/core/src/test/scala/org/dbpedia/extraction/wikiparser/TemplateTransformParserTest.scala
+++ b/core/src/test/scala/org/dbpedia/extraction/wikiparser/TemplateTransformParserTest.scala
@@ -73,6 +73,21 @@ class TemplateTransformParserTest extends FlatSpec with Matchers
       parse("en", "{{Nihongo|Tokyo|東京|Tōkyō}}") should be (Some("東京"))
     }
 
+  it should "extract text from {{Script|Arab|أبجدية عربية}}" in
+    {
+      parse("en", "{{Script|Arab|أبجدية عربية}}") should be (Some("أبجدية عربية"))
+    }
+
+  it should "extract text from {{Transliteration|ru|Moskva}}" in
+    {
+      parse("en", "{{Transliteration|ru|Moskva}}") should be (Some("Moskva"))
+    }
+
+  it should "extract text from {{Langx|ja|東京}}" in
+    {
+      parse("en", "{{Langx|ja|東京}}") should be (Some("東京"))
+    }
+
 
   private val wikiParser = WikiParser.getInstance()
 


### PR DESCRIPTION
## Problem
Templates like `{{lang|nap|Abbrùzzu}}` and `{{Nihongo2|東京都}}` in Wikipedia infoboxes 
were not being extracted, resulting in missing text content in DBpedia.

## Root Cause
The `Lang` template was configured to extract parameter 3, but `{{lang}}` only has 2 parameters.
Additionally, `Native name`, `Nihongo`, and `Nihongo2` templates were not configured.

## Fix
Updated [templatetransform.json](cci:7://file:///c:/Users/Vaibhav%20Mishra/gsoc2026/prr5/extraction-framework/core/src/main/resources/templatetransform.json:0:0-0:0):
- **Lang**: Extract param 2 (was incorrectly param 3)
- **Native name|native_name**: Added - extracts param 2
- **Nihongo2**: Added - extracts param 1
- **Nihongo**: Added - extracts param 2

## Examples
| Template | Before | After |
|----------|--------|-------|
| `{{lang\|nap\|Abbrùzzu}}` | *(empty)* | Abbrùzzu |
| `{{Nihongo2\|東京都}}` | *(empty)* | 東京都 |

## Testing
- Added test cases to [TemplateTransformParserTest.scala](cci:7://file:///c:/Users/Vaibhav%20Mishra/gsoc2026/prr5/extraction-framework/core/src/test/scala/org/dbpedia/extraction/wikiparser/TemplateTransformParserTest.scala:0:0-0:0)
- Verified configuration with standalone validation script

fixes issue #747 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Broader template parsing: many additional language templates and commons fields are now recognized, improving extraction of native names, transliterations, scripts, and standardized currency/stock labels.
  * Improved list and structural handling for richer, more consistent text extraction from complex list formats.

* **Tests**
  * Added tests covering extraction for multiple new language template formats to ensure correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->