### PR TITLE
Fix crash in DisambiguationExtractor by adding safe fallback for missing language configurations

### DIFF
--- a/.github/workflows/snapshot_deploy.yml
+++ b/.github/workflows/snapshot_deploy.yml
@@ -77,4 +77,5 @@ jobs:
         run: |
           echo "Deploying to https://maven.pkg.github.com/${REPO} with revision ${REVISION}"
           mvn deploy -DskipTests \
-            -Dgithub.repo.url="https://maven.pkg.github.com/${REPO}"
+            -Dgithub.repo.url="https://maven.pkg.github.com/${REPO}" \
+            -DskipNexusStagingDeployMojo=true

--- a/core/src/main/scala/org/dbpedia/extraction/mappings/DisambiguationExtractor.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/mappings/DisambiguationExtractor.scala
@@ -22,7 +22,7 @@ extends PageNodeExtractor
 {
   private val language = context.language
 
-  private val replaceString = DisambiguationExtractorConfig.disambiguationTitlePartMap(language.wikiCode)
+  private val replaceString = DisambiguationExtractorConfig.disambiguationTitlePartMap.getOrElse(language.wikiCode, " (disambiguation)")
 
   val wikiPageDisambiguatesProperty = context.ontology.properties("wikiPageDisambiguates")
 


### PR DESCRIPTION
##  Fix: Safe Language Config Lookup in `DisambiguationExtractor`

### Problem
Direct map access caused a runtime crash when a language code was missing from `disambiguationTitlePartMap`:
```scala
// Before (unsafe)
private val replaceString =
  DisambiguationExtractorConfig.disambiguationTitlePartMap(language.wikiCode)
// java.util.NoSuchElementException: key not found: ro
```

### Solution
Replaced with `.getOrElse` to fall back to `" (disambiguation)"` when a language config is absent:
```scala
// After (safe)
private val replaceString =
  DisambiguationExtractorConfig.disambiguationTitlePartMap
    .getOrElse(language.wikiCode, " (disambiguation)")
```

### Testing
- No `NoSuchElementException` thrown for missing language codes
- Fallback value `" (disambiguation)"` applied correctly
- mvn clean compile` passed with no errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of disambiguation extraction with a safer fallback for missing language-specific title parts, reducing processing errors.
* **Chores**
  * Adjusted snapshot deployment workflow to modify snapshot publish behavior during CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->