### PR TITLE
feat(ontology): add rdfs:comment to infobox property definitions

### DIFF
--- a/.github/workflows/snapshot_deploy.yml
+++ b/.github/workflows/snapshot_deploy.yml
@@ -77,4 +77,5 @@ jobs:
         run: |
           echo "Deploying to https://maven.pkg.github.com/${REPO} with revision ${REVISION}"
           mvn deploy -DskipTests \
-            -Dgithub.repo.url="https://maven.pkg.github.com/${REPO}"
+            -Dgithub.repo.url="https://maven.pkg.github.com/${REPO}" \
+            -DskipNexusStagingDeployMojo=true

--- a/core/src/main/java/org/dbpedia/extraction/nif/Link.java
+++ b/core/src/main/java/org/dbpedia/extraction/nif/Link.java
@@ -11,11 +11,29 @@ public class Link implements Comparable<Link> {
 	private boolean topicLink = false;
 	private boolean topicPartLink = false;
 	private boolean surfaceFormLink = false;
-	
+	private boolean citation = false;
+	private String citationId = "";
+
 	public Link() {
-		
+
 	}
-	
+
+	public boolean isCitation() {
+		return citation;
+	}
+
+	public void setCitation(boolean citation) {
+		this.citation = citation;
+	}
+
+	public String getCitationId() {
+		return citationId;
+	}
+
+	public void setCitationId(String citationId) {
+		this.citationId = citationId;
+	}
+
 	public boolean isSurfaceFormLink() {
 		return surfaceFormLink;
 	}
@@ -91,12 +109,12 @@ public class Link implements Comparable<Link> {
 	@Override
 	public int compareTo(Link link) {
 		// TODO Auto-generated method stub
-		if(this.wordStart==link.getWordStart()) 
+		if (this.wordStart == link.getWordStart())
 			return 0;
-		else if(this.wordStart<link.getWordStart())
+		else if (this.wordStart < link.getWordStart())
 			return -1;
 		else
 			return 1;
 	}
-	
+
 }

--- a/core/src/main/java/org/dbpedia/extraction/nif/LinkExtractor.java
+++ b/core/src/main/java/org/dbpedia/extraction/nif/LinkExtractor.java
@@ -16,84 +16,87 @@ public class LinkExtractor implements NodeVisitor {
 	private int skipLevel = -1;
 	private List<Paragraph> paragraphs = null;
 	private Paragraph paragraph = null;
-    private Link tempLink;
+	private Link tempLink;
 	private boolean inSup = false;
 	private boolean invisible = false;
-    private NifExtractorContext context;
+	private NifExtractorContext context;
 	private ArrayList<String> errors = new ArrayList<>();
-	
+
 	public LinkExtractor(NifExtractorContext context) {
-        paragraphs = new ArrayList<Paragraph>();
+		paragraphs = new ArrayList<Paragraph>();
 		this.context = context;
 	}
-	
+
 	/**
 	 * Gets called when entering an element
-	 * -handle text cleanup and remove Wikipedia specific stuff like reference numbers
+	 * -handle text cleanup and remove Wikipedia specific stuff like reference
+	 * numbers
 	 * -if we encounter a link, we make a new nif:Word
-	 * -we get the text out of a whitelist of elements. 
-	 *   If we encounter a non-whitelisted element, we set this.skipLevel to the current depth 
-	 *   of the dom tree and skip everything until we are back to that depth
+	 * -we get the text out of a whitelist of elements.
+	 * If we encounter a non-whitelisted element, we set this.skipLevel to the
+	 * current depth
+	 * of the dom tree and skip everything until we are back to that depth
 	 * -this thing badly needs refactoring
 	 */
-	
+
 	public void head(Node node, int depth) {
 
-		if(skipLevel>=0){
+		if (skipLevel >= 0) {
 			return;
 		}
 
-        if(paragraph == null) {
+		if (paragraph == null) {
 			paragraph = new Paragraph(0, "", "p");
 		}
-		//ignore all content inside invisible tags
-		if(invisible || node.attr("style").matches(".*display\\s*:\\s*none.*")) {
+		// ignore all content inside invisible tags
+		if (invisible || node.attr("style").matches(".*display\\s*:\\s*none.*")) {
 			invisible = true;
 			return;
 		}
 
-		if(node.nodeName().equals("#text")) {
-		  String tempText = node.toString();
+		if (node.nodeName().equals("#text")) {
+			String tempText = node.toString();
 
-		  //replace no-break spaces because unescape doesn't deal with them
-		  tempText = StringEscapeUtils.unescapeHtml4(tempText);
-          tempText = org.dbpedia.extraction.util.StringUtils.escape(tempText, replaceChars());
-		  tempText = tempText.replace("\\n", "\n").replace("\\t", "\t").replace("\\r", "");
+			// replace no-break spaces because unescape doesn't deal with them
+			tempText = StringEscapeUtils.unescapeHtml4(tempText);
+			tempText = org.dbpedia.extraction.util.StringUtils.escape(tempText, replaceChars());
+			tempText = tempText.replace("\\n", "\n").replace("\\t", "\t").replace("\\r", "");
 
-		  //this text node is the content of an <a> element: make a new nif:Word
-		  if(inLink) {
-              if(!tempText.trim().startsWith(this.context.wikipediaTemplateString + ":"))  //not!
-              {
-                  tempLink.setLinkText(tempText);
-                  tempLink.setWordStart(paragraph.getLength() + (Paragraph.FollowedByWhiteSpace(paragraph.getText()) ? 1 : 0));
-                  paragraph.addText(tempText);
-                  tempLink.setWordEnd(paragraph.getLength());
-              }
-              else{                                            // -> filter out hidden links to the underlying template
-				  errors.add("found Template in resource: " + this.context.resource + ": " + tempText);
-				  return;
-			  }
-		  }
-		  else
-		    paragraph.addText(tempText);
+			// this text node is the content of an <a> element: make a new nif:Word
+			if (inLink) {
+				if (!tempText.trim().startsWith(this.context.wikipediaTemplateString + ":")) // not!
+				{
+					tempLink.setLinkText(tempText);
+					tempLink.setWordStart(
+							paragraph.getLength() + (Paragraph.FollowedByWhiteSpace(paragraph.getText()) ? 1 : 0));
+					paragraph.addText(tempText);
+					tempLink.setWordEnd(paragraph.getLength());
+				} else { // -> filter out hidden links to the underlying template
+					errors.add("found Template in resource: " + this.context.resource + ": " + tempText);
+					return;
+				}
+			} else
+				paragraph.addText(tempText);
 		}
 
-		else if(node.nodeName().equals("a")) {
+		else if (node.nodeName().equals("a")) {
 
-            String link = node.attr("href");
-            //TODO central string management
+			String link = node.attr("href");
+			// TODO central string management
 			/**
-			 * remove internal links linking to mediawiki meta pages. Also removes links that contain ":".
+			 * remove internal links linking to mediawiki meta pages. Also removes links
+			 * that contain ":".
 			 * Wikipedia api standard link looks like (allowed):
 			 * <a href="/wiki/Philosopher" title="Philosopher">philosopher</a>
-			 * see Schopenhauer: https://en.wikipedia.org/w/api.php?uselang=en&format=xml&action=parse&prop=text&pageid=17340400
+			 * see Schopenhauer:
+			 * https://en.wikipedia.org/w/api.php?uselang=en&format=xml&action=parse&prop=text&pageid=17340400
 			 */
-            String linkPrefix = "/wiki/";
+			String linkPrefix = "/wiki/";
 
 			// SPECIAL CASE FOR RESTAPI PARSING https://en.wikipedia.org/api/rest_v1/
-			if(node.hasAttr("rel")) {
+			if (node.hasAttr("rel")) {
 				String relType = node.attr("rel");
-				if(relType.equals("mw:WikiLink")){
+				if (relType.equals("mw:WikiLink")) {
 					tempLink = new Link();
 					String uri = cleanLink(node.attr("href"), false);
 					setUri(uri);
@@ -109,13 +112,20 @@ public class LinkExtractor implements NodeVisitor {
 					String uri = cleanLink(node.attr("href"), false);
 					setUri(uri);
 
-					//simple example of Help:IPA
-					// <a href="/wiki/Help:IPA/Standard_German" title="Help:IPA/Standard German">[ˈaɐ̯tʊɐ̯ ˈʃoːpn̩haʊ̯ɐ]</a>
+					// simple example of Help:IPA
+					// <a href="/wiki/Help:IPA/Standard_German" title="Help:IPA/Standard
+					// German">[ˈaɐ̯tʊɐ̯ ˈʃoːpn̩haʊ̯ɐ]</a>
 				} else if (link.contains(linkPrefix) && link.contains(":")) {
 					/**
 					 * TODO buggy
 					 * Cleans up child nodes: difficult example
-					 * <a href="/wiki/Help:IPA/English" title="Help:IPA/English">/<span style="border-bottom:1px dotted"><span title="/ˈ/: primary stress follows">ˈ</span><span title="/ʃ/: 'sh' in 'shy'">ʃ</span><span title="/oʊ/: 'o' in 'code'">oʊ</span><span title="'p' in 'pie'">p</span><span title="/ən/: 'on' in 'button'">ən</span><span title="'h' in 'hi'">h</span><span title="/aʊ/: 'ou' in 'mouth'">aʊ</span><span title="/./: syllable break">.</span><span title="/ər/: 'er' in 'letter'">ər</span></span>/</a>
+					 * <a href="/wiki/Help:IPA/English" title="Help:IPA/English">/<span style=
+					 * "border-bottom:1px dotted"><span title="/ˈ/: primary stress
+					 * follows">ˈ</span><span title="/ʃ/: 'sh' in 'shy'">ʃ</span><span title="/oʊ/:
+					 * 'o' in 'code'">oʊ</span><span title="'p' in 'pie'">p</span><span title="/ən/:
+					 * 'on' in 'button'">ən</span><span title="'h' in 'hi'">h</span><span title=
+					 * "/aʊ/: 'ou' in 'mouth'">aʊ</span><span title="/./: syllable
+					 * break">.</span><span title="/ər/: 'er' in 'letter'">ər</span></span>/</a>
 					 */
 					if (!node.childNodes().isEmpty()) {
 						if (node.childNode(0).nodeName().equals("#text") &&
@@ -128,93 +138,98 @@ public class LinkExtractor implements NodeVisitor {
 					} else {
 						skipLevel = depth;
 					}
-					//TODO add example
+					// TODO add example
 				} else if (node.attr("class").equals("external text")) {
-					//don't skip external links
+					// don't skip external links
 					tempLink = new Link();
 					String uri = cleanLink(node.attr("href"), true);
 					setUri(uri);
 
+				} else if (link.startsWith("#cite_note-")) {
+					tempLink = new Link();
+					tempLink.setCitation(true);
+					tempLink.setCitationId(link.substring(1));
+					inLink = true;
 				} else {
 					skipLevel = depth;
 				}
 			}
-        } else if(node.nodeName().equals("p")) {
-            if(paragraph != null) {
-                addParagraph("p");
-            }
-            else
-                paragraph = new Paragraph(0, "", "p");
-		} else if(node.nodeName().equals("sup")) {
+		} else if (node.nodeName().equals("p")) {
+			if (paragraph != null) {
+				addParagraph("p");
+			} else
+				paragraph = new Paragraph(0, "", "p");
+		} else if (node.nodeName().equals("sup")) {
 			inSup = true;
-        } else if(node.nodeName().matches("h\\d")) {
-            addParagraph(node.nodeName());
-        } else if(node.nodeName().equals("table")) {
-            addParagraph("table");
-			paragraph.addStructure(paragraph.getLength(), node.outerHtml(), "table", node.attr("class"), node.attr("id"));
-            addParagraph("p");
-            skipLevel = depth;
-        } else if(node.nodeName().equals("span")) {
-			//denote notes
+		} else if (node.nodeName().matches("h\\d")) {
+			addParagraph(node.nodeName());
+		} else if (node.nodeName().equals("table")) {
+			addParagraph("table");
+			paragraph.addStructure(paragraph.getLength(), node.outerHtml(), "table", node.attr("class"),
+					node.attr("id"));
+			addParagraph("p");
+			skipLevel = depth;
+		} else if (node.nodeName().equals("span")) {
+			// denote notes
 
-		    if(node.attr("class").contains("notebegin"))
-                addParagraph("note");
+			if (node.attr("class").contains("notebegin"))
+				addParagraph("note");
 
-        } else if(node.nodeName().equals("math"))  {
-            addParagraph("math");
-            paragraph.addStructure(paragraph.getLength(), node.outerHtml(), "math", "tex", null);
-            addParagraph("p");
-            skipLevel = depth;
-        }
+		} else if (node.nodeName().equals("math")) {
+			addParagraph("math");
+			paragraph.addStructure(paragraph.getLength(), node.outerHtml(), "math", "tex", null);
+			addParagraph("p");
+			skipLevel = depth;
+		}
 	}
 
 	private void setUri(String uri) {
-		if(uri!=null) {
-            tempLink.setUri(uri);
-            tempLink.setExternal(true);
-            inLink = true;
-        } else {
-            tempLink = new Link();
-        }
+		if (uri != null) {
+			tempLink.setUri(uri);
+			tempLink.setExternal(true);
+			inLink = true;
+		} else {
+			tempLink = new Link();
+		}
 	}
-	
+
 	private String cleanLink(String uri, boolean external) {
-		if(!external) {
+		if (!external) {
 
 			String linkPrefix = "/wiki/";
-			String linkPrefix2= "./";
-			if(uri.contains(linkPrefix)){
-				uri=uri.substring(uri.indexOf("?title=")+7);
+			String linkPrefix2 = "./";
+			if (uri.contains(linkPrefix)) {
+				uri = uri.substring(uri.indexOf("?title=") + 7);
 			} else if (uri.contains(linkPrefix2)) {
-				uri=uri.substring(uri.indexOf("?title=")+3);
+				uri = uri.substring(uri.indexOf("?title=") + 3);
 			}
-			//TODO central string management
-			if(!this.context.language.equals("en")) {
-				uri="http://"+this.context.language+".dbpedia.org/resource/"+uri;
+			// TODO central string management
+			if (!this.context.language.equals("en")) {
+				uri = "http://" + this.context.language + ".dbpedia.org/resource/" + uri;
 			} else {
-				uri="http://dbpedia.org/resource/"+uri;
+				uri = "http://dbpedia.org/resource/" + uri;
 			}
 			uri = uri.replace("&action=edit&redlink=1", "");
-			
+
 		} else {
-			//there are links that contain illegal hostnames
+			// there are links that contain illegal hostnames
 			try {
-				if(uri.startsWith("//"))
-					uri = "http:"+uri;
-				uri = URLEncoder.encode(uri,"UTF-8");
+				if (uri.startsWith("//"))
+					uri = "http:" + uri;
+				uri = URLEncoder.encode(uri, "UTF-8");
 				uri = uri.replace("%3A", ":").replace("%2F", "/").replace("%2E", ".");
-					
-			} catch(UnsupportedEncodingException e) {
-				//this doesn't happen
+
+			} catch (UnsupportedEncodingException e) {
+				// this doesn't happen
 				e.printStackTrace();
 			}
 		}
 		return UriUtils.uriToDbpediaIri(uri).toString();
 	}
-	
+
 	public void tail(Node node, int depth) {
-		if(skipLevel>0) {
-			if(skipLevel==depth) {
+		if (skipLevel > 0) {
+			if (skipLevel == depth) {
 				skipLevel = -1;
 				return;
 			} else {
@@ -222,74 +237,68 @@ public class LinkExtractor implements NodeVisitor {
 			}
 		}
 
-		if(node.nodeName().equals("a") && inLink) {
+		if (node.nodeName().equals("a") && inLink) {
 			inLink = false;
 			paragraph.addLink(tempLink);
 			tempLink = new Link();
-		}
-		else if(invisible && node.attr("style").matches(".*display\\s*:\\s*none.*")) {
-            invisible = false;
-        }
-        else if(node.nodeName().equals("p") && paragraph != null) {
-            addParagraph("p");
-        }
-        else if(node.nodeName().equals("sup") && inSup) {
+		} else if (invisible && node.attr("style").matches(".*display\\s*:\\s*none.*")) {
+			invisible = false;
+		} else if (node.nodeName().equals("p") && paragraph != null) {
+			addParagraph("p");
+		} else if (node.nodeName().equals("sup") && inSup) {
 
 			inSup = false;
+		} else if (node.nodeName().matches("h\\d")) {
+			addParagraph("p");
+		} else if (node.nodeName().equals("span")) {
+			if (node.attr("class").contains("noteend"))
+				addParagraph("p");
 		}
-        else if(node.nodeName().matches("h\\d")) {
-            addParagraph("p");
-        }
-        else if(node.nodeName().equals("span")) {
-            if(node.attr("class").contains("noteend"))
-                addParagraph("p");
-        }
 	}
-	
+
 	public List<Paragraph> getParagraphs() {
-		if(paragraph != null && paragraph.getLength() > 0)
-        {
-            paragraphs.add(paragraph);
-            paragraph = null;
-        }
-        return paragraphs;
+		if (paragraph != null && paragraph.getLength() > 0) {
+			paragraphs.add(paragraph);
+			paragraph = null;
+		}
+		return paragraphs;
 	}
 
-	private void addParagraph(String newTag){
-	    if(paragraph.getLength() != 0 || paragraph.getHtmlStrings().size() > 0)
-            paragraphs.add(paragraph);
+	private void addParagraph(String newTag) {
+		if (paragraph.getLength() != 0 || paragraph.getHtmlStrings().size() > 0)
+			paragraphs.add(paragraph);
 
-	    paragraph = new Paragraph(0, "", (newTag == null ? "p" : newTag));
-    }
+		paragraph = new Paragraph(0, "", (newTag == null ? "p" : newTag));
+	}
 
-	public int getTableCount(){
-		int count =0;
-		for(Paragraph p : this.getParagraphs()){
+	public int getTableCount() {
+		int count = 0;
+		for (Paragraph p : this.getParagraphs()) {
 			count += paragraph.getHtmlStrings().size();
 		}
 		return count;
 	}
 
-	public ArrayList<String> getErrors(){
+	public ArrayList<String> getErrors() {
 		return errors;
 	}
 
-    private String[] replaceChars() {
-        String[] rep = new String[256];
-        rep['\n'] = "";
-        rep['\u00A0'] = " ";
-        return rep;
-    }
+	private String[] replaceChars() {
+		String[] rep = new String[256];
+		rep['\n'] = "";
+		rep['\u00A0'] = " ";
+		return rep;
+	}
 
-    public static class NifExtractorContext {
-        private String language;
-        private String resource;
-        private String wikipediaTemplateString;
+	public static class NifExtractorContext {
+		private String language;
+		private String resource;
+		private String wikipediaTemplateString;
 
-        public NifExtractorContext(String language, String resource, String templateString){
-            this.language = language;
-            this.resource = resource;
-            this.wikipediaTemplateString = templateString;
-        }
-    }
+		public NifExtractorContext(String language, String resource, String templateString) {
+			this.language = language;
+			this.resource = resource;
+			this.wikipediaTemplateString = templateString;
+		}
+	}
 }

--- a/core/src/main/resources/addonlangs.json
+++ b/core/src/main/resources/addonlangs.json
@@ -79,5 +79,11 @@
     "name": "Cantonese",
     "isoCode": "yue",
     "iso639_3": "yue"
+  },
+  "en": {
+    "wikiCode": "en",
+    "name": "English",
+    "isoCode": "en",
+    "iso639_3": "eng"
   }
 }

--- a/core/src/main/resources/nifextractionconfig.json
+++ b/core/src/main/resources/nifextractionconfig.json
@@ -14,7 +14,6 @@
     "nif-remove-elements":[
       ".noprint",
       ".haudio",
-      "sup.reference",
       "span.mw-editsection",
       ".error",
       "#coordinates",

--- a/core/src/main/scala/org/dbpedia/extraction/mappings/DisambiguationExtractor.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/mappings/DisambiguationExtractor.scala
@@ -22,7 +22,7 @@ extends PageNodeExtractor
 {
   private val language = context.language
 
-  private val replaceString = DisambiguationExtractorConfig.disambiguationTitlePartMap(language.wikiCode)
+  private val replaceString = DisambiguationExtractorConfig.disambiguationTitlePartMap.getOrElse(language.wikiCode, " (disambiguation)")
 
   val wikiPageDisambiguatesProperty = context.ontology.properties("wikiPageDisambiguates")
 

--- a/core/src/main/scala/org/dbpedia/extraction/mappings/InfoboxExtractor.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/mappings/InfoboxExtractor.scala
@@ -58,6 +58,7 @@ extends PageNodeExtractor
     private val ignoreProperties = InfoboxExtractorConfig.ignoreProperties
 
     private val labelProperty = ontology.properties("rdfs:label")
+    private val commentProperty = ontology.properties("rdfs:comment")
     private val typeProperty = ontology.properties("rdf:type")
     private val propertyClass = ontology.classes("rdf:Property")
     private val rdfLangStrDt = ontology.datatypes("rdf:langString")
@@ -165,6 +166,8 @@ extends PageNodeExtractor
                                 seenProperties += propertyUri
                                 quads += new Quad(language, DBpediaDatasets.InfoboxPropertyDefinitions, propertyUri, typeProperty, propertyClass.uri, splitNode.sourceIri)
                                 quads += new Quad(language, DBpediaDatasets.InfoboxPropertyDefinitions, propertyUri, labelProperty, propertyLabel, splitNode.sourceIri, rdfLangStrDt)
+                                val propertyComment = "Raw property extracted from Wikipedia infobox: " + property.key
+                                quads += new Quad(language, DBpediaDatasets.InfoboxPropertyDefinitions, propertyUri, commentProperty, propertyComment, splitNode.sourceIri, rdfLangStrDt)
                             }
                         }
                     }

--- a/core/src/main/scala/org/dbpedia/extraction/nif/HtmlNifExtractor.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/nif/HtmlNifExtractor.scala
@@ -39,6 +39,7 @@ abstract class HtmlNifExtractor(nifContextIri: String, language: String, nifPara
   protected val templateString = "Template"
 
   private val sectionMap = new mutable.HashMap[PageSection, ExtractedSection]()
+  private val citationMap = new mutable.HashMap[String, String]()
 
   /**
     * Extract the relevant html page divided in sections and paragraphs
@@ -285,9 +286,17 @@ abstract class HtmlNifExtractor(nifContextIri: String, language: String, nifPara
         words += nifLinks(word, RdfNamespace.NIF.append("beginIndex"), (offset + link.getWordStart).toString, sourceUrl, RdfNamespace.XSD.append("nonNegativeInteger"))
         words += nifLinks(word, RdfNamespace.NIF.append("endIndex"), (offset + link.getWordEnd).toString, sourceUrl, RdfNamespace.XSD.append("nonNegativeInteger"))
         words += nifLinks(word, RdfNamespace.NIF.append("superString"), paragraphUri, sourceUrl, null)
-        UriUtils.createURI(link.getUri) match{
-          case Success(s) => words += nifLinks(word, "http://www.w3.org/2005/11/its/rdf#taIdentRef", s.toString, sourceUrl, null)  //TODO IRI's might throw exception in org.dbpedia.extraction.destinations.formatters please check this
-          case Failure(f) =>
+        if (link.isCitation) {
+          words += nifLinks(word, RdfNamespace.RDF.append("type"), "http://dbpedia.org/ontology/Citation", sourceUrl, null)
+          citationMap.get(link.getCitationId) match {
+            case Some(url) => words += nifLinks(word, "http://www.w3.org/2005/11/its/rdf#taIdentRef", url, sourceUrl, null)
+            case None =>
+          }
+        } else {
+          UriUtils.createURI(link.getUri) match{
+            case Success(s) => words += nifLinks(word, "http://www.w3.org/2005/11/its/rdf#taIdentRef", s.toString, sourceUrl, null)  //TODO IRI's might throw exception in org.dbpedia.extraction.destinations.formatters please check this
+            case Failure(f) =>
+          }
         }
         if(writeLinkAnchors)
           words += nifLinks(word, RdfNamespace.NIF.append("anchorOf"), link.getLinkText, sourceUrl, RdfNamespace.XSD.append("string"))
@@ -345,6 +354,15 @@ abstract class HtmlNifExtractor(nifContextIri: String, language: String, nifPara
 
   protected def getJsoupDoc(html: String): Document = {
     val doc = Jsoup.parse(cleanHtml(html))
+
+    //extract citations
+    for(note <- doc.select("li[id^=cite_note-]").asScala){
+      val id = note.id()
+      val extLink = note.select("a.external.text").first()
+      if (extLink != null) {
+        citationMap.put(id, extLink.attr("href"))
+      }
+    }
 
     //delete queries
     for(query <- cssSelectorConfigMap.removeElements)

--- a/core/src/main/scala/org/dbpedia/extraction/util/DateFinder.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/util/DateFinder.scala
@@ -18,19 +18,23 @@ class DateFinder[T](val finder: Finder[T]){
     _date
   else throw new IllegalStateException("date not set")
 
-  def byName(name: String, auto: Boolean = false): Option[T] = {
+  def byName(name: String, auto: Boolean = false, required: Boolean = true): Option[T] = {
     if (_date == null) {
       if (! auto)
         throw new IllegalStateException("date not set")
-      _date = finder.dates(name).last
+      val dates = finder.dates(name, required)
+      if (dates.isEmpty) return None
+      _date = dates.last
     }
     finder.file(_date, name)
   }
 
-  def byPattern (pattern: String, auto: Boolean = false): Seq[T] = {
+  def byPattern (pattern: String, auto: Boolean = false, required: Boolean = true): Seq[T] = {
     if (_date == null) {
       if (! auto) throw new IllegalStateException("date not set")
-      _date = finder.dates(pattern, true, true).last
+      val dates = finder.dates(pattern, required, isSuffixRegex = true)
+      if (dates.isEmpty) return Seq.empty
+      _date = dates.last
     }
     finder.matchFiles(_date, pattern).toSeq
   }

--- a/core/src/main/scala/org/dbpedia/extraction/util/Finder.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/util/Finder.scala
@@ -63,7 +63,7 @@ class Finder[T](val baseDir: T, val language: Language, val wikiNameSuffix: Stri
         case None => false
       }}
 
-    val dates = wikiDir.names.filter(dateFilter).filter(suffixFilter).sortBy(_.toInt)
+    val dates = wikiDir.names.filter(dateFilter).filter(suffixFilter).distinct.sortBy(_.toInt)
     
     if (required && dates.isEmpty) {
       var msg = "found no directory "+wikiDir+"/[YYYYMMDD]"

--- a/core/src/main/scala/org/dbpedia/extraction/util/Language.scala
+++ b/core/src/main/scala/org/dbpedia/extraction/util/Language.scala
@@ -123,13 +123,35 @@ object Language extends (String => Language)
       request.setHeader("User-Agent", customUserAgentText)
     }
 
-    val response = client.execute(request)
-    val stream = response.getEntity.getContent
-    val wikiLanguageCodes = 
-      try Source.fromInputStream(stream).getLines().toList 
-      finally{ 
-        stream.close()
-        client.close() 
+    val wikiLanguageCodes =
+      try {
+        // Set a default User-Agent if none is provided
+        if (!customUserAgentEnabled) {
+          request.setHeader("User-Agent", "DBpedia-Extraction-Framework/1.0 (https://github.com/dbpedia/extraction-framework; dbpedia@infai.org)")
+        }
+
+        val response = client.execute(request)
+        val status = response.getStatusLine.getStatusCode
+        if (status >= 200 && status < 300) {
+          val stream = response.getEntity.getContent
+          try {
+            Source.fromInputStream(stream).getLines()
+              .map(_.trim)
+              .filter(line => line.nonEmpty && !line.contains(" ")) // Basic filter for language codes
+              .toList
+          } finally {
+            stream.close()
+          }
+        } else {
+          logger.log(Level.WARNING, "Language list fetch failed with status " + status + " from " + wikipediaLanguageUrl)
+          List.empty
+        }
+      } catch {
+        case e: Exception =>
+          logger.log(Level.WARNING, "Could not fetch language list from " + wikipediaLanguageUrl + ": " + e.getMessage)
+          List.empty // Fallback to empty list, addonlangs.json will still be used
+      } finally {
+        client.close()
       }
 
     val specialLangs: JsonConfig = new JsonConfig(this.getClass.getClassLoader.getResource("addonlangs.json"))

--- a/dump/src/test/resources/extraction-configs/extraction.nif.abstracts.properties
+++ b/dump/src/test/resources/extraction-configs/extraction.nif.abstracts.properties
@@ -112,3 +112,4 @@ nif-isTestRun=false
 nif-write-anchor=true
 # write only the anchor text for link instances
 nif-write-link-anchor=true
+compare-dataset-ids=false

--- a/dump/src/test/resources/extraction-configs/extraction.plain.abstracts.properties
+++ b/dump/src/test/resources/extraction-configs/extraction.plain.abstracts.properties
@@ -105,3 +105,4 @@ nif-isTestRun=false
 nif-write-anchor=true
 # write only the anchor text for link instances
 nif-write-link-anchor=true
+compare-dataset-ids=false

--- a/dump/src/test/resources/extraction-configs/generic-spark.extraction.minidump.properties
+++ b/dump/src/test/resources/extraction-configs/generic-spark.extraction.minidump.properties
@@ -126,3 +126,6 @@ extractors.zh=
 # If we need to Exclude Non-Free Images in this Extraction, set this to true
 copyrightCheck=false
 
+# Disable remote DataID comparison for tests to avoid external dependencies
+compare-dataset-ids=false
+

--- a/dump/src/test/resources/extraction-configs/mappings.extraction.minidump.properties
+++ b/dump/src/test/resources/extraction-configs/mappings.extraction.minidump.properties
@@ -28,3 +28,7 @@ extractors=.MappingExtractor
 # If we need to Exclude Non-Free Images in this Extraction, set this to true
 copyrightCheck=false
 
+# Disable remote DataID comparison for tests to avoid external dependencies
+compare-dataset-ids=false
+
+

--- a/dump/src/test/resources/extraction-configs/wikidata.extraction.properties
+++ b/dump/src/test/resources/extraction-configs/wikidata.extraction.properties
@@ -30,3 +30,4 @@ extractors=
 extractors.wikidata=.WikidataLexemeExtractor,.WikidataRawExtractor,.WikidataSameAsExtractor,.WikidataR2RExtractor,.WikidataLLExtractor,.WikidataReferenceExtractor,.WikidataAliasExtractor,.WikidataLabelExtractor,.WikidataNameSpaceSameAsExtractor,.WikidataPropertyExtractor,.WikidataDescriptionExtractor
 
 
+compare-dataset-ids=false

--- a/ontology.xml
+++ b/ontology.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><mediawiki xmlns="http://www.mediawiki.org/xml/export-0.8/"><page><title>OntologyClass:Academic</title><ns>200</ns><id>13556</id><revision><id>59230</id><timestamp>2023-02-19T19:11:55Z</timestamp><text>{{Class
+<?xml version='1.0' encoding='UTF-8'?><mediawiki xmlns="http://www.mediawiki.org/xml/export-0.8/"><page><title>OntologyClass:Academic</title><ns>200</ns><id>13556</id><revision><id>59230</id><timestamp>2023-02-19T19:11:55Z</timestamp><text>{{Class
 | labels =
 	{{label|en|Academic Person}}
 	{{label|eu|Pertsona Akademikoa}}
@@ -263,7 +263,7 @@
 {{label|it|aeroporto}}
 | rdfs:subClassOf = Infrastructure
 | owl:equivalentClass = schema:Airport,wikidata:Q1248784
-}}</text></revision></page><page><title>OntologyClass:Album</title><ns>200</ns><id>294</id><revision><id>57729</id><timestamp>2022-04-26T11:48:32Z</timestamp><text>{{Class
+}}</text></revision></page><page><title>OntologyClass:Album</title><ns>200</ns><id>294</id><revision><id>59728</id><timestamp>2024-07-27T22:09:14Z</timestamp><text>{{Class
 | labels =
 {{label|en|album}}
 {{label|ga|albam}}
@@ -279,6 +279,7 @@
 {{label|zh|照片集}}
 {{label|es|album}}
 {{label|ur|تصویروں اور دستخط کی کتاب}}
+{{label|am|አልበም}}
 {{label|it|album}}
 {{label|pl|album (wydawnictwo muzyczne)}}
 | rdfs:subClassOf = MusicalWork
@@ -514,9 +515,9 @@
 }}
 
 
-&lt;ref name="anime"&gt;http://en.wikipedia.org/wiki/Anime&lt;/ref&gt;
+&lt;ref name="anime">http://en.wikipedia.org/wiki/Anime&lt;/ref>
 ==References==
-&lt;references/&gt;</text></revision></page><page><title>OntologyClass:Annotation</title><ns>200</ns><id>11279</id><revision><id>55523</id><timestamp>2021-09-15T05:03:47Z</timestamp><text>{{Class
+&lt;references/></text></revision></page><page><title>OntologyClass:Annotation</title><ns>200</ns><id>11279</id><revision><id>55523</id><timestamp>2021-09-15T05:03:47Z</timestamp><text>{{Class
 | labels =
 {{label|en|Annotation}}
 {{label|el|Σχόλιο}}
@@ -753,7 +754,7 @@
                     {{comment|el|Στο πλαίσιο των διαστημικών πτήσεων, ένας τεχνητός δορυφόρος είναι ένα τεχνητό αντικείμενο το οποίο εκ προθέσεως έχει τοποθετηθεί σε τροχιά.}}
                     {{comment|fr|Un satellite artificiel est un objet placé intentionellement en orbite.}}
 | rdfs:subClassOf = Satellite
-&lt;!-- | owl:equivalentClass = http://www.ontotext.com/proton/protonext#ArtificialSatellite --&gt;
+&lt;!-- | owl:equivalentClass = http://www.ontotext.com/proton/protonext#ArtificialSatellite -->
 }}</text></revision></page><page><title>OntologyClass:Artist</title><ns>200</ns><id>303</id><revision><id>54969</id><timestamp>2021-09-09T11:05:16Z</timestamp><text>{{Class
 | labels =
 {{label|en|artist}}
@@ -854,7 +855,7 @@
 | rdfs:subClassOf = Person
 | specificProperties = {{SpecificProperty | ontologyProperty = timeInSpace | unit = minute }}
 | owl:equivalentClass = wikidata:Q11631
-}}</text></revision></page><page><title>OntologyClass:Athlete</title><ns>200</ns><id>305</id><revision><id>55075</id><timestamp>2021-09-09T15:02:51Z</timestamp><text>{{Class
+}}</text></revision></page><page><title>OntologyClass:Athlete</title><ns>200</ns><id>305</id><revision><id>59698</id><timestamp>2024-07-08T13:20:57Z</timestamp><text>{{Class
 | labels =
 {{label|en|athlete}}
 {{label|ga|lúthchleasaí}}
@@ -867,6 +868,7 @@
 {{label|ko|운동 선수}}
 {{label|ur|کھلاڑی}}
 | rdfs:subClassOf = Person
+| owl:equivalentClass = wikidata:Q2066131
 }}</text></revision></page><page><title>OntologyClass:Athletics</title><ns>200</ns><id>7844</id><revision><id>59144</id><timestamp>2023-01-02T08:48:06Z</timestamp><text>{{Class
 | labels =
 {{label|en|athletics}}
@@ -1074,7 +1076,7 @@
   {{label|ja|バドミントン選手}}
 
 | rdfs:subClassOf = Athlete
-}}</text></revision></page><page><title>OntologyClass:Band</title><ns>200</ns><id>311</id><revision><id>57346</id><timestamp>2022-03-31T11:28:03Z</timestamp><text>{{Class
+}}</text></revision></page><page><title>OntologyClass:Band</title><ns>200</ns><id>311</id><revision><id>59721</id><timestamp>2024-07-27T21:40:59Z</timestamp><text>{{Class
 | labels =
 	{{label|en|Band}}
         {{label|ga|banna ceoil}}
@@ -1086,8 +1088,9 @@
 	{{label|es|banda}}
 	{{label|ko|음악 그룹}}
 	{{label|ja|バンド_(音楽)}}
-        {{label|it|gruppo musicale}}
-        {{label|ur|گانے والوں کا گروہ}}
+    {{label|it|gruppo musicale}}
+    {{label|ur|گانے والوں کا گروہ}}
+    {{label|am|ባንድ}}
 | rdfs:subClassOf = Group, schema:MusicGroup, dul:SocialPerson
 | owl:equivalentClass = wikidata:Q215380
 }}</text></revision></page><page><title>OntologyClass:Bank</title><ns>200</ns><id>10290</id><revision><id>57797</id><timestamp>2022-05-01T12:24:45Z</timestamp><text>{{Class
@@ -1461,12 +1464,12 @@
 | owl:equivalentClass = wikidata:Q131436
 |comments =
 {{comment|en|come from http://en.wikipedia.org/wiki/Category:Board_games}}
-{{comment|it|Un gioco da tavolo è un gioco che richiede una ben definita superficie di gioco, che viene detta di solito tabellone o plancia.&lt;ref&gt;https://it.wikipedia.org/wiki/Gioco_da_tavolo&lt;/ref&gt;}}
+{{comment|it|Un gioco da tavolo è un gioco che richiede una ben definita superficie di gioco, che viene detta di solito tabellone o plancia.&lt;ref>https://it.wikipedia.org/wiki/Gioco_da_tavolo&lt;/ref>}}
 {{comment|ur|ایک بورڈ گیم ایک ایسا کھیل ہے جس کے لیے ایک اچھی طرح سے متعین کردہ سطح کی ضرورت ہوتی ہے ، جسے عام طور پر ایک بورڈ کہا جاتا ہے۔}}
 }}
 
 == References ==
-&lt;references /&gt;</text></revision></page><page><title>OntologyClass:BobsleighAthlete</title><ns>200</ns><id>11134</id><revision><id>56113</id><timestamp>2021-11-05T11:38:45Z</timestamp><text>{{Class
+&lt;references /></text></revision></page><page><title>OntologyClass:BobsleighAthlete</title><ns>200</ns><id>11134</id><revision><id>56113</id><timestamp>2021-11-05T11:38:45Z</timestamp><text>{{Class
 | labels = 
 {{label|en|BobsleighAthlete}}
 {{label|ur|بوبسلیگ کھلاڑی}}
@@ -1811,13 +1814,13 @@
   {{label|ur|تصویر کھینچنے کا آلہ}}
 | rdfs:subClassOf = Device
 |comments =
-{{comment|it|Una fotocamera (in lingua italiana nota tradizionalmente come macchina fotografica) è uno strumento utilizzato per la ripresa fotografica e per ottenere immagini di oggetti reali stampabili su supporti materiali cartacei o archiviabili su supporti elettronici.&lt;ref&gt;http://it.wikipedia.org/wiki/Fotocamera&lt;/ref&gt;}}
+{{comment|it|Una fotocamera (in lingua italiana nota tradizionalmente come macchina fotografica) è uno strumento utilizzato per la ripresa fotografica e per ottenere immagini di oggetti reali stampabili su supporti materiali cartacei o archiviabili su supporti elettronici.&lt;ref>http://it.wikipedia.org/wiki/Fotocamera&lt;/ref>}}
 {{comment|el|Φωτογραφική μηχανή ονομάζεται η συσκευή που χρησιμοποιείται για τη λήψη φωτογραφιών.Οι ευρύτερα χρησιμοποιούμενες σήμερα φωτογραφικές μηχανές, ερασιτεχνικής ή επαγγελματικής χρήσης, διακρίνονται σε δύο βασικές κατηγορίες: τις συμπαγείς και στις μονοοπτικές ρεφλέξ. Διακρινόμενες, ανάλογα με την τεχνολογία τους,είναι οι κλασικές φωτογραφικές μηχανές με φιλμ και οι ψηφιακές φωτογραφικές μηχανές.}}
 {{comment|ur|ایک کیمرہ (اطالوی میں روایتی طور پر کیمرے کے نام سے جانا جاتا ہے) ایک ایسا آلہ ہے جو فوٹو گرافی کی شوٹنگ اور حقیقی اشیاء کی تصاویر حاصل کرنے کے لیے استعمال کیا جاتا ہے جو کاغذ پر چھپ سکتی ہیں یا الیکٹرانک میڈیا پر محفوظ کی جا سکتی ہیں۔}}
 }}
 
 == References ==
-&lt;references /&gt;</text></revision></page><page><title>OntologyClass:CanadianFootballLeague</title><ns>200</ns><id>2282</id><revision><id>55577</id><timestamp>2021-09-15T08:24:43Z</timestamp><text>{{Class
+&lt;references /></text></revision></page><page><title>OntologyClass:CanadianFootballLeague</title><ns>200</ns><id>2282</id><revision><id>55577</id><timestamp>2021-09-15T08:24:43Z</timestamp><text>{{Class
 | labels =
 {{label|it|lega di football canadese}}
 {{label|en|canadian football league}}
@@ -1951,7 +1954,7 @@
 
 
 == References ==
-&lt;references /&gt;</text></revision></page><page><title>OntologyClass:Cardinal</title><ns>200</ns><id>326</id><revision><id>57495</id><timestamp>2022-04-24T10:42:48Z</timestamp><text>{{Class
+&lt;references /></text></revision></page><page><title>OntologyClass:Cardinal</title><ns>200</ns><id>326</id><revision><id>57495</id><timestamp>2022-04-24T10:42:48Z</timestamp><text>{{Class
 | labels =
 {{label|it|cardinale}}
 {{label|en|cardinal}}
@@ -2060,7 +2063,7 @@
 {{label|ja|猫}}
 {{label|ur|بلی}}
 | rdfs:subClassOf = Mammal
-| owl:disjointWith = &lt;!--Dog--&gt; &lt;!-- due to a bug cannot declare 2-way disjointness, this is declared in class Dog and transitively applies to cat--&gt;
+| owl:disjointWith = &lt;!--Dog--> &lt;!-- due to a bug cannot declare 2-way disjointness, this is declared in class Dog and transitively applies to cat-->
 | owl:equivalentClass = wikidata:Q146
 }}</text></revision></page><page><title>OntologyClass:Caterer</title><ns>200</ns><id>11141</id><revision><id>57661</id><timestamp>2022-04-25T09:22:41Z</timestamp><text>{{Class
 | labels =
@@ -2118,7 +2121,7 @@
 {{comment|en|A burial place}}
 {{comment|ur|ایک تدفین کی جگہ}}
 {{comment|el|Νεκροταφείο (ή Κοιμητήριο) ονομάζεται ο χώρος ο προορισμένος για την ταφή των νεκρών.}}
-{{comment|fr|Un cimetière est un groupement de sépultures monumentales.&lt;ref&gt;https://fr.wikipedia.org/wiki/Cimetière&lt;/ref&gt;}}
+{{comment|fr|Un cimetière est un groupement de sépultures monumentales.&lt;ref>https://fr.wikipedia.org/wiki/Cimetière&lt;/ref>}}
 
 | rdfs:subClassOf = Place
 | owl:equivalentClass = wikidata:Q39614
@@ -2126,7 +2129,7 @@
 
 == References ==
 
-&lt;references/&gt;</text></revision></page><page><title>OntologyClass:Chancellor</title><ns>200</ns><id>329</id><revision><id>57515</id><timestamp>2022-04-24T11:25:24Z</timestamp><text>{{Class
+&lt;references/></text></revision></page><page><title>OntologyClass:Chancellor</title><ns>200</ns><id>329</id><revision><id>57515</id><timestamp>2022-04-24T11:25:24Z</timestamp><text>{{Class
 | labels =
 {{label|en|chancellor}}
 {{label|ga|seansailéir}}
@@ -2706,11 +2709,11 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 |comments =
 {{comment|ur| عروقی (نالی دار)پودے ہیں ، بیج ایک شنک میں موجود ہوتے ہیں۔ وہ لکڑی کے پودے ہیں۔}}
 {{comment|it|Le conifere sono piante vascolari, con semi contenuti in un cono. Sono piante legnose, perlopiù sono alberi e solo poche sono arbusti. 
-&lt;ref&gt;http://it.wikipedia.org/wiki/Pinophyta&lt;/ref&gt;}}
+&lt;ref>http://it.wikipedia.org/wiki/Pinophyta&lt;/ref>}}
 {{comment|es|Las coníferas son plantas vasculares, con las semillas contenidas en un cono. Son plantas leñosas.}}
 }}
 == References ==
-&lt;references /&gt;</text></revision></page><page><title>OntologyClass:Constellation</title><ns>200</ns><id>4549</id><revision><id>59177</id><timestamp>2023-01-02T19:36:54Z</timestamp><text>{{Class
+&lt;references /></text></revision></page><page><title>OntologyClass:Constellation</title><ns>200</ns><id>4549</id><revision><id>59177</id><timestamp>2023-01-02T19:36:54Z</timestamp><text>{{Class
 | rdfs:subClassOf = CelestialBody
 | labels = 
 {{label|en|constellation}}
@@ -2726,13 +2729,13 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{label|ja|星座}}
 {{label|ko|별자리}}
 |comments =
-{{comment|it|Una costellazione è ognuna delle 88 parti in cui la sfera celeste è convenzionalmente suddivisa allo scopo di mappare le stelle.&lt;ref&gt;http://it.wikipedia.org/wiki/Costellazione&lt;/ref&gt;}}
-{{comment|ur|ایک برج 88 حصوں میں سے ہر ایک ہے جس میں ستاروں کی نقشہ سازی کے مقصد کے لئے آسمانی کرہ روایتی طور پر تقسیم کیا جاتا ہے۔&lt;ref&gt;http://it.wikipedia.org/wiki/Costellazione&lt;/ref&gt;}}
+{{comment|it|Una costellazione è ognuna delle 88 parti in cui la sfera celeste è convenzionalmente suddivisa allo scopo di mappare le stelle.&lt;ref>http://it.wikipedia.org/wiki/Costellazione&lt;/ref>}}
+{{comment|ur|ایک برج 88 حصوں میں سے ہر ایک ہے جس میں ستاروں کی نقشہ سازی کے مقصد کے لئے آسمانی کرہ روایتی طور پر تقسیم کیا جاتا ہے۔&lt;ref>http://it.wikipedia.org/wiki/Costellazione&lt;/ref>}}
 
 | owl:equivalentClass = wikidata:Q8928
 }}
 == References ==
-&lt;references /&gt;</text></revision></page><page><title>OntologyClass:Contest</title><ns>200</ns><id>8060</id><revision><id>57626</id><timestamp>2022-04-24T18:12:48Z</timestamp><text>{{Class
+&lt;references /></text></revision></page><page><title>OntologyClass:Contest</title><ns>200</ns><id>8060</id><revision><id>57626</id><timestamp>2022-04-24T18:12:48Z</timestamp><text>{{Class
 | labels =
 {{label|en|contest}}
 {{label|ga|comórtas}}
@@ -2761,11 +2764,11 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 | owl:equivalentClass = schema:Continent
 |comments =
 {{comment|ur|براعظم زمین کا ایک بڑا علاقہ ہے جو زمین کی پرت سے نکلا ہے ، درحقیقت یہ ان سب سے بڑی تقسیم ہے جس کے ساتھ ابھرتی ہوئی زمینیں تقسیم کی گئی ہیں۔}}
-{{comment|it|Un continente è una grande area di terra emersa della crosta terrestre, è anzi la più vasta delle ripartizioni con le quali si suddividono le terre emerse.&lt;ref&gt;http://it.wikipedia.org/wiki/Continente&lt;/ref&gt;}}
+{{comment|it|Un continente è una grande area di terra emersa della crosta terrestre, è anzi la più vasta delle ripartizioni con le quali si suddividono le terre emerse.&lt;ref>http://it.wikipedia.org/wiki/Continente&lt;/ref>}}
 {{comment|es|Un continente es una gran área de tierra emergida de la costra terrestre.}}
 }}
 == References ==
-&lt;references /&gt;</text></revision></page><page><title>OntologyClass:ControlledDesignationOfOriginWine</title><ns>200</ns><id>5831</id><revision><id>59179</id><timestamp>2023-01-02T19:51:43Z</timestamp><text>{{Class
+&lt;references /></text></revision></page><page><title>OntologyClass:ControlledDesignationOfOriginWine</title><ns>200</ns><id>5831</id><revision><id>59179</id><timestamp>2023-01-02T19:51:43Z</timestamp><text>{{Class
 | labels = 
 {{label|en|Controlled designation of origin wine}}
 {{label|ur|معیاری شراب کے لئے اصل کا سرٹیفکیٹ}}
@@ -3196,13 +3199,13 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{label|ur|سجاوٹ}}
 |comments =
 {{comment|ur|ایک شے ، جیسے تمغہ یا آرڈر ، جو وصول کنندہ کو عزت سے نوازنے کے لیے دیا جاتا ہے۔}}
-  {{comment|en|An object, such as a medal or an order, that is awarded to honor the recipient ostentatiously.&lt;ref name="decoration"&gt;http://en.wikipedia.org/wiki/Decoration&lt;/ref&gt;}}
-  {{comment|it|Per onorificenza si intende un segno di onore che viene concesso da un'autorità in riconoscimento di particolari atti benemeriti.&lt;ref name="onorificenza"&gt;http://it.wikipedia.org/wiki/Onorificenza&lt;/ref&gt;}}
-  {{comment|fr|Une distinction honorifique en reconnaissance d'un service civil ou militaire .&lt;ref name="décoration"&gt;http://fr.wikipedia.org/wiki/D%C3%A9coration_%28honorifique%29&lt;/ref&gt;}}
+  {{comment|en|An object, such as a medal or an order, that is awarded to honor the recipient ostentatiously.&lt;ref name="decoration">http://en.wikipedia.org/wiki/Decoration&lt;/ref>}}
+  {{comment|it|Per onorificenza si intende un segno di onore che viene concesso da un'autorità in riconoscimento di particolari atti benemeriti.&lt;ref name="onorificenza">http://it.wikipedia.org/wiki/Onorificenza&lt;/ref>}}
+  {{comment|fr|Une distinction honorifique en reconnaissance d'un service civil ou militaire .&lt;ref name="décoration">http://fr.wikipedia.org/wiki/D%C3%A9coration_%28honorifique%29&lt;/ref>}}
 | rdfs:subClassOf = Award
 }}
 ==References==
-&lt;references/&gt;</text></revision></page><page><title>OntologyClass:Deity</title><ns>200</ns><id>6672</id><revision><id>59147</id><timestamp>2023-01-02T08:55:02Z</timestamp><text>{{Class
+&lt;references/></text></revision></page><page><title>OntologyClass:Deity</title><ns>200</ns><id>6672</id><revision><id>59147</id><timestamp>2023-01-02T08:55:02Z</timestamp><text>{{Class
 | labels =
 {{label|en|deity}}
 {{label|de|Gottheit}}
@@ -3501,9 +3504,9 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{label|ur|ماہر معاشیات}}
 
 |comments =
-  {{comment|en|An economist is a professional in the social science discipline of economics.&lt;ref name="Economist"&gt;http://en.wikipedia.org/wiki/Economist&lt;/ref&gt;}}
-  {{comment|fr|Le terme d’économiste désigne une personne experte en science économique.&lt;ref name="Économiste"&gt;http://fr.wikipedia.org/wiki/%C3%89conomiste&lt;/ref&gt;}}
-  {{comment|es|Un economista es un profesional de las ciencias sociales experto en economía teórica o aplicada.&lt;ref name="Economista"&gt;http://es.wikipedia.org/wiki/Economista&lt;/ref&gt;}}
+  {{comment|en|An economist is a professional in the social science discipline of economics.&lt;ref name="Economist">http://en.wikipedia.org/wiki/Economist&lt;/ref>}}
+  {{comment|fr|Le terme d’économiste désigne une personne experte en science économique.&lt;ref name="Économiste">http://fr.wikipedia.org/wiki/%C3%89conomiste&lt;/ref>}}
+  {{comment|es|Un economista es un profesional de las ciencias sociales experto en economía teórica o aplicada.&lt;ref name="Economista">http://es.wikipedia.org/wiki/Economista&lt;/ref>}}
 
   {{comment|ur|ایک ماہر معاشیات معاشیات کے سماجی سائنس کے شعبے میں پیشہ ور ہوتا ہے}}
 | rdfs:subClassOf = Person
@@ -3511,7 +3514,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 }}
 
 == References ==
-&lt;references/&gt;</text></revision></page><page><title>OntologyClass:EducationalInstitution</title><ns>200</ns><id>355</id><revision><id>54957</id><timestamp>2021-09-09T09:39:30Z</timestamp><text>{{Class
+&lt;references/></text></revision></page><page><title>OntologyClass:EducationalInstitution</title><ns>200</ns><id>355</id><revision><id>54957</id><timestamp>2021-09-09T09:39:30Z</timestamp><text>{{Class
 | labels =
 {{label|en|educational institution}}
 {{label|da|uddannelsesinstitution}}
@@ -4623,7 +4626,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
   {{ comment|el|Περιγράφει την κιθάρα}}
   {{ comment|ur|ایک تار والا میوزیکل آلہ ، جس میں فنگر فنگر بورڈ ہوتا ہے ، عام طور پر کٹے ہوئے اطراف ، اور چھ یا بارہ تار ، انگلیوں یا پلیکٹرم سے توڑنے یا جھومنے سے بجائے جاتے ہیں۔}}
 | rdfs:subClassOf = Instrument
-&lt;!--| owl:sameAs = &lt;http://www.semanticweb.org/ontologies/2011/3/InstrumentOntology.owl#Guitar&gt;--&gt;
+&lt;!--| owl:sameAs = &lt;http://www.semanticweb.org/ontologies/2011/3/InstrumentOntology.owl#Guitar>-->
 | owl:equivalentClass = wikidata:Q6607
 }}</text></revision></page><page><title>OntologyClass:Guitarist</title><ns>200</ns><id>8178</id><revision><id>56104</id><timestamp>2021-11-05T11:11:02Z</timestamp><text>{{Class
 | labels =
@@ -4875,7 +4878,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 | owl:equivalentClass = wikidata:Q1445650
 }}
 
-&lt;references/&gt;</text></revision></page><page><title>OntologyClass:HollywoodCartoon</title><ns>200</ns><id>6103</id><revision><id>55970</id><timestamp>2021-09-18T06:39:45Z</timestamp><text>{{Class
+&lt;references/></text></revision></page><page><title>OntologyClass:HollywoodCartoon</title><ns>200</ns><id>6103</id><revision><id>55970</id><timestamp>2021-09-18T06:39:45Z</timestamp><text>{{Class
 | labels = 
 {{label|en|hollywood cartoon}}
 {{label|nl|Hollywood cartoon}}
@@ -5147,7 +5150,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 تمام آلات موسیقی کو بیان کرتا ہے}}
 | rdfs:subClassOf = Device, schema:Product
 | owl:equivalentClass = wikidata:Q225829
-}}</text></revision></page><page><title>OntologyClass:Instrumentalist</title><ns>200</ns><id>7753</id><revision><id>59181</id><timestamp>2023-01-02T20:11:21Z</timestamp><text>{{Class
+}}</text></revision></page><page><title>OntologyClass:Instrumentalist</title><ns>200</ns><id>7753</id><revision><id>59722</id><timestamp>2024-07-27T21:43:02Z</timestamp><text>{{Class
 | labels =
 {{label|en|instrumentalist}}
 {{label|ga|ionstraimí}}
@@ -5157,6 +5160,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{label|ur|سازندہ}}
 {{label|el|μουσικός}}
 {{label|ja|音楽家}}
+{{lable|am|የሙዚቃ መሣሪያ ተጫዋች}}
 | rdfs:subClassOf = MusicalArtist
 | comments =
 {{comment|el|Ο μουσικός είναι ένα άτομο το οποίο γράφει, ερμηνεύει, ή κάνει μουσική.}}
@@ -5296,7 +5300,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 | specificProperties = {{SpecificProperty | ontologyProperty = shoreLength | unit = kilometre }}
                        {{SpecificProperty | ontologyProperty = areaOfCatchment | unit = squareKilometre }}
                        {{SpecificProperty | ontologyProperty = volume | unit = cubicMetre }}
-}}</text></revision></page><page><title>OntologyClass:Language</title><ns>200</ns><id>392</id><revision><id>56213</id><timestamp>2022-02-15T18:24:17Z</timestamp><text>{{Class
+}}</text></revision></page><page><title>OntologyClass:Language</title><ns>200</ns><id>392</id><revision><id>59706</id><timestamp>2024-07-27T18:45:20Z</timestamp><text>{{Class
 | labels =
 	{{label|en|language}}
 {{label|ur|زبان}}
@@ -5310,6 +5314,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 	{{label|fr|langage}}
 	{{label|ko|언어}}
 	{{label|ja|言語}}
+    {{label|am|ቋንቋ}}
 | owl:equivalentClass = schema:Language, wikidata:Q315
 | rdfs:subClassOf = owl:Thing
 }}</text></revision></page><page><title>OntologyClass:LatterDaySaint</title><ns>200</ns><id>13572</id><revision><id>56214</id><timestamp>2022-02-15T18:26:54Z</timestamp><text>{{Class
@@ -5411,7 +5416,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{comment|en|A letter from the alphabet.}}
 {{comment|fr|Ene lettre de l'alphabet.}}
 | rdfs:subClassOf = WrittenWork
-&lt;!--	| rdfs:subClassOf = Language --&gt;
+&lt;!--	| rdfs:subClassOf = Language -->
 | owl:equivalentClass = wikidata:Q9788, wikidata:Q133492
 }}</text></revision></page><page><title>OntologyClass:Library</title><ns>200</ns><id>2934</id><revision><id>56236</id><timestamp>2022-02-15T19:04:47Z</timestamp><text>{{Class
 | labels =
@@ -5427,7 +5432,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{label|ko|도서관}}
 {{label|nl|bibliotheek}}
 {{label|pl|biblioteka}}
-| rdfs:subClassOf = EducationalInstitution &lt;!-- , Building --&gt;
+| rdfs:subClassOf = EducationalInstitution &lt;!-- , Building -->
 | owl:equivalentClass = schema:Library, wikidata:Q7075
 }}</text></revision></page><page><title>OntologyClass:Lieutenant</title><ns>200</ns><id>2331</id><revision><id>58547</id><timestamp>2022-05-14T20:32:44Z</timestamp><text>{{Class
 | labels =
@@ -5473,12 +5478,12 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{label|el|ανάλαφρο μυθιστόρημα}}
 | rdfs:subClassOf = Novel
 | comments =
-{{comment|en|A style of Japanese novel&lt;ref name="light novel"&gt;http://en.wikipedia.org/wiki/Light_novel&lt;/ref&gt;}}
-{{comment|ur|جاپانی ناول کا ایک انداز&lt;ref name="light novel"&gt;http://en.wikipedia.org/wiki/Light_novel&lt;/ref&gt;}}
+{{comment|en|A style of Japanese novel&lt;ref name="light novel">http://en.wikipedia.org/wiki/Light_novel&lt;/ref>}}
+{{comment|ur|جاپانی ناول کا ایک انداز&lt;ref name="light novel">http://en.wikipedia.org/wiki/Light_novel&lt;/ref>}}
 | owl:equivalentClass = wikidata:Q747381
 }}
 ==References==
-&lt;references/&gt;</text></revision></page><page><title>OntologyClass:Lighthouse</title><ns>200</ns><id>395</id><revision><id>56247</id><timestamp>2022-02-16T07:45:44Z</timestamp><text>{{Class
+&lt;references/></text></revision></page><page><title>OntologyClass:Lighthouse</title><ns>200</ns><id>395</id><revision><id>56247</id><timestamp>2022-02-16T07:45:44Z</timestamp><text>{{Class
 | labels =
 {{label|de|Leuchtturm}}
 {{label|en|lighthouse}}
@@ -5594,7 +5599,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{label|nl|locomotief}}
 {{label|ja|機関車}}
 &lt;!-- | specificProperties =
-    {{SpecificProperty | ontologyProperty = modelLineVehicle}} --&gt;
+    {{SpecificProperty | ontologyProperty = modelLineVehicle}} -->
 | rdfs:subClassOf = MeanOfTransportation, schema:Product
 | owl:equivalentClass = wikidata:Q93301
 }}</text></revision></page><page><title>OntologyClass:LunarCrater</title><ns>200</ns><id>396</id><revision><id>56962</id><timestamp>2022-03-09T09:20:15Z</timestamp><text>{{Class
@@ -5686,14 +5691,14 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{label|el|κινούμενα σχέδια}}
 | rdfs:subClassOf = Comic
 | comments =
-{{comment|en|Manga are comics created in Japan&lt;ref name="manga"&gt;http://en.wikipedia.org/wiki/Manga&lt;/ref&gt;}}
-{{comment|ur|منگا جاپان میں تخلیق کردہ کامکس ہیں&lt;ref name="manga"&gt;http://en.wikipedia.org/wiki/Manga&lt;/ref&gt;}}
+{{comment|en|Manga are comics created in Japan&lt;ref name="manga">http://en.wikipedia.org/wiki/Manga&lt;/ref>}}
+{{comment|ur|منگا جاپان میں تخلیق کردہ کامکس ہیں&lt;ref name="manga">http://en.wikipedia.org/wiki/Manga&lt;/ref>}}
 
-{{comment|nl|Manga is het Japanse equivalent van het stripverhaal&lt;ref name="manga"&gt;http://nl.wikipedia.org/wiki/Manga_(strip&lt;/ref&gt;}}
+{{comment|nl|Manga is het Japanse equivalent van het stripverhaal&lt;ref name="manga">http://nl.wikipedia.org/wiki/Manga_(strip&lt;/ref>}}
 | owl:equivalentClass = wikidata:Q8274
 }}
 ==References==
-&lt;references/&gt;</text></revision></page><page><title>OntologyClass:Manhua</title><ns>200</ns><id>5819</id><revision><id>57986</id><timestamp>2022-05-06T07:59:29Z</timestamp><text>{{Class
+&lt;references/></text></revision></page><page><title>OntologyClass:Manhua</title><ns>200</ns><id>5819</id><revision><id>57986</id><timestamp>2022-05-06T07:59:29Z</timestamp><text>{{Class
 | labels =
     {{label|en|manhua}}
     {{label|de|manhua}}
@@ -5704,16 +5709,16 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
     {{label|fr|manhua}}
 | rdfs:subClassOf = Comic
 | comments =
-    {{comment|en|Comics originally produced in China&lt;ref name="manhua"&gt;http://en.wikipedia.org/wiki/Manhua&lt;/ref&gt;}}
+    {{comment|en|Comics originally produced in China&lt;ref name="manhua">http://en.wikipedia.org/wiki/Manhua&lt;/ref>}}
 {{comment|ur|کامکس اصل میں چین میں تیار کیے گئے تھے}}
-    {{comment|fr|Bandes dessinées produites initialement en Chine&lt;ref  name="manhua"&gt;http://en.wikipedia.org/wiki/Manhua&lt;/ref&gt;}}
-    {{comment|de|Außerhalb Chinas wird der Begriff für Comics aus China verwendet.&lt;ref  name="manhua"&gt;http://de.wikipedia.org/wiki/Manhua&lt;/ref&gt;}}
+    {{comment|fr|Bandes dessinées produites initialement en Chine&lt;ref  name="manhua">http://en.wikipedia.org/wiki/Manhua&lt;/ref>}}
+    {{comment|de|Außerhalb Chinas wird der Begriff für Comics aus China verwendet.&lt;ref  name="manhua">http://de.wikipedia.org/wiki/Manhua&lt;/ref>}}
     {{comment|nl|Manhua is het Chinese equivalent van het stripverhaal}}
-    {{comment|el|Κόμικς που παράγονται αρχικά στην Κίνα&lt;ref  name="manhua"&gt;http://en.wikipedia.org/wiki/Manhua&lt;/ref&gt;}}
+    {{comment|el|Κόμικς που παράγονται αρχικά στην Κίνα&lt;ref  name="manhua">http://en.wikipedia.org/wiki/Manhua&lt;/ref>}}
 | owl:equivalentClass = wikidata:Q754669
 }}
 ==References==
-&lt;references/&gt;</text></revision></page><page><title>OntologyClass:Manhwa</title><ns>200</ns><id>5818</id><revision><id>57705</id><timestamp>2022-04-26T11:26:47Z</timestamp><text>{{Class
+&lt;references/></text></revision></page><page><title>OntologyClass:Manhwa</title><ns>200</ns><id>5818</id><revision><id>57705</id><timestamp>2022-04-26T11:26:47Z</timestamp><text>{{Class
 | labels =
 {{label|en|manhwa}}
 {{label|nl|manhwa}}
@@ -5723,16 +5728,16 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{label|ur|منحوا}}
 | rdfs:subClassOf = Comic
 | comments =
-{{comment|en|Korean term for comics and print cartoons&lt;ref name="manhwa"&gt;http://en.wikipedia.org/wiki/Manhwa&lt;/ref&gt;}}
-{{comment|ur|مزاحیہ اور پرنٹ کارٹونز کے لیے کورین اصطلاح&lt;ref name="manhwa"&gt;http://en.wikipedia.org/wiki/Manhwa&lt;/ref&gt;}}
+{{comment|en|Korean term for comics and print cartoons&lt;ref name="manhwa">http://en.wikipedia.org/wiki/Manhwa&lt;/ref>}}
+{{comment|ur|مزاحیہ اور پرنٹ کارٹونز کے لیے کورین اصطلاح&lt;ref name="manhwa">http://en.wikipedia.org/wiki/Manhwa&lt;/ref>}}
 
-{{comment|de|ist die in der westlichen Welt verbreitete Bezeichnung für Comics aus Südkorea.&lt;ref name="manhwa"&gt;http://de.wikipedia.org/wiki/Manhwa&lt;/ref&gt;}}
+{{comment|de|ist die in der westlichen Welt verbreitete Bezeichnung für Comics aus Südkorea.&lt;ref name="manhwa">http://de.wikipedia.org/wiki/Manhwa&lt;/ref>}}
 {{comment|nl|Manhua is het Koreaanse equivalent van het stripverhaal}}
 {{comment|el|Κορεάτικος όρος για τα κόμικς και τα κινούμενα σχέδια εκτύπωσης}}
 | owl:equivalentClass = wikidata:Q562214
 }}
 ==References==
-&lt;references/&gt;</text></revision></page><page><title>OntologyClass:Manor</title><ns>200</ns><id>12327</id><revision><id>56631</id><timestamp>2022-02-27T05:09:50Z</timestamp><text>{{Class
+&lt;references/></text></revision></page><page><title>OntologyClass:Manor</title><ns>200</ns><id>12327</id><revision><id>56631</id><timestamp>2022-02-27T05:09:50Z</timestamp><text>{{Class
 | labels =
 {{label|en|Manor}}
 {{label|ur|جاگیر
@@ -5744,7 +5749,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 | comments =
 {{comment|en|Estate and/or (cluster of) lands that are under the jurisdiction of a feudal lord. Hence it is also the shorthand expression for the physical estate itself: a manor is a stately house in the countryside with the surrounding grounds}}
 | rdfs:subClassOf = HistoricalAreaOfAuthority
-| dcterms:references = &lt;http://nl.dbpedia.org/resource/Heerlijkheid_(bestuursvorm)&gt; , &lt;http://en.dbpedia.org/resource/Manor&gt; , &lt;http://fr.dbpedia.org/resource/Seigneurie&gt; , &lt;http://de.dbpedia.org/resource/Grundherrschaft&gt; , &lt;http://ru.dbpedia.org/resource/%D0%A0%D1%8B%D1%86%D0%B0%D1%80%D1%81%D0%BA%D0%B0%D1%8F_%D0%BC%D1%8B%D0%B7%D0%B0&gt; .
+| dcterms:references = &lt;http://nl.dbpedia.org/resource/Heerlijkheid_(bestuursvorm)> , &lt;http://en.dbpedia.org/resource/Manor> , &lt;http://fr.dbpedia.org/resource/Seigneurie> , &lt;http://de.dbpedia.org/resource/Grundherrschaft> , &lt;http://ru.dbpedia.org/resource/%D0%A0%D1%8B%D1%86%D0%B0%D1%80%D1%81%D0%BA%D0%B0%D1%8F_%D0%BC%D1%8B%D0%B7%D0%B0> .
 }}</text></revision></page><page><title>OntologyClass:MartialArtist</title><ns>200</ns><id>4123</id><revision><id>57990</id><timestamp>2022-05-06T10:17:53Z</timestamp><text>{{Class
 | labels =
 {{label|en|martial artist}}
@@ -5763,7 +5768,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{comment|ur|ریاضی کے تصورات، جیسے فبونیکی نمبرز، خیالی نمبرز، سمیٹری}}
 {{comment|fr|Concepts mathématiques tels que les nombres de Fibonacci, les nombres imaginaires, la symétrie}}
 | rdfs:subClassOf = TopicalConcept
-}}</text></revision></page><page><title>OntologyClass:Mayor</title><ns>200</ns><id>400</id><revision><id>57898</id><timestamp>2022-05-05T10:57:46Z</timestamp><text>{{Class
+}}</text></revision></page><page><title>OntologyClass:Mayor</title><ns>200</ns><id>400</id><revision><id>59761</id><timestamp>2024-08-05T00:07:31Z</timestamp><text>{{Class
 | labels =
 {{label|en|mayor}}
 {{label|ur| شہر کا منتظم }}
@@ -5773,6 +5778,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{label|ja|首長}}
 {{label|el|δήμαρχος}}
 {{label|nl|burgemeester}}
+{{label|am|ከንቲባ}}
 | rdfs:subClassOf = Politician
 | owl:equivalentClass = wikidata:Q30185
 }}</text></revision></page><page><title>OntologyClass:MeanOfTransportation</title><ns>200</ns><id>401</id><revision><id>57375</id><timestamp>2022-03-31T12:56:20Z</timestamp><text>{{Class
@@ -6052,14 +6058,14 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{label|nl|mineraal}}
 {{label|ko|광물}}
 | comments =
-{{comment|en|A naturally occurring solid chemical substance.&lt;ref&gt;http://en.wikipedia.org/wiki/Mineral&lt;/ref&gt;}}
+{{comment|en|A naturally occurring solid chemical substance.&lt;ref>http://en.wikipedia.org/wiki/Mineral&lt;/ref>}}
 {{comment|ur|قدرتی طور پر پائے جانے والا ٹھوس کیمیائی مادہ}}
-{{comment|it|Corpi naturali inorganici, in genere solidi.&lt;ref&gt;http://it.wikipedia.org/wiki/Minerale&lt;/ref&gt;}}
+{{comment|it|Corpi naturali inorganici, in genere solidi.&lt;ref>http://it.wikipedia.org/wiki/Minerale&lt;/ref>}}
 | rdfs:subClassOf = ChemicalSubstance
 | owl:equivalentClass = wikidata:Q7946
 }}
 ==References==
-&lt;references/&gt;</text></revision></page><page><title>OntologyClass:Minister</title><ns>200</ns><id>11947</id><revision><id>56554</id><timestamp>2022-02-18T03:26:10Z</timestamp><text>{{Class
+&lt;references/></text></revision></page><page><title>OntologyClass:Minister</title><ns>200</ns><id>11947</id><revision><id>56554</id><timestamp>2022-02-18T03:26:10Z</timestamp><text>{{Class
 | labels =
 {{label|en|minister}}
 {{label|de|Minister}}
@@ -6159,20 +6165,20 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{label|ja|僧院}}
 {{label|ur|خانقاہ}}
 |comments=
-{{comment|en|Monastery denotes the building, or complex of buildings, comprising the domestic quarters and workplace(s) of monastics, whether monks or nuns, and whether living in community or alone (hermits). The monastery generally includes a place reserved for prayer which may be a chapel, church or temple, and may also serve as an oratory.&lt;ref&gt;http://en.wikipedia.org/wiki/Monastry&lt;/ref&gt;}}
+{{comment|en|Monastery denotes the building, or complex of buildings, comprising the domestic quarters and workplace(s) of monastics, whether monks or nuns, and whether living in community or alone (hermits). The monastery generally includes a place reserved for prayer which may be a chapel, church or temple, and may also serve as an oratory.&lt;ref>http://en.wikipedia.org/wiki/Monastry&lt;/ref>}}
 
-{{comment|ur|خانقاہ عمارت، یا عمارتوں کے کمپلیکس کی نشاندہی کرتی ہے، جس میں خانقاہوں کے گھریلو کوارٹرز اور کام کی جگہیں شامل ہیں، چاہے وہ راہب ہوں یا راہبائیں، اور چاہے وہ برادری میں رہ رہے ہوں یا اکیلے (حرمت والے)۔ خانقاہ میں عام طور پر نماز کے لیے مخصوص جگہ شامل ہوتی ہے جو ایک چیپل، گرجا گھر یا مندر ہو سکتا ہے، اور ایک تقریر کے طور پر بھی کام کر سکتا ہے۔&lt;ref&gt;http://en.wikipedia.org/wiki/Monastry&lt;/ref&gt;}}
-{{comment|ca|Un monestir és un tipus d'edificació per a la reclusió dels religiosos, que hi viuen en comú. Originàriament un monestir era la cel·la d'un sol monjo, dit en aquest cas ermità o anacoreta.&lt;ref&gt;https://ca.wikipedia.org/wiki/Monestir&lt;/ref&gt;}}
-{{comment|el|Μονή υποδηλώνει το κτίριο ή συγκρότημα κτιρίων, που αποτελείται από τις εγχώρια τρίμηνα και στο χώρο εργασίας (ες) των μοναχών, αν οι μοναχοί ή μοναχές, και αν ζουν στην κοινότητα ή μεμονωμένα (ερημίτες). Η μονή περιλαμβάνει γενικά ένα χώρο που προορίζεται για την προσευχή που μπορεί να είναι ένα παρεκκλήσι, εκκλησία ή ναό, και μπορεί επίσης να χρησιμεύσει ως μια ρητορική.&lt;ref&gt;https://el.wikipedia.org/wiki/%CE%9C%CE%BF%CE%BD%CE%B1%CF%83%CF%84%CE%AE%CF%81%CE%B9_(%CE%B8%CF%81%CE%B7%CF%83%CE%BA%CE%B5%CE%AF%CE%B1)&lt;/ref&gt;}}
-{{comment|fr|Le monastère est un ensemble de bâtiments où habite une communauté religieuse de moines ou de moniales.&lt;ref&gt;http://fr.wikipedia.org/wiki/Monast%C3%A8re&lt;/ref&gt;.}}
-{{comment|ga|Is pobal manaigh ina gcónaí faoi móideanna reiligiúnach í mainistir.&lt;ref&gt;https://ga.wikipedia.org/wiki/Mainistir&lt;/ref&gt;}}
-{{comment|nl|Een klooster (van het Latijnse claustrum, afgesloten ruimte) is een gebouw of een samenstel van gebouwen dat dient tot huisvesting van een groep of gemeenschap van mannen of vrouwen, vaak monniken of monialen genoemd, die zich uit de wereld heeft teruggetrokken om een godsdienstig leven te leiden.&lt;ref&gt;http://nl.wikipedia.org/wiki/Klooster_%28gebouw%29&lt;/ref&gt;}}
-{{comment|pl|Klasztor – budynek lub zespół budynków, w którym mieszkają wspólnoty religijne zakonników albo zakonnic.&lt;ref&gt;https://pl.wikipedia.org/wiki/Klasztor&lt;/ref&gt;}}
+{{comment|ur|خانقاہ عمارت، یا عمارتوں کے کمپلیکس کی نشاندہی کرتی ہے، جس میں خانقاہوں کے گھریلو کوارٹرز اور کام کی جگہیں شامل ہیں، چاہے وہ راہب ہوں یا راہبائیں، اور چاہے وہ برادری میں رہ رہے ہوں یا اکیلے (حرمت والے)۔ خانقاہ میں عام طور پر نماز کے لیے مخصوص جگہ شامل ہوتی ہے جو ایک چیپل، گرجا گھر یا مندر ہو سکتا ہے، اور ایک تقریر کے طور پر بھی کام کر سکتا ہے۔&lt;ref&gt;http://en.wikipedia.org/wiki/Monastry&lt;/ref>}}
+{{comment|ca|Un monestir és un tipus d'edificació per a la reclusió dels religiosos, que hi viuen en comú. Originàriament un monestir era la cel·la d'un sol monjo, dit en aquest cas ermità o anacoreta.&lt;ref>https://ca.wikipedia.org/wiki/Monestir&lt;/ref>}}
+{{comment|el|Μονή υποδηλώνει το κτίριο ή συγκρότημα κτιρίων, που αποτελείται από τις εγχώρια τρίμηνα και στο χώρο εργασίας (ες) των μοναχών, αν οι μοναχοί ή μοναχές, και αν ζουν στην κοινότητα ή μεμονωμένα (ερημίτες). Η μονή περιλαμβάνει γενικά ένα χώρο που προορίζεται για την προσευχή που μπορεί να είναι ένα παρεκκλήσι, εκκλησία ή ναό, και μπορεί επίσης να χρησιμεύσει ως μια ρητορική.&lt;ref>https://el.wikipedia.org/wiki/%CE%9C%CE%BF%CE%BD%CE%B1%CF%83%CF%84%CE%AE%CF%81%CE%B9_(%CE%B8%CF%81%CE%B7%CF%83%CE%BA%CE%B5%CE%AF%CE%B1)&lt;/ref>}}
+{{comment|fr|Le monastère est un ensemble de bâtiments où habite une communauté religieuse de moines ou de moniales.&lt;ref>http://fr.wikipedia.org/wiki/Monast%C3%A8re&lt;/ref>.}}
+{{comment|ga|Is pobal manaigh ina gcónaí faoi móideanna reiligiúnach í mainistir.&lt;ref>https://ga.wikipedia.org/wiki/Mainistir&lt;/ref>}}
+{{comment|nl|Een klooster (van het Latijnse claustrum, afgesloten ruimte) is een gebouw of een samenstel van gebouwen dat dient tot huisvesting van een groep of gemeenschap van mannen of vrouwen, vaak monniken of monialen genoemd, die zich uit de wereld heeft teruggetrokken om een godsdienstig leven te leiden.&lt;ref>http://nl.wikipedia.org/wiki/Klooster_%28gebouw%29&lt;/ref>}}
+{{comment|pl|Klasztor – budynek lub zespół budynków, w którym mieszkają wspólnoty religijne zakonników albo zakonnic.&lt;ref>https://pl.wikipedia.org/wiki/Klasztor&lt;/ref>}}
 | rdfs:subClassOf = ReligiousBuilding
 | owl:equivalentClass = wikidata:Q44613, d0:Location
 }}
 
-&lt;references /&gt;</text></revision></page><page><title>OntologyClass:MonoclonalAntibody</title><ns>200</ns><id>11918</id><revision><id>57941</id><timestamp>2022-05-05T14:27:46Z</timestamp><text>{{Class
+&lt;references /></text></revision></page><page><title>OntologyClass:MonoclonalAntibody</title><ns>200</ns><id>11918</id><revision><id>57941</id><timestamp>2022-05-05T14:27:46Z</timestamp><text>{{Class
 | labels =
 {{label|de|monoklonaler Antikörper}}
 {{label|en|monoclonal antibody}}
@@ -6215,20 +6221,20 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{label|ur|مسجد}}
 
 | comments =
-{{comment|en|A mosque, sometimes spelt mosk, is a place of worship for followers of Islam.&lt;ref&gt;http://en.wikipedia.org/wiki/Mosque&lt;/ref&gt;}}
-{{comment|ur|  ایک مسجد اسلام کے پیروکاروں کے لیے عبادت گاہ ہے۔&lt;ref&gt;http://en.wikipedia.org/wiki/Mosque&lt;/ref&gt;}}
+{{comment|en|A mosque, sometimes spelt mosk, is a place of worship for followers of Islam.&lt;ref>http://en.wikipedia.org/wiki/Mosque&lt;/ref>}}
+{{comment|ur|  ایک مسجد اسلام کے پیروکاروں کے لیے عبادت گاہ ہے۔&lt;ref>http://en.wikipedia.org/wiki/Mosque&lt;/ref>}}
 
 
 {{comment|el|Το τζαμί είναι ο τόπος λατρείας των Μουσουλμάνων.}}
-{{comment|fr|Une mosquée est un lieu de culte où se rassemblent les musulmans pour les prières communes.&lt;ref&gt;http://fr.wikipedia.org/wiki/Mosquée&lt;/ref&gt;}}
-{{comment|ga|Is áit adhartha na Moslamach, lucht leanúna an reiligiúin Ioslam, é mosc&lt;ref&gt;https://ga.wikipedia.org/wiki/Mosc&lt;/ref&gt;}}
-{{comment|pl|Meczet – miejsce kultu muzułmańskiego&lt;ref&gt;https://pl.wikipedia.org/wiki/Meczet&lt;/ref&gt;}}
+{{comment|fr|Une mosquée est un lieu de culte où se rassemblent les musulmans pour les prières communes.&lt;ref>http://fr.wikipedia.org/wiki/Mosquée&lt;/ref>}}
+{{comment|ga|Is áit adhartha na Moslamach, lucht leanúna an reiligiúin Ioslam, é mosc&lt;ref>https://ga.wikipedia.org/wiki/Mosc&lt;/ref>}}
+{{comment|pl|Meczet – miejsce kultu muzułmańskiego&lt;ref>https://pl.wikipedia.org/wiki/Meczet&lt;/ref>}}
 | rdfs:subClassOf = ReligiousBuilding
 | owl:equivalentClass = wikidata:Q32815
 }}
 
 == references ==
-&lt;references/&gt;</text></revision></page><page><title>OntologyClass:Moss</title><ns>200</ns><id>410</id><revision><id>57944</id><timestamp>2022-05-05T14:31:19Z</timestamp><text>{{Class
+&lt;references/></text></revision></page><page><title>OntologyClass:Moss</title><ns>200</ns><id>410</id><revision><id>57944</id><timestamp>2022-05-05T14:31:19Z</timestamp><text>{{Class
 | labels =
 {{label|en|moss}}
 {{label|ur|کائی}}
@@ -6301,7 +6307,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{label|nl|motorsportseizoen}}
 {{label|de|Motorsportsaison}}
 | rdfs:subClassOf = SportsSeason
-}}</text></revision></page><page><title>OntologyClass:Mountain</title><ns>200</ns><id>411</id><revision><id>56609</id><timestamp>2022-02-27T04:38:32Z</timestamp><text>{{Class
+}}</text></revision></page><page><title>OntologyClass:Mountain</title><ns>200</ns><id>411</id><revision><id>59760</id><timestamp>2024-08-05T00:05:51Z</timestamp><text>{{Class
 | labels =
 {{label|en|mountain}}
 {{label|ga|sliabh}}
@@ -6315,6 +6321,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{label|pt|montanha}}
 {{label|ja|山}}
 {{label|zh|山}}
+{{label|am|ተራራ}}
 | rdfs:subClassOf = NaturalPlace
 | owl:equivalentClass = schema:Mountain, wikidata:Q8502
 | owl:disjointWith = Person
@@ -6542,7 +6549,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{label|ko| 뮤지컬}}
 | rdfs:subClassOf = MusicalWork
 | owl:equivalentClass = wikidata:Q2743
-}}</text></revision></page><page><title>OntologyClass:MusicalArtist</title><ns>200</ns><id>415</id><revision><id>54931</id><timestamp>2021-09-09T08:09:18Z</timestamp><text>
+}}</text></revision></page><page><title>OntologyClass:MusicalArtist</title><ns>200</ns><id>415</id><revision><id>59723</id><timestamp>2024-07-27T21:44:09Z</timestamp><text>
 {{Class
 | labels =
 	{{label|en|musical artist}}
@@ -6553,6 +6560,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 	{{label|el|μουσικός}}
 	{{label|ko|음악가 }}
 	{{label|ja|音楽家}}
+    {{label|am|የሙዚቃ አርቲስት}}
 {{label|ur|موسیقی کا فنکار}}
 | rdfs:subClassOf = Artist, schema:MusicGroup, dul:NaturalPerson
 }}</text></revision></page><page><title>OntologyClass:MusicalWork</title><ns>200</ns><id>416</id><revision><id>55995</id><timestamp>2021-09-18T07:54:29Z</timestamp><text>{{Class
@@ -6575,7 +6583,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{label|el|μυθικό πλάσμα}}
 {{label|it|figura mitologica}}
 {{label|nl|mythologisch figuur}}
-| rdfs:subClassOf = FictionalCharacter &lt;!-- this is not always correct --&gt;
+| rdfs:subClassOf = FictionalCharacter &lt;!-- this is not always correct -->
 | owl:equivalentClass = wikidata:Q15410431
 }}</text></revision></page><page><title>OntologyClass:NCAATeamSeason</title><ns>200</ns><id>6071</id><revision><id>58586</id><timestamp>2022-05-15T06:51:47Z</timestamp><text>{{Class
 | labels =
@@ -6839,15 +6847,15 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{label|ur|افسانه}}
 | rdfs:subClassOf = book
 | comments =
-{{comment|ur| ادبی نثر میں طویل داستان کی کتاب&gt;http://en.wikipedia.org/wiki/Novel&lt;/ref&gt;}}
+{{comment|ur| ادبی نثر میں طویل داستان کی کتاب>http://en.wikipedia.org/wiki/Novel&lt;/ref>}}
 
-{{comment|en| A book of long narrative in literary prose&lt;ref name="novel"&gt;http://en.wikipedia.org/wiki/Novel&lt;/ref&gt;}}
+{{comment|en| A book of long narrative in literary prose&lt;ref name="novel">http://en.wikipedia.org/wiki/Novel&lt;/ref>}}
 {{comment|el|Ένα βιβλίο με μεγάλη αφήγηση σε λογοτεχνική πρόζα}}
-{{comment|fr|Le roman est un genre littéraire, caractérisé pour l'essentiel par une narration fictionnelle plus ou moins longue.&lt;ref&gt;http://fr.wikipedia.org/wiki/Roman_%28litt%C3%A9rature%29&lt;/ref&gt;}}
+{{comment|fr|Le roman est un genre littéraire, caractérisé pour l'essentiel par une narration fictionnelle plus ou moins longue.&lt;ref>http://fr.wikipedia.org/wiki/Roman_%28litt%C3%A9rature%29&lt;/ref>}}
 | owl:equivalentClass = wikidata:Q8261
 }}
 ==References==
-&lt;references/&gt;</text></revision></page><page><title>OntologyClass:NuclearPowerStation</title><ns>200</ns><id>9144</id><revision><id>56309</id><timestamp>2022-02-16T12:27:58Z</timestamp><text>{{Class
+&lt;references/></text></revision></page><page><title>OntologyClass:NuclearPowerStation</title><ns>200</ns><id>9144</id><revision><id>56309</id><timestamp>2022-02-16T12:27:58Z</timestamp><text>{{Class
 | labels =
 {{label|de|Kernkraftwerk}}
 {{label|en|Nuclear Power plant}}
@@ -7042,7 +7050,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 | rdfs:range = xsd:string
 | owl:equivalentClass = owl:Thing
 }}
---&gt;</text></revision></page><page><title>OntologyClass:PaintballLeague</title><ns>200</ns><id>2182</id><revision><id>58591</id><timestamp>2022-05-15T07:10:04Z</timestamp><text>{{Class
+--></text></revision></page><page><title>OntologyClass:PaintballLeague</title><ns>200</ns><id>2182</id><revision><id>58591</id><timestamp>2022-05-15T07:10:04Z</timestamp><text>{{Class
 | labels =
 {{label|en|paintball league}}
 {{label|de|Paintball-Liga}}
@@ -7186,7 +7194,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{comment|fr|Une publication périodique est un titre de presse qui paraît régulièrement.}}
 | rdfs:subClassOf = WrittenWork
 | owl:equivalentClass = wikidata:Q1092563
-}}</text></revision></page><page><title>OntologyClass:Person</title><ns>200</ns><id>429</id><revision><id>56079</id><timestamp>2021-10-02T16:33:47Z</timestamp><text>{{Class
+}}</text></revision></page><page><title>OntologyClass:Person</title><ns>200</ns><id>429</id><revision><id>59681</id><timestamp>2024-06-17T13:38:44Z</timestamp><text>{{Class
 | labels =
 	{{label|el|Πληροφορίες προσώπου}}
 	{{label|en|person}}
@@ -7205,6 +7213,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 	{{label|pl|osoba}}
 	{{label|hy|անձ}}
 	{{label|ar|شخص}}
+    {{label|am|ሰው}}
 | rdfs:subClassOf = Animal
 | owl:equivalentClass = foaf:Person, schema:Person, wikidata:Q215627, wikidata:Q5, dul:NaturalPerson
 | specificProperties = {{SpecificProperty | ontologyProperty = weight | unit = kilogram }}
@@ -7290,7 +7299,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 	{{label|ar|طيار}}
 {{label|ur|طیارہ اڑانے والا}}
 | rdfs:subClassOf = Person
-}}</text></revision></page><page><title>OntologyClass:Place</title><ns>200</ns><id>432</id><revision><id>56279</id><timestamp>2022-02-16T09:54:51Z</timestamp><text>{{Class
+}}</text></revision></page><page><title>OntologyClass:Place</title><ns>200</ns><id>432</id><revision><id>59694</id><timestamp>2024-06-18T09:04:27Z</timestamp><text>{{Class
 | labels =
 	{{label|en|place}}
 	{{label|ca|lloc}}
@@ -7307,6 +7316,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 	{{label|nl|plaats}}
 	{{label|ar|مكان}}
 	{{label|ur|جگہ}}
+    {{label|am|ቦታ}}
 | comments =
 	{{comment|ur|غیر متحرک چیزیں یا مقامات۔}}
 	{{comment|pt|uma localização}}
@@ -7479,7 +7489,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{comment|en|for example: Democratic_Party_(United_States)}}
 {{comment|el|για παράδειγμα: Δημοκρατικό Κόμμα _United_States)}}
 | owl:equivalentClass = wikidata:Q7278
-}}</text></revision></page><page><title>OntologyClass:Politician</title><ns>200</ns><id>437</id><revision><id>55291</id><timestamp>2021-09-11T11:25:16Z</timestamp><text>{{Class
+}}</text></revision></page><page><title>OntologyClass:Politician</title><ns>200</ns><id>437</id><revision><id>59740</id><timestamp>2024-07-27T23:59:11Z</timestamp><text>{{Class
 | labels =
 {{label|en|politician}}
 {{label|ga|polaiteoir}}
@@ -7492,6 +7502,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{label|sl|politik}}
 {{label|ja|政治家}}
 {{label|ko|정치인}}
+{{label|am|የፖለቲካ ሰው}}
 
 | rdfs:subClassOf = Person
 | owl:equivalentClass = wikidata:Q82955
@@ -8220,13 +8231,13 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
   {{label|nl|cultusgebouw}}
   {{label|ko|종교 건물}}
 | comments =
-|{{comment|en|An establishment or her location where a group of people (a congregation) comes to perform acts of religious study, honor, or devotion.&lt;ref&gt;http://en.wikipedia.org/wiki/Religious_building&lt;/ref&gt;}}
+|{{comment|en|An establishment or her location where a group of people (a congregation) comes to perform acts of religious study, honor, or devotion.&lt;ref&gt;http://en.wikipedia.org/wiki/Religious_building&lt;/ref>}}
 |{{comment|ur|ایک اسٹیبلشمنٹ یا اس کا مقام جہاں لوگوں کا ایک گروپ (ایک جماعت) مذہبی مطالعہ، عزت، یا عقیدت کے اعمال انجام دینے آتا ہے۔}}
 | rdfs:subClassOf = Building
 | owl:equivalentClass = wikidata:Q1370598
 }}
 ==References==
-&lt;references/&gt;</text></revision></page><page><title>OntologyClass:ReligiousOrganisation</title><ns>200</ns><id>10298</id><revision><id>57531</id><timestamp>2022-04-24T12:13:20Z</timestamp><text>{{Class
+&lt;references/></text></revision></page><page><title>OntologyClass:ReligiousOrganisation</title><ns>200</ns><id>10298</id><revision><id>57531</id><timestamp>2022-04-24T12:13:20Z</timestamp><text>{{Class
 | labels =
 	{{label|en|religious organisation}}
 	{{label|de|Religionsorganisation}}
@@ -8308,7 +8319,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
   {{comment|fr|Un curriculum vitae (CV) résume l'expérience d'une personne dans le travail ainsi que ses compétences.}}
   {{comment|nl|Een CV (curriculum vitae) beschrijft iemands werkervaring en vaardigheden.}}
 | rdfs:subClassOf = WrittenWork
-}}</text></revision></page><page><title>OntologyClass:River</title><ns>200</ns><id>2286</id><revision><id>59204</id><timestamp>2023-01-02T21:03:05Z</timestamp><text>{{Class
+}}</text></revision></page><page><title>OntologyClass:River</title><ns>200</ns><id>2286</id><revision><id>59717</id><timestamp>2024-07-27T20:00:22Z</timestamp><text>{{Class
 | labels =
 {{label|en|river}}
 {{label|ur|دریا}}
@@ -8320,6 +8331,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{label|pt|rio}}
 {{label|ko|강}}
 {{label|ja|川}}
+{{label|am|ወንዝ}}
 | comments =
 {{comment|en|a large natural stream}}
 {{comment|ur|ایک بڑی قدرتی ندی}}
@@ -8561,7 +8573,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{comment|ur|ایک فلکیاتی شے جو کسی سیارے یا ستارے کے گرد چکر لگاتی ہے}}
 {{comment|el|Ένα αστρονομικό αντικείμενο που βρίσκεται σε τροχιά γύρω από έναν πλανήτη ή αστέρι.}}
 | rdfs:subClassOf =  CelestialBody
-&lt;!-- | owl:equivalentClass = http://www.ontotext.com/proton/protonext#Satellite --&gt;
+&lt;!-- | owl:equivalentClass = http://www.ontotext.com/proton/protonext#Satellite -->
 }}</text></revision></page><page><title>OntologyClass:School</title><ns>200</ns><id>636</id><revision><id>56519</id><timestamp>2022-02-17T11:43:10Z</timestamp><text>{{Class
 | labels =
 {{label|en|school}}
@@ -8717,7 +8729,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 | rdfs:subClassOf = MeanOfTransportation, schema:Product
 | owl:equivalentClass = wikidata:Q11446
 }}
-&lt;!--  --&gt;</text></revision></page><page><title>OntologyClass:ShoppingMall</title><ns>200</ns><id>457</id><revision><id>56448</id><timestamp>2022-02-17T04:46:04Z</timestamp><text>{{Class
+&lt;!--  --></text></revision></page><page><title>OntologyClass:ShoppingMall</title><ns>200</ns><id>457</id><revision><id>56448</id><timestamp>2022-02-17T04:46:04Z</timestamp><text>{{Class
 |labels=
 {{label|en|shopping mall}}
 {{label|ga|ionad siopadóireachta}}
@@ -8744,7 +8756,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 
 | rdfs:subClassOf = ReligiousBuilding
 | owl:equivalentClass = wikidata:Q697295
-}}</text></revision></page><page><title>OntologyClass:Singer</title><ns>200</ns><id>9427</id><revision><id>57121</id><timestamp>2022-03-12T22:29:35Z</timestamp><text>{{Class
+}}</text></revision></page><page><title>OntologyClass:Singer</title><ns>200</ns><id>9427</id><revision><id>59724</id><timestamp>2024-07-27T21:45:38Z</timestamp><text>{{Class
 | labels          = {{label|en|Singer}}
 {{label|ga|amhránaí}}
 {{label|de|Sänger}}
@@ -8753,6 +8765,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{label|nl|zanger}}
 {{label|ja|歌手}}
 {{label|ur|گلوکار}}
+{{label|am|ድምጻዊ}}
 | comments        = 
   {{comment|en|a person who sings.}}
   {{comment|fr|Tout chanteur(euse) (incluant soliste et choriste, interprète, chanteur-instrumentaliste, etc). Tout artiste solo qui compose et/ou fait partie d'un groupe.}}
@@ -8847,7 +8860,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 
 {{label|ur|ہوا میں چھلانگ لگانے والا}}
 | rdfs:subClassOf =  WinterSportPlayer
-&lt;!-- | owl:equivalentClass = wikidata:Q15117302 --&gt;
+&lt;!-- | owl:equivalentClass = wikidata:Q15117302 -->
 }}</text></revision></page><page><title>OntologyClass:Skier</title><ns>200</ns><id>6213</id><revision><id>56454</id><timestamp>2022-02-17T06:12:21Z</timestamp><text>{{Class
 | labels = {{label|en|skier}}
 {{label|ga|sciálaí}}
@@ -8934,7 +8947,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{comment|en|The official world ranking in snooker for a certain year/season}}
 {{comment|ur|ایک مخصوص سال/سیزن کے لیے سنوکر میں آفیشل عالمی درجہ بندی}}
 {{comment|de|Die offizielle Weltrangliste im Snooker eines Jahres / einer Saison}}
-| rdfs:subClassOf =  SportCompetitionResult &lt;!-- dul:Role --&gt;
+| rdfs:subClassOf =  SportCompetitionResult &lt;!-- dul:Role -->
 }}</text></revision></page><page><title>OntologyClass:SoapCharacter</title><ns>200</ns><id>6096</id><revision><id>59150</id><timestamp>2023-01-02T09:00:11Z</timestamp><text>{{Class
 | labels = 
     {{label|en|soap character}}
@@ -8948,7 +8961,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
   {{comment|en|Character of soap - radio or television serial frequently characterized by melodrama, ensemble casts, and sentimentality.}}
   {{comment|fr|Personnage de feuilleton mélodramatique ou sentimental pour la radio ou la télévision.}}
 | rdfs:subClassOf = FictionalCharacter
-}}</text></revision></page><page><title>OntologyClass:SoccerClub</title><ns>200</ns><id>462</id><revision><id>58630</id><timestamp>2022-05-15T08:34:07Z</timestamp><text>{{Class
+}}</text></revision></page><page><title>OntologyClass:SoccerClub</title><ns>200</ns><id>462</id><revision><id>59753</id><timestamp>2024-07-28T23:32:41Z</timestamp><text>{{Class
 | labels =
 {{label|en|soccer club}}
 {{label|ca|club de futbol}}
@@ -8961,6 +8974,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{label|nl|voetbalclub}}
 {{label|pl|klub piłkarski}}
 {{label|ur|فٹ بال  تنظیم}}
+{{label|am|የእግር ኳስ ቡድን}}
 | rdfs:subClassOf = SportsClub
 
 
@@ -9101,7 +9115,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{comment|el|Έκλειψη ηλίου ονομάζεται το φαινόμενο κατά το οποίο η Σελήνη παρεμβάλλεται ανάμεσα στον Ήλιο και τη Γη, με αποτέλεσμα ορισμένες περιοχές της Γης να δέχονται λιγότερο φως από ό,τι συνήθως.}}
 {{comment|ur|سورج گرہن ایک ایسا واقعہ ہے جس میں چاند سورج اور زمین کے درمیان مداخلت کرتا ہے، جس کی وجہ سے زمین کے کچھ علاقوں کو معمول سے کم روشنی ملتی ہے}}
 | owl:equivalentClass = wikidata:Q3887
-}}</text></revision></page><page><title>OntologyClass:Song</title><ns>200</ns><id>465</id><revision><id>55658</id><timestamp>2021-09-17T06:49:18Z</timestamp><text>{{Class
+}}</text></revision></page><page><title>OntologyClass:Song</title><ns>200</ns><id>465</id><revision><id>59765</id><timestamp>2024-08-05T07:00:22Z</timestamp><text>{{Class
 | labels =
 {{label|en|song}}
 {{label|ga|amhrán}}
@@ -9114,7 +9128,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{label|ko|노래}}
 {{label|ja|歌}}
 {{label|ur|گانا}}
-
+{{label|am|ዘፈን}}
 | rdfs:subClassOf = MusicalWork, schema:MusicRecording
 | owl:equivalentClass = 
 }}</text></revision></page><page><title>OntologyClass:SongWriter</title><ns>200</ns><id>9426</id><revision><id>56420</id><timestamp>2022-02-16T18:17:16Z</timestamp><text>{{Class
@@ -9239,7 +9253,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{comment|ur|درجہ بندی کے نظام میں ایک زمرہ}}
 {{comment|en|A category in the rating system}}
 | rdfs:subClassOf = owl:Thing
-&lt;!-- dul:Organism --&gt;
+&lt;!-- dul:Organism -->
 }}</text></revision></page><page><title>OntologyClass:SpeedSkater</title><ns>200</ns><id>11169</id><revision><id>56461</id><timestamp>2022-02-17T06:21:36Z</timestamp><text>{{Class
 | labels = 
 {{label|en|speed skater}}
@@ -9495,7 +9509,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
   {{label|ru|Звездное скопление}}
 | owl:disjointWith = Person
 | rdfs:subClassOf = owl:Thing
-}}</text></revision></page><page><title>OntologyClass:State</title><ns>200</ns><id>7030</id><revision><id>56577</id><timestamp>2022-02-18T04:03:35Z</timestamp><text>{{Class
+}}</text></revision></page><page><title>OntologyClass:State</title><ns>200</ns><id>7030</id><revision><id>59769</id><timestamp>2024-08-05T07:50:09Z</timestamp><text>{{Class
 | labels =
 {{label|en|state}}
 {{label|el|πολιτεία}}
@@ -9504,6 +9518,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{label|nl|staat}}
 {{label|ja|州}}
 {{label|ur|ریاست}}
+{{label|am|ስቴት}}
 | rdfs:subClassOf = PopulatedPlace
 | owl:equivalentClass = wikidata:Q7275
 }}</text></revision></page><page><title>OntologyClass:StatedResolution</title><ns>200</ns><id>9126</id><revision><id>58849</id><timestamp>2022-06-20T13:06:28Z</timestamp><text>{{Class
@@ -9705,15 +9720,15 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{label|ur|یہودیوں کی عبادت گاہ}}
 
 | comments =
-{{comment|en|A synagogue, sometimes spelt synagog, is a Jewish or Samaritan house of prayer.&lt;ref&gt;http://en.wikipedia.org/wiki/Synagogue&lt;/ref&gt;}}
-{{comment|fr|Une synagogue est un lieu de culte juif.&lt;ref&gt;http://fr.wikipedia.org/wiki/Synagogue&lt;/ref&gt;}}
+{{comment|en|A synagogue, sometimes spelt synagog, is a Jewish or Samaritan house of prayer.&lt;ref>http://en.wikipedia.org/wiki/Synagogue&lt;/ref>}}
+{{comment|fr|Une synagogue est un lieu de culte juif.&lt;ref>http://fr.wikipedia.org/wiki/Synagogue&lt;/ref>}}
 {{comment|ur|یہودیوں کی عبادت گاہ، ایک یہودی یا سامری نماز کا گھر ہے۔}}
 | rdfs:subClassOf = ReligiousBuilding
 | owl:equivalentClass = wikidata:Q34627
 }}
 
 == references ==
-&lt;references/&gt;</text></revision></page><page><title>OntologyClass:SystemOfLaw</title><ns>200</ns><id>6603</id><revision><id>45813</id><timestamp>2015-03-14T12:16:24Z</timestamp><text>{{Class
+&lt;references/></text></revision></page><page><title>OntologyClass:SystemOfLaw</title><ns>200</ns><id>6603</id><revision><id>45813</id><timestamp>2015-03-14T12:16:24Z</timestamp><text>{{Class
 | labels=
 {{label|en|System of law}}
 {{label|el|σύστημα δικαίου}}
@@ -10082,7 +10097,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{comment|en|a settlement ranging from a few hundred to several thousand (occasionally hundreds of thousands). The precise meaning varies between countries and is not always a matter of legal definition. Usually, a town is thought of as larger than a village but smaller than a city, though there are exceptions to this rule.}}
 {{comment|ur|چند سو سے لے کر کئی ہزار (کبھی کبھار سیکڑوں ہزاروں) تک کی تصفیہ۔ درست معنی ممالک کے درمیان مختلف ہوتے ہیں اور یہ ہمیشہ قانونی تعریف کا معاملہ نہیں ہوتا ہے۔ عام طور پر، ایک قصبہ کو گاؤں سے بڑا لیکن شہر سے چھوٹا سمجھا جاتا ہے، حالانکہ اس اصول میں مستثنیات ہیں}}
 | owl:equivalentClass = wikidata:Q3957
-}}</text></revision></page><page><title>OntologyClass:TrackList</title><ns>200</ns><id>7162</id><revision><id>58281</id><timestamp>2022-05-13T12:04:33Z</timestamp><text>{{Class
+}}</text></revision></page><page><title>OntologyClass:TrackList</title><ns>200</ns><id>7162</id><revision><id>59763</id><timestamp>2024-08-05T06:29:34Z</timestamp><text>{{Class
 | labels =
 {{label|en|track list}}
 {{label|ur|موسیقی کے ریکارڈوں کی فہرست}}
@@ -10090,6 +10105,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{label|el|λίστα κομματιών}}
 {{label|fr|liste de pistes}}
 {{label|nl|lijst van nummers}}
+{{label|am|የዘፈኖች ዝርዝር}}
 | comments =
 {{comment|en|A list of music tracks, like on a CD}}
 {{comment|ur|میوزک ٹریکس کی فہرست، جیسے سی ڈی پر}}
@@ -10150,7 +10166,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{label|fr|station de tramway}}
 {{label|nl|tramhalte}}
 | rdfs:subClassOf = Station
-| owl:equivalentClass = &lt;http://vocab.org/transit/terms/stop&gt;
+| owl:equivalentClass = &lt;http://vocab.org/transit/terms/stop>
 }}</text></revision></page><page><title>OntologyClass:Treadmill</title><ns>200</ns><id>6315</id><revision><id>58287</id><timestamp>2022-05-13T14:11:47Z</timestamp><text>{{Class
 | labels =
 {{label|el|Μύλος}}
@@ -10611,12 +10627,12 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
   {{comment|en|A windmill is a machine that converts the energy of wind into rotational energy by means of vanes called sails}}
 {{comment|ur|ہوا کی چکی ایک مشین ہے جو ہوا کی توانائی کو سیل نامی وینز کے ذریعے گردشی توانائی میں تبدیل کرتی ہے}}
 
-  {{comment|fr|Le moulin à vent est un dispositif qui transforme l’énergie éolienne (énergie cinétique du vent) en mouvement rotatif au moyen d’ailes ajustables.&lt;ref name="moulin à vent"&gt;http://fr.wikipedia.org/wiki/Moulin_%C3%A0_vent&lt;/ref&gt;}}
+  {{comment|fr|Le moulin à vent est un dispositif qui transforme l’énergie éolienne (énergie cinétique du vent) en mouvement rotatif au moyen d’ailes ajustables.&lt;ref name="moulin à vent">http://fr.wikipedia.org/wiki/Moulin_%C3%A0_vent&lt;/ref>}}
 | owl:equivalentClass = wikidata:Q38720
 }}
 
 ==References==
-&lt;references/&gt;</text></revision></page><page><title>OntologyClass:Wine</title><ns>200</ns><id>5830</id><revision><id>57563</id><timestamp>2022-04-24T15:05:54Z</timestamp><text>{{Class
+&lt;references/></text></revision></page><page><title>OntologyClass:Wine</title><ns>200</ns><id>5830</id><revision><id>57563</id><timestamp>2022-04-24T15:05:54Z</timestamp><text>{{Class
 |labels=
   {{label|en|wine}}
 {{label|ga|fíon}}
@@ -10865,7 +10881,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 | rdfs:label@en = abbey church blessing charge
 | rdfs:domain = Cleric
 | rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Abbreviation</title><ns>202</ns><id>494</id><revision><id>58847</id><timestamp>2022-06-20T12:57:01Z</timestamp><text>{{DatatypeProperty
+}}</text></revision></page><page><title>OntologyProperty:Abbreviation</title><ns>202</ns><id>494</id><revision><id>59768</id><timestamp>2024-08-05T07:39:08Z</timestamp><text>{{DatatypeProperty
 | labels =
 {{label|en|abbreviation}}
 {{label|ur|مخفف}}
@@ -10877,6 +10893,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{label|mk|кратенка}}
 {{label|sr|скраћеница}}
 {{label|pl|skrót}}
+{{label|am| ምዕጻረ ቃል}}
 | rdfs:domain = owl:Thing
 | rdfs:range = xsd:string
 | owl:equivalentProperty = wikidata:P743
@@ -11536,13 +11553,14 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 	{{label|el|από το άλμπουμ}}
 | rdfs:range = Album
 | rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:AlbumRuntime</title><ns>202</ns><id>7864</id><revision><id>52832</id><timestamp>2018-02-08T20:14:33Z</timestamp><text>{{Merge|duration}}
+}}</text></revision></page><page><title>OntologyProperty:AlbumRuntime</title><ns>202</ns><id>7864</id><revision><id>59725</id><timestamp>2024-07-27T21:48:30Z</timestamp><text>{{Merge|duration}}
 
 {{DatatypeProperty
 | labels =
 {{label|en|album duration}}
 {{label|de|Album Länge}}
 {{label|sr|трајање албума}}
+{{label|am|የአልበም ርዝመት}}
 | rdfs:domain = Album
 | rdfs:range = Time
 | owl:equivalentProperty = 
@@ -11603,6 +11621,14 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 | rdfs:label@sr = уз
 | rdfs:range = Person
 | rdfs:subPropertyOf = dul:sameSettingAs
+}}</text></revision></page><page><title>OntologyProperty:Alphabet</title><ns>202</ns><id>14448</id><revision><id>59713</id><timestamp>2024-07-27T19:34:42Z</timestamp><text>{{ObjectProperty
+| labels =
+	{{label|en|alphabet}}
+    {{label|am|ፊደል}}
+| comments = 
+    {{comment|en|A set of characters used to represent the phonemic structure of a language}}
+    {{comment|am|የቋንቋውን የአጻጻፍ መዋቅር}}
+| rdfs:domain = Language
 }}</text></revision></page><page><title>OntologyProperty:AlpsGroup</title><ns>202</ns><id>5696</id><revision><id>35814</id><timestamp>2014-07-08T12:40:53Z</timestamp><text>
 {{ObjectProperty
 | rdfs:domain = Mountain
@@ -11611,11 +11637,11 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 | rdfs:label@el = ομάδα των άλπεων
 | rdfs:label@it = gruppo alpino
 | rdfs:label@sr = алпска група
-| rdfs:comment@en = the Alps group to which the mountain belongs, according to the SOIUSA classification&lt;ref name="alpsMainPart"&gt;http://en.wikipedia.org/wiki/SOIUSA&lt;/ref&gt;
+| rdfs:comment@en = the Alps group to which the mountain belongs, according to the SOIUSA classification&lt;ref name="alpsMainPart">http://en.wikipedia.org/wiki/SOIUSA&lt;/ref>
 | rdfs:subPropertyOf = dul:hasLocation
 }}
 ==References==
-&lt;references/&gt;</text></revision></page><page><title>OntologyProperty:AlpsMainPart</title><ns>202</ns><id>5680</id><revision><id>35815</id><timestamp>2014-07-08T12:41:01Z</timestamp><text>
+&lt;references/></text></revision></page><page><title>OntologyProperty:AlpsMainPart</title><ns>202</ns><id>5680</id><revision><id>35815</id><timestamp>2014-07-08T12:41:01Z</timestamp><text>
 {{ObjectProperty
 | rdfs:domain = Mountain
 | rdfs:range = MountainRange
@@ -11623,11 +11649,11 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 | rdfs:label@el = κύριο μέρος των άλπεων
 | rdfs:label@it = grande parte alpina
 | rdfs:label@sr = главни део Алпа
-| rdfs:comment@en = the Alps main part to which the mountain belongs, according to the SOIUSA classification&lt;ref name="alpsMainPart"&gt;http://en.wikipedia.org/wiki/SOIUSA&lt;/ref&gt;
+| rdfs:comment@en = the Alps main part to which the mountain belongs, according to the SOIUSA classification&lt;ref name="alpsMainPart">http://en.wikipedia.org/wiki/SOIUSA&lt;/ref>
 | rdfs:subPropertyOf = dul:hasLocation
 }}
 ==References==
-&lt;references/&gt;</text></revision></page><page><title>OntologyProperty:AlpsMajorSector</title><ns>202</ns><id>5692</id><revision><id>35816</id><timestamp>2014-07-08T12:41:08Z</timestamp><text>
+&lt;references/></text></revision></page><page><title>OntologyProperty:AlpsMajorSector</title><ns>202</ns><id>5692</id><revision><id>35816</id><timestamp>2014-07-08T12:41:08Z</timestamp><text>
 {{ObjectProperty
 | rdfs:domain = Mountain
 | rdfs:range = MountainRange
@@ -11635,11 +11661,11 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 | rdfs:label@sr = главни Алпски сектор
 | rdfs:label@el = σημαντικότερος τομέας των άλπεων
 | rdfs:label@it = grande settore alpino
-| rdfs:comment@en = the Alps major sector to which the mountain belongs, according to the SOIUSA classification&lt;ref name="alpsMainPart"&gt;http://en.wikipedia.org/wiki/SOIUSA&lt;/ref&gt;
+| rdfs:comment@en = the Alps major sector to which the mountain belongs, according to the SOIUSA classification&lt;ref name="alpsMainPart">http://en.wikipedia.org/wiki/SOIUSA&lt;/ref>
 | rdfs:subPropertyOf = dul:hasLocation
 }}
 ==References==
-&lt;references/&gt;</text></revision></page><page><title>OntologyProperty:AlpsSection</title><ns>202</ns><id>5693</id><revision><id>35817</id><timestamp>2014-07-08T12:41:16Z</timestamp><text>
+&lt;references/></text></revision></page><page><title>OntologyProperty:AlpsSection</title><ns>202</ns><id>5693</id><revision><id>35817</id><timestamp>2014-07-08T12:41:16Z</timestamp><text>
 {{ObjectProperty
 | rdfs:domain = Mountain
 | rdfs:range = MountainRange
@@ -11647,21 +11673,21 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 | rdfs:label@el = τμήμα των άλπεων
 | rdfs:label@sr = Алпска секција
 | rdfs:label@it = sezione alpina
-| rdfs:comment@en = the Alps section to which the mountain belongs, according to the SOIUSA classification&lt;ref name="alpsMainPart"&gt;http://en.wikipedia.org/wiki/SOIUSA&lt;/ref&gt;
+| rdfs:comment@en = the Alps section to which the mountain belongs, according to the SOIUSA classification&lt;ref name="alpsMainPart">http://en.wikipedia.org/wiki/SOIUSA&lt;/ref>
 | rdfs:subPropertyOf = dul:hasLocation
 }}
 ==References==
-&lt;references/&gt;</text></revision></page><page><title>OntologyProperty:AlpsSoiusaCode</title><ns>202</ns><id>5698</id><revision><id>30488</id><timestamp>2014-01-21T13:55:26Z</timestamp><text>{{DatatypeProperty
+&lt;references/></text></revision></page><page><title>OntologyProperty:AlpsSoiusaCode</title><ns>202</ns><id>5698</id><revision><id>30488</id><timestamp>2014-01-21T13:55:26Z</timestamp><text>{{DatatypeProperty
 | rdfs:domain = Mountain
 | rdfs:range = xsd:string
 | rdfs:label@en = Alps SOIUSA code
 | rdfs:label@el = κώδικας SOIUSA των άλπεων 
 | rdfs:label@it = codice SOIUSA
 | rdfs:label@sr = алпски SOIUSA код
-| rdfs:comment@en = the Alps SOIUSA code corresponding to the mountain, according to the SOIUSA classification&lt;ref name="alpsMainPart"&gt;http://en.wikipedia.org/wiki/SOIUSA&lt;/ref&gt;
+| rdfs:comment@en = the Alps SOIUSA code corresponding to the mountain, according to the SOIUSA classification&lt;ref name="alpsMainPart">http://en.wikipedia.org/wiki/SOIUSA&lt;/ref>
 }}
 ==References==
-&lt;references/&gt;</text></revision></page><page><title>OntologyProperty:AlpsSubgroup</title><ns>202</ns><id>5697</id><revision><id>35818</id><timestamp>2014-07-08T12:41:38Z</timestamp><text>
+&lt;references/></text></revision></page><page><title>OntologyProperty:AlpsSubgroup</title><ns>202</ns><id>5697</id><revision><id>35818</id><timestamp>2014-07-08T12:41:38Z</timestamp><text>
 {{ObjectProperty
 | rdfs:domain = Mountain
 | rdfs:range = MountainRange
@@ -11669,11 +11695,11 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 | rdfs:label@el = υποομάδα των άλπεων
 | rdfs:label@it = sottogruppo alpino
 | rdfs:label@sr = Алпска подгрупа
-| rdfs:comment@en = the Alps subgroup to which the mountain belongs, according to the SOIUSA classification&lt;ref name="alpsMainPart"&gt;http://en.wikipedia.org/wiki/SOIUSA&lt;/ref&gt;
+| rdfs:comment@en = the Alps subgroup to which the mountain belongs, according to the SOIUSA classification&lt;ref name="alpsMainPart">http://en.wikipedia.org/wiki/SOIUSA&lt;/ref>
 | rdfs:subPropertyOf = dul:hasLocation
 }}
 ==References==
-&lt;references/&gt;</text></revision></page><page><title>OntologyProperty:AlpsSubsection</title><ns>202</ns><id>5694</id><revision><id>35819</id><timestamp>2014-07-08T12:41:47Z</timestamp><text>
+&lt;references/></text></revision></page><page><title>OntologyProperty:AlpsSubsection</title><ns>202</ns><id>5694</id><revision><id>35819</id><timestamp>2014-07-08T12:41:47Z</timestamp><text>
 {{ObjectProperty
 | rdfs:domain = Mountain
 | rdfs:range = MountainRange
@@ -11681,11 +11707,11 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 | rdfs:label@el = Alps υποδιαίρεση των άλπεων
 | rdfs:label@it = sottosezione alpina
 | rdfs:label@sr = Алпска подсекција
-| rdfs:comment@en = the Alps subsection to which the mountain belongs, according to the SOIUSA classification&lt;ref name="alpsMainPart"&gt;http://en.wikipedia.org/wiki/SOIUSA&lt;/ref&gt;
+| rdfs:comment@en = the Alps subsection to which the mountain belongs, according to the SOIUSA classification&lt;ref name="alpsMainPart">http://en.wikipedia.org/wiki/SOIUSA&lt;/ref>
 | rdfs:subPropertyOf = dul:hasLocation
 }}
 ==References==
-&lt;references/&gt;</text></revision></page><page><title>OntologyProperty:AlpsSupergroup</title><ns>202</ns><id>5695</id><revision><id>35820</id><timestamp>2014-07-08T12:41:55Z</timestamp><text>
+&lt;references/></text></revision></page><page><title>OntologyProperty:AlpsSupergroup</title><ns>202</ns><id>5695</id><revision><id>35820</id><timestamp>2014-07-08T12:41:55Z</timestamp><text>
 {{ObjectProperty
 | rdfs:domain = Mountain
 | rdfs:range = MountainRange
@@ -11693,11 +11719,11 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 | rdfs:label@el = Alps υπερομάδα
 | rdfs:label@it = supergruppo alpino
 | rdfs:label@sr = Алпска супергрупа
-| rdfs:comment@en = the Alps supergroup to which the mountain belongs, according to the SOIUSA classification&lt;ref name="alpsMainPart"&gt;http://en.wikipedia.org/wiki/SOIUSA&lt;/ref&gt;
+| rdfs:comment@en = the Alps supergroup to which the mountain belongs, according to the SOIUSA classification&lt;ref name="alpsMainPart">http://en.wikipedia.org/wiki/SOIUSA&lt;/ref>
 | rdfs:subPropertyOf = dul:hasLocation
 }}
 ==References==
-&lt;references/&gt;</text></revision></page><page><title>OntologyProperty:AlternativeName</title><ns>202</ns><id>8167</id><revision><id>57318</id><timestamp>2022-03-31T08:59:29Z</timestamp><text>{{DatatypeProperty
+&lt;references/></text></revision></page><page><title>OntologyProperty:AlternativeName</title><ns>202</ns><id>8167</id><revision><id>57318</id><timestamp>2022-03-31T08:59:29Z</timestamp><text>{{DatatypeProperty
 | labels =
   {{label|en|alternative name}}
   {{label|fr|autre nom}}
@@ -11731,7 +11757,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 | rdfs:domain = Work
 | rdfs:range = rdf:langString
 | owl:equivalentProperty = schema:alternativeTitle
-}}</text></revision></page><page><title>OntologyProperty:Altitude</title><ns>202</ns><id>7921</id><revision><id>53775</id><timestamp>2020-10-19T17:21:23Z</timestamp><text>{{ObjectProperty
+}}</text></revision></page><page><title>OntologyProperty:Altitude</title><ns>202</ns><id>7921</id><revision><id>59689</id><timestamp>2024-06-18T08:25:54Z</timestamp><text>{{ObjectProperty
 | labels =
 {{label|en|altitude}}
 {{label|de|Höhe}}
@@ -12139,7 +12165,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 | rdfs:label@sr = рурална област
 | rdfs:domain = PopulatedPlace
 | rdfs:range = Area
-}}</text></revision></page><page><title>OntologyProperty:AreaTotal</title><ns>202</ns><id>556</id><revision><id>59650</id><timestamp>2024-06-04T21:17:07Z</timestamp><text>{{DatatypeProperty
+}}</text></revision></page><page><title>OntologyProperty:AreaTotal</title><ns>202</ns><id>556</id><revision><id>59691</id><timestamp>2024-06-18T08:28:52Z</timestamp><text>{{DatatypeProperty
 | labels =
 {{label|de|Fläche}}
 {{label|en|area total}}
@@ -12147,7 +12173,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{label|el|έκταση περιοχής}}
 {{label|fr|superficie}}
 {{label|sr|укупна површина}}
-{{label|am|የመሬት ስፋት}}
+{{label|am|ጠቅላላ የመሬት ስፋት}}
 | rdfs:domain = Place
 | rdfs:range = Area
 | owl:equivalentProperty=wikidata:P2046
@@ -12234,11 +12260,11 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 | comments =
 	{{comment|en|An influential, wealthy person who supported an artist, craftsman, a scholar or a noble.
 {{comment|ur|ایک بااثر، دولت مند شخص جس نے کسی فنکار، کاریگر، عالم یا بزرگ کی حمایت کی۔}}
-&lt;ref&gt;http://en.wiktionary.org/wiki/patron&lt;/ref&gt;. See also&lt;ref&gt;http://en.wikipedia.org/wiki/Patronage&lt;/ref&gt;}}
-	{{comment|fr|Celui qui encourage par ses libéralités les sciences, les lettres et les arts.&lt;ref&gt;http://fr.wiktionary.org/wiki/m%C3%A9c%C3%A8ne&lt;/ref&gt;}}
+&lt;ref>http://en.wiktionary.org/wiki/patron&lt;/ref>. See also&lt;ref>http://en.wikipedia.org/wiki/Patronage&lt;/ref>}}
+	{{comment|fr|Celui qui encourage par ses libéralités les sciences, les lettres et les arts.&lt;ref>http://fr.wiktionary.org/wiki/m%C3%A9c%C3%A8ne&lt;/ref>}}
 | rdfs:subPropertyOf = dul:sameSettingAs
 }}
-&lt;references/&gt;</text></revision></page><page><title>OntologyProperty:Artery</title><ns>202</ns><id>563</id><revision><id>35836</id><timestamp>2014-07-08T12:44:25Z</timestamp><text>
+&lt;references/></text></revision></page><page><title>OntologyProperty:Artery</title><ns>202</ns><id>563</id><revision><id>35836</id><timestamp>2014-07-08T12:44:25Z</timestamp><text>
 {{ObjectProperty
 | rdfs:label@en = artery
 | rdfs:label@de = Arterie
@@ -12252,7 +12278,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{label|en|artificial snow area}}
 | rdfs:domain = Place
 | rdfs:range = xsd:float
-}}</text></revision></page><page><title>OntologyProperty:Artist</title><ns>202</ns><id>564</id><revision><id>59041</id><timestamp>2022-06-21T17:38:18Z</timestamp><text>
+}}</text></revision></page><page><title>OntologyProperty:Artist</title><ns>202</ns><id>564</id><revision><id>59762</id><timestamp>2024-08-05T06:25:05Z</timestamp><text>
 {{ObjectProperty
 | labels =
 	{{label|de|Interpret}}
@@ -12262,6 +12288,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 	{{label|es|intérprete}}
 	{{label|fr|interprète}}
 	{{label|nl|artiest}}
+	{{label|am|አርቲስት}}
 {{label|ur|فنکار}}
 	{{label|pl|wykonawca}}
 | comments = 
@@ -12505,18 +12532,18 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{label|pl|liczba atomowa}}
 {{label|ur|جوہری عدد}}
 | comments = 
-{{comment|en|the ratio of the average mass of atoms of an element (from a single given sample or source) to 1⁄12 of the mass of an atom of carbon-12&lt;ref&gt;https://en.wikipedia.org/wiki/Atomic_number&lt;/ref&gt;}}
+{{comment|en|the ratio of the average mass of atoms of an element (from a single given sample or source) to 1⁄12 of the mass of an atom of carbon-12&lt;ref>https://en.wikipedia.org/wiki/Atomic_number&lt;/ref>}}
 {{comment|ur|کسی عنصر کے ایٹموں کی اوسط کمیت کا تناسب (ایک دیے گئے نمونے یا ماخذ سے) کاربن 12 کے ایٹم کے بڑے پیمانے پر}}
-{{comment|nl|het atoomnummer of atoomgetal (symbool: Z) geeft het aantal protonen in de kern van een atoom aan.&lt;ref&gt;https://nl.wikipedia.org/wiki/Atoomnummer&lt;/ref&gt;}}
-{{comment|de|die Anzahl der Protonen im Atomkern eines chemischen Elements, deshalb auch Protonenzahl.&lt;ref&gt;https://de.wikipedia.org/wiki/Ordnungszahl&lt;/ref&gt;}}
-{{comment|ga|Is eard is uimhir adamhach (Z) adaimh ann ná líon na bprótón i núicléas an adaimh sin&lt;ref&gt;https://ga.wikipedia.org/wiki/Uimhir_adamhach&lt;/ref&gt;}}
-{{comment|pl|liczba określająca, ile protonów znajduje się w jądrze danego atomu&lt;ref&gt;https://pl.wikipedia.org/wiki/Liczba_atomowa&lt;/ref&gt;}}
+{{comment|nl|het atoomnummer of atoomgetal (symbool: Z) geeft het aantal protonen in de kern van een atoom aan.&lt;ref>https://nl.wikipedia.org/wiki/Atoomnummer&lt;/ref>}}
+{{comment|de|die Anzahl der Protonen im Atomkern eines chemischen Elements, deshalb auch Protonenzahl.&lt;ref>https://de.wikipedia.org/wiki/Ordnungszahl&lt;/ref>}}
+{{comment|ga|Is eard is uimhir adamhach (Z) adaimh ann ná líon na bprótón i núicléas an adaimh sin&lt;ref>https://ga.wikipedia.org/wiki/Uimhir_adamhach&lt;/ref>}}
+{{comment|pl|liczba określająca, ile protonów znajduje się w jądrze danego atomu&lt;ref>https://pl.wikipedia.org/wiki/Liczba_atomowa&lt;/ref>}}
 | rdfs:domain = ChemicalElement
 | rdfs:range = xsd:nonNegativeInteger
 | owl:equivalentProperty = wikidata:P1086
 }}
 
-&lt;references/&gt;</text></revision></page><page><title>OntologyProperty:AttorneyGeneral</title><ns>202</ns><id>6601</id><revision><id>35850</id><timestamp>2014-07-08T12:46:43Z</timestamp><text>
+&lt;references/></text></revision></page><page><title>OntologyProperty:AttorneyGeneral</title><ns>202</ns><id>6601</id><revision><id>35850</id><timestamp>2014-07-08T12:46:43Z</timestamp><text>
 {{ObjectProperty
 | labels =
 	{{label|en|attorney general}}
@@ -12683,8 +12710,8 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{label|en| Average size of the revision per month }}
 {{label|fr| Taille moyenne des révisions par mois}}
 | comments =
-{{comment|en| used for DBpedia History &gt; Subject must be a blank node containing a dc:date and a rdfs:value  }}
-{{comment|fr| utilisé par DBpedia Historique &gt; Le sujet de cette relation doit être un noeud blanc contenant une  dc:date et une rdfs:value  }}
+{{comment|en| used for DBpedia History > Subject must be a blank node containing a dc:date and a rdfs:value  }}
+{{comment|fr| utilisé par DBpedia Historique > Le sujet de cette relation doit être un noeud blanc contenant une  dc:date et une rdfs:value  }}
 | rdfs:domain = prov:Entity
 | rdfs:range = xsd:anyURI
 }}</text></revision></page><page><title>OntologyProperty:AvgRevSizePerYear</title><ns>202</ns><id>14285</id><revision><id>59132</id><timestamp>2022-12-02T11:59:04Z</timestamp><text>{{DatatypeProperty
@@ -12692,8 +12719,8 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{label|en| Average size of the revision per year }}
 {{label|fr| Taille moyenne des révisions par année}}
 | comments =
-{{comment|en| used for DBpedia History &gt; Subject must be a blank node containing a dc:date and a rdfs:value  }}
-{{comment|fr| utilisé par DBpedia Historique &gt; Le sujet de cette relation doit être un noeud blanc contenant une  dc:date et une rdfs:value  }}
+{{comment|en| used for DBpedia History > Subject must be a blank node containing a dc:date and a rdfs:value  }}
+{{comment|fr| utilisé par DBpedia Historique > Le sujet de cette relation doit être un noeud blanc contenant une  dc:date et une rdfs:value  }}
 | rdfs:domain = prov:Entity
 | rdfs:range = xsd:anyURI
 }}</text></revision></page><page><title>OntologyProperty:AvifaunaPopulation</title><ns>202</ns><id>7102</id><revision><id>25626</id><timestamp>2013-05-26T13:38:35Z</timestamp><text>{{DatatypeProperty
@@ -12701,7 +12728,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{label|en|avifauna population}}
 | rdfs:domain = Place
 | rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Award</title><ns>202</ns><id>585</id><revision><id>59001</id><timestamp>2022-06-21T10:21:51Z</timestamp><text>{{ObjectProperty
+}}</text></revision></page><page><title>OntologyProperty:Award</title><ns>202</ns><id>585</id><revision><id>59678</id><timestamp>2024-06-17T06:54:48Z</timestamp><text>{{ObjectProperty
 | labels =
 	{{label|en|award}}
 	{{label|nl|onderscheiding}}
@@ -12709,7 +12736,8 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 	{{label|el|διακρίσεις}}
 	{{label|de|Auszeichnung}}
 	{{label|ja|受賞}}
-        {{label|ur|انعام}}
+    {{label|ur|انعام}}
+    {{label|am|ሽልማት}}
 | rdfs:range = Award
 | rdfs:comment@en = Award won by a Person, Musical or other Work, RaceHorse, Building, etc
 | owl:equivalentProperty = schema:awards , wikidata:P166, rkd:Award
@@ -12812,6 +12840,17 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 | rdfs:range = Work
 | rdfs:subPropertyOf = dul:coparticipatesWith
 | owl:equivalentProperty = wikidata:P144
+}}</text></revision></page><page><title>OntologyProperty:BasinCountry</title><ns>202</ns><id>14449</id><revision><id>59720</id><timestamp>2024-07-27T20:48:59Z</timestamp><text>
+{{ObjectProperty
+| labels =
+	{{label|en|basin country}}
+    {{label|am|ተፋሰስ ሀገር}}
+| comments = 
+     {{comment|en|country that have drainage to/from or border the body of water}}
+     {{comment|am|ከውኃው አካል ጋር የሚደርስ የውሃ ፍሳሽ ወይም ድንበር ያለው ሀገር}}
+| rdfs:domain = Place
+| rdfs:range = Place
+| rdfs:subPropertyOf = dul:hasLocation
 }}</text></revision></page><page><title>OntologyProperty:Battery</title><ns>202</ns><id>11979</id><revision><id>52607</id><timestamp>2017-10-31T11:12:38Z</timestamp><text>{{ObjectProperty
 | labels = {{label|it|batteria}}
 {{label|nl|batterij}}
@@ -12829,12 +12868,13 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 | rdfs:domain = Athlete
 | rdfs:range = xsd:string
 | rdfs:comment = The side the player bats, Left, Right, or Unknown.
-}}</text></revision></page><page><title>OntologyProperty:Battle</title><ns>202</ns><id>593</id><revision><id>56995</id><timestamp>2022-03-09T12:07:13Z</timestamp><text>{{ObjectProperty
+}}</text></revision></page><page><title>OntologyProperty:Battle</title><ns>202</ns><id>593</id><revision><id>59738</id><timestamp>2024-07-27T23:56:52Z</timestamp><text>{{ObjectProperty
 | labels =
 	{{label|en|battle}}
 	{{label|fr|bataille}}
 	{{label|nl|veldslag}}
 	{{label|de|Schlacht}}
+	{{label|am|ጦርነት}}
 | rdfs:range = MilitaryConflict
 | rdfs:subPropertyOf = dul:isPartOf
 | owl:equivalentProperty = wikidata:P607
@@ -13024,7 +13064,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
    {{comment|el|Τα πτηνά είναι ζώα ομοιόθερμα σπονδυλωτά, που στη συντριπτική πλειονότητα τους μπορούν να πετούν με τις πτέρυγες ή φτερούγες τους.}}
 | rdfs:domain = Place
 | rdfs:range = Species
-}}</text></revision></page><page><title>OntologyProperty:BirthDate</title><ns>202</ns><id>604</id><revision><id>56080</id><timestamp>2021-10-02T16:36:26Z</timestamp><text>{{DatatypeProperty
+}}</text></revision></page><page><title>OntologyProperty:BirthDate</title><ns>202</ns><id>604</id><revision><id>59668</id><timestamp>2024-06-17T06:28:35Z</timestamp><text>{{DatatypeProperty
 | labels =
 {{label|en|birth date}}
 {{label|bn|জন্মদিন}}
@@ -13036,6 +13076,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{label|ja|生年月日}}
 {{label|nl|geboortedatum}}
 {{label|pl|data urodzenia}}
+{{label|am|የልደት ቀን}}
 | rdfs:domain = Animal
 | rdfs:range = xsd:date
 | rdf:type = owl:FunctionalProperty
@@ -13051,7 +13092,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 | rdfs:domain = Person
 | rdfs:range = rdf:langString
 | owl:equivalentProperty = wikidata:P1477, foaf:givenname
-}}</text></revision></page><page><title>OntologyProperty:BirthPlace</title><ns>202</ns><id>606</id><revision><id>56081</id><timestamp>2021-10-02T16:37:23Z</timestamp><text>{{ObjectProperty
+}}</text></revision></page><page><title>OntologyProperty:BirthPlace</title><ns>202</ns><id>606</id><revision><id>59669</id><timestamp>2024-06-17T06:29:27Z</timestamp><text>{{ObjectProperty
 | labels =
 	{{label|en|birth place}}
 	{{label|ca|lloc de naixement}}
@@ -13062,6 +13103,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 	{{label|ja|出生地}}
 	{{label|nl|geboorteplaats}}
 	{{label|pl|miejsce urodzenia}}
+    {{label|am|የትውልድ_ቦታ}}
 | comments =
 	{{comment|en|where the person was born}}
 | rdfs:domain = Animal
@@ -14159,7 +14201,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 	{{label|en|chief place}}
 | rdfs:range = PopulatedPlace
 | rdfs:subPropertyOf = dul:hasLocation
-}}</text></revision></page><page><title>OntologyProperty:Child</title><ns>202</ns><id>674</id><revision><id>57012</id><timestamp>2022-03-09T12:40:36Z</timestamp><text>{{ObjectProperty
+}}</text></revision></page><page><title>OntologyProperty:Child</title><ns>202</ns><id>674</id><revision><id>59680</id><timestamp>2024-06-17T10:22:25Z</timestamp><text>{{ObjectProperty
 | labels =
 	{{label|en|child}}
 	{{label|fr|enfant}}
@@ -14168,6 +14210,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 	{{label|el|παιδί}}
 	{{label|ja|子供}}
 	{{label|ar|طفل}}
+    {{label|am|ልጅ}}
 | rdfs:domain = Person
 | rdfs:range = Person
 | owl:equivalentProperty = schema:children
@@ -14236,7 +14279,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
             {{label|fr|longueur de circuit}}
 	| rdfs:domain = FormulaOneRacing
 	| rdfs:range = Length
-&lt;!--	| rdf:type = owl:FunctionalProperty --&gt;
+&lt;!--	| rdf:type = owl:FunctionalProperty -->
 }}</text></revision></page><page><title>OntologyProperty:CircuitName</title><ns>202</ns><id>5332</id><revision><id>34840</id><timestamp>2014-05-15T05:18:44Z</timestamp><text>{{ DatatypeProperty
 
 	| rdfs:label@en = circuit name
@@ -14361,13 +14404,13 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 | rdfs:range = owl:Thing
 |comments =
 {{comment|en|the living thing class (from the Latin "classis"), according to the biological taxonomy}}
-{{comment|fr|Troisième niveau de la classification classique (c’est-à-dire n’utilisant pas la notion de distance génétique) des espèces vivantes (voir systématique).&lt;ref&gt;https://fr.wikipedia.org/wiki/Classe_%28biologie%29&lt;/ref&gt;}}
+{{comment|fr|Troisième niveau de la classification classique (c’est-à-dire n’utilisant pas la notion de distance génétique) des espèces vivantes (voir systématique).&lt;ref>https://fr.wikipedia.org/wiki/Classe_%28biologie%29&lt;/ref>}}
 | owl:equivalentProperty = wikidata:P77
-&lt;!-- wrong range, find more suited property for P225| owl:equivalentProperty = wikidata:P225 --&gt;
+&lt;!-- wrong range, find more suited property for P225| owl:equivalentProperty = wikidata:P225 -->
 }}
 
 == references ==
-&lt;references/&gt;</text></revision></page><page><title>OntologyProperty:Climate</title><ns>202</ns><id>3802</id><revision><id>35936</id><timestamp>2014-07-08T13:00:12Z</timestamp><text>
+&lt;references/></text></revision></page><page><title>OntologyProperty:Climate</title><ns>202</ns><id>3802</id><revision><id>35936</id><timestamp>2014-07-08T13:00:12Z</timestamp><text>
 {{ObjectProperty
 | rdfs:label@en = climate
 | rdfs:label@pt = clima
@@ -14659,8 +14702,9 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{label|de|Zusammenarbeit}}
 | rdfs:domain = Person
 | rdfs:range = Person
-}}</text></revision></page><page><title>OntologyProperty:Colleague</title><ns>202</ns><id>10422</id><revision><id>39431</id><timestamp>2015-01-20T10:04:05Z</timestamp><text>{{ObjectProperty
+}}</text></revision></page><page><title>OntologyProperty:Colleague</title><ns>202</ns><id>10422</id><revision><id>59780</id><timestamp>2024-08-06T23:29:01Z</timestamp><text>{{ObjectProperty
 | rdfs:label@en = colleague
+| rdfs:label@am = የሥራ ባልደረባ
 | rdfs:comment@en = Colleague of a Person or OfficeHolder (not PersonFunction nor CareerStation). Sub-properties include: president, vicePresident, chancellor, viceChancellor, governor, lieutenant. Points to a Person who may have a general "position" (resource) or "title" (literal).
 | rdfs:domain = Person
 | rdfs:range = Person
@@ -15286,11 +15330,12 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 | rdfs:range = PopulatedPlace
 | rdfs:subPropertyOf = dul:hasLocation
 | owl:equivalentProperty = wikidata:P131
-}}</text></revision></page><page><title>OntologyProperty:CountySeat</title><ns>202</ns><id>3215</id><revision><id>35982</id><timestamp>2014-07-08T13:07:17Z</timestamp><text>
+}}</text></revision></page><page><title>OntologyProperty:CountySeat</title><ns>202</ns><id>3215</id><revision><id>59755</id><timestamp>2024-07-28T23:40:50Z</timestamp><text>
 {{ObjectProperty
 | labels =
 	{{label|en|county seat}}
 	{{label|nl|provincie zetel}}
+    {{label|am|ካውንቲ መቀመጫ}}
 | rdfs:domain = PopulatedPlace
 | rdfs:subPropertyOf = dul:hasLocation
 }}</text></revision></page><page><title>OntologyProperty:Course</title><ns>202</ns><id>732</id><revision><id>7938</id><timestamp>2010-05-28T12:56:18Z</timestamp><text>{{DatatypeProperty
@@ -15582,7 +15627,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 	{{label|es|actual Campeón del mundo}}
 	{{label|nl|huidig wereldkampioen}}
 | rdfs:domain = Sport
-| rdfs:range = Agent &lt;!-- it could be a country ... --&gt;
+| rdfs:range = Agent &lt;!-- it could be a country ... -->
 | rdfs:subPropertyOf = dul:hasParticipant
 }}</text></revision></page><page><title>OntologyProperty:CurrentlyUsedFor</title><ns>202</ns><id>3838</id><revision><id>26662</id><timestamp>2013-06-28T17:01:54Z</timestamp><text>{{DatatypeProperty
 | labels =
@@ -16077,7 +16122,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 | rdfs:domain = Person
 | owl:equivalentProperty = wikidata:P509
 | rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:DeathDate</title><ns>202</ns><id>765</id><revision><id>56082</id><timestamp>2021-10-02T16:38:37Z</timestamp><text>{{DatatypeProperty
+}}</text></revision></page><page><title>OntologyProperty:DeathDate</title><ns>202</ns><id>765</id><revision><id>59675</id><timestamp>2024-06-17T06:48:31Z</timestamp><text>{{DatatypeProperty
 | labels =
 {{label|en|death date}}
 {{label|de|Sterbedatum}}
@@ -16085,6 +16130,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{label|el|ημερομηνία_θανάτου}}
 {{label|ja|没年月日}}
 {{label|nl|sterfdatum}}
+{{label|am|የሞት ቀን}}
 | rdfs:domain = Animal
 | rdfs:range = xsd:date
 | rdf:type = owl:FunctionalProperty
@@ -16407,18 +16453,20 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{label|en|depths}}
 | rdfs:domain = Place
 | rdfs:range = Depth
-}}</text></revision></page><page><title>OntologyProperty:Deputy</title><ns>202</ns><id>2341</id><revision><id>36012</id><timestamp>2014-07-08T13:11:56Z</timestamp><text>
+}}</text></revision></page><page><title>OntologyProperty:Deputy</title><ns>202</ns><id>2341</id><revision><id>59739</id><timestamp>2024-07-27T23:57:29Z</timestamp><text>
 {{ObjectProperty
 | rdfs:label@en = deputy
 | rdfs:label@de = Stellvertreter
+| rdfs:label@am = ምክትል
 | rdfs:range = Person
 | rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:DeputyDirector</title><ns>202</ns><id>14436</id><revision><id>59658</id><timestamp>2024-06-05T00:14:16Z</timestamp><text>{{ObjectProperty
+}}</text></revision></page><page><title>OntologyProperty:DeputyDirector</title><ns>202</ns><id>14436</id><revision><id>59662</id><timestamp>2024-06-16T15:57:31Z</timestamp><text>{{ObjectProperty
 | labels =
 	{{label|en|deputy director}}
 	{{label|am|ምክትል ዳይሬክተር}}
 | comments =
     {{comment|en|Second in command to the Director and assumes the primary position in the absence of the Director in film making.}}
+| rdfs:domain = Film
 | rdfs:range = Person
 | rdfs:subPropertyOf = dul:coparticipatesWith
 }}</text></revision></page><page><title>OntologyProperty:Derivative</title><ns>202</ns><id>780</id><revision><id>36013</id><timestamp>2014-07-08T13:12:05Z</timestamp><text>{{DisclaimerOntologyProperty}}
@@ -16435,7 +16483,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{label|de|abgeleitetes Wort}}
 | rdfs:domain = Person
 | rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Description</title><ns>202</ns><id>5241</id><revision><id>56894</id><timestamp>2022-03-02T18:12:00Z</timestamp><text>{{ DatatypeProperty
+}}</text></revision></page><page><title>OntologyProperty:Description</title><ns>202</ns><id>5241</id><revision><id>59714</id><timestamp>2024-07-27T19:40:52Z</timestamp><text>{{ DatatypeProperty
 	| comments = 
 {{comment|en|Short description of a person}}
 {{comment|fr|description courte d'une personne}}
@@ -16445,6 +16493,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{label|el|περιγραφή}}
 {{label|de|Beschreibung}}
 {{label|nl|omschrijving}}
+{{label|am|መግለጫ}}
 	| rdfs:range = rdf:langString
         | owl:equivalentProperty = schema:description
 }}</text></revision></page><page><title>OntologyProperty:DesignCompany</title><ns>202</ns><id>781</id><revision><id>52599</id><timestamp>2017-10-31T10:21:44Z</timestamp><text>
@@ -16499,6 +16548,14 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
  |rdfs:comment@en=Department for Education (UK) number of a school in England or Wales
  |rdfs:domain=School
  |rdfs:subPropertyOf=code
+}}</text></revision></page><page><title>OntologyProperty:Dialect</title><ns>202</ns><id>14447</id><revision><id>59712</id><timestamp>2024-07-27T19:27:27Z</timestamp><text>{{ObjectProperty
+| labels =
+	{{label|en|dialect}}
+    {{label|am|ዘዬ}}
+|comments = 
+    {{comment|en|A form of the language that is spoken in a particular part of the country or by a particular group of people}}
+    {{comment|am|በአንድ የተወሰነ የአገሪቱ ክፍል ወይም በተወሰኑ የሰዎች ስብስብ የሚነገር የቋንቋ ዓይነት}}
+| rdfs:domain = Language
 }}</text></revision></page><page><title>OntologyProperty:Diameter</title><ns>202</ns><id>787</id><revision><id>52773</id><timestamp>2018-01-23T14:56:10Z</timestamp><text>{{DatatypeProperty
 | labels =
 {{label|en|diameter}}
@@ -16541,7 +16598,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 | rdfs:range = Diocese
 | rdf:type = | rdfs:subPropertyOf     = 
 | owl:equivalentProperty = 
-&lt;!--| rdfs:subPropertyOf = dul:isPartOf--&gt;
+&lt;!--| rdfs:subPropertyOf = dul:isPartOf-->
 | owl:equivalentProperty = wikidata:P708
 }}</text></revision></page><page><title>OntologyProperty:Diploma</title><ns>202</ns><id>7540</id><revision><id>33607</id><timestamp>2014-04-03T15:35:04Z</timestamp><text>{{ObjectProperty
 | labels =
@@ -16563,8 +16620,8 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 	{{label|fr|réalisateur}}
     {{label|am|ዳይሬክተር}}
 | comments =
-	{{comment|en|A film director is a person who directs the making of a film.&lt;ref&gt;https://en.wikipedia.org/wiki/Film_director&lt;/ref&gt;}}
-	{{comment|fr|Un réalisateur (au féminin, réalisatrice) est une personne qui dirige la fabrication d'une œuvre audiovisuelle, généralement pour le cinéma ou la télévision.&lt;ref&gt;https://fr.wikipedia.org/wiki/Réalisateur&lt;/ref&gt;}}
+	{{comment|en|A film director is a person who directs the making of a film.&lt;ref>https://en.wikipedia.org/wiki/Film_director&lt;/ref>}}
+	{{comment|fr|Un réalisateur (au féminin, réalisatrice) est une personne qui dirige la fabrication d'une œuvre audiovisuelle, généralement pour le cinéma ou la télévision.&lt;ref>https://fr.wikipedia.org/wiki/Réalisateur&lt;/ref>}}
 | rdfs:domain = Film
 | rdfs:range = Person
 | owl:equivalentProperty = schema:director, wikidata:P57
@@ -16573,7 +16630,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 '''Warning''': this property is used for film making. For a more general term see [[OntologyProperty:Head]].
 
 == references ==
-&lt;references/&gt;</text></revision></page><page><title>OntologyProperty:DisappearanceDate</title><ns>202</ns><id>7072</id><revision><id>58783</id><timestamp>2022-05-31T14:25:04Z</timestamp><text>{{DatatypeProperty
+&lt;references/></text></revision></page><page><title>OntologyProperty:DisappearanceDate</title><ns>202</ns><id>7072</id><revision><id>58783</id><timestamp>2022-05-31T14:25:04Z</timestamp><text>{{DatatypeProperty
 | labels =
 {{label|en|date disappearance of a populated place}}
 | rdfs:domain = PopulatedPlace
@@ -16589,11 +16646,12 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 | rdfs:label@nl = uitstoot
 | rdfs:domain = Stream
 | rdfs:range = FlowRate
-}}</text></revision></page><page><title>OntologyProperty:DischargeAverage</title><ns>202</ns><id>791</id><revision><id>32859</id><timestamp>2014-03-20T22:03:12Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = discharge average
+}}</text></revision></page><page><title>OntologyProperty:DischargeAverage</title><ns>202</ns><id>791</id><revision><id>59718</id><timestamp>2024-07-27T20:03:34Z</timestamp><text>{{DatatypeProperty
+| rdfs:label@en = discharge average 
+| rdfs:label@am = አማካኝ የፍሳሽ መጠን
 | rdfs:domain = MeanOfTransportation
 | rdfs:range = FlowRate
-}}</text></revision></page><page><title>OntologyProperty:Disciple</title><ns>202</ns><id>7338</id><revision><id>36020</id><timestamp>2014-07-08T13:13:10Z</timestamp><text>
+}}</text></revision></page><page><title>OntologyProperty:Disciple</title><ns>202</ns><id>7338</id><revision><id>59701</id><timestamp>2024-07-08T13:31:53Z</timestamp><text>
 {{ObjectProperty
 | labels =
 	{{label|en|disciple}}
@@ -16603,11 +16661,12 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 | rdfs:range = Artist
 | owl:inversePropertyOf = mentor
 | comments =
-	{{comment|en|A person who learns from another, especially one who then teaches others..&lt;ref&gt;http://en.wiktionary.org/wiki/disciple&lt;/ref&gt;}}
-	{{comment|fr|Celui qui apprend d’un maître quelque science ou quelque art libéral.&lt;ref&gt;http://fr.wiktionary.org/wiki/disciple&lt;/ref&gt;}}
+	{{comment|en|A person who learns from another, especially one who then teaches others..&lt;ref>http://en.wiktionary.org/wiki/disciple&lt;/ref>}}
+	{{comment|fr|Celui qui apprend d’un maître quelque science ou quelque art libéral.&lt;ref>http://fr.wiktionary.org/wiki/disciple&lt;/ref>}}
 | rdfs:subPropertyOf = dul:sameSettingAs
+| owl:equivalentProperty = wikidata:P802
 }}
-&lt;references/&gt;</text></revision></page><page><title>OntologyProperty:Discipline</title><ns>202</ns><id>6134</id><revision><id>47564</id><timestamp>2015-04-03T09:13:23Z</timestamp><text>{{ObjectProperty
+&lt;references/></text></revision></page><page><title>OntologyProperty:Discipline</title><ns>202</ns><id>6134</id><revision><id>47564</id><timestamp>2015-04-03T09:13:23Z</timestamp><text>{{ObjectProperty
 | labels =
 	{{label|en|discipline}}
 	{{label|de|Disziplin}}
@@ -16639,7 +16698,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 	{{label|fr|découvreur}}
 	{{label|es|descubridor}}
 | rdfs:range = Person
-| owl:equivalentProperty = wikidata:P61 &lt;!-- P61 is somehow more general : discoverer or inventor --&gt;
+| owl:equivalentProperty = wikidata:P61 &lt;!-- P61 is somehow more general : discoverer or inventor -->
 | rdfs:subPropertyOf = dul:coparticipatesWith
 }}</text></revision></page><page><title>OntologyProperty:Discovery</title><ns>202</ns><id>7059</id><revision><id>33611</id><timestamp>2014-04-03T15:35:22Z</timestamp><text>{{DatatypeProperty
 | labels =
@@ -16997,15 +17056,15 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
   {{label|nl|duur}}
 {{label|am| ቆይታ}}
 | comments =
-  {{comment|en|The duration of the item (movie, audio recording, event, etc.) in ISO 8601 date format&lt;ref name="schema:duration"&gt;http://schema.org/duration&lt;/ref&gt;}}
-  {{comment|fr|Durée d'un élément (film, enregistrement audio, événement, etc.) au format de date ISO 8601&lt;ref name="schema:duration"/&gt;}}
+  {{comment|en|The duration of the item (movie, audio recording, event, etc.) in ISO 8601 date format&lt;ref name="schema:duration">http://schema.org/duration&lt;/ref>}}
+  {{comment|fr|Durée d'un élément (film, enregistrement audio, événement, etc.) au format de date ISO 8601&lt;ref name="schema:duration"/>}}
 | rdfs:domain =
 | rdfs:range = Time
 | owl:equivalentProperty = schema:duration
 }}
 
 ==References==
-&lt;references/&gt;</text></revision></page><page><title>OntologyProperty:DutchArtworkCode</title><ns>202</ns><id>11710</id><revision><id>51311</id><timestamp>2016-06-30T08:40:50Z</timestamp><text>{{DatatypeProperty
+&lt;references/></text></revision></page><page><title>OntologyProperty:DutchArtworkCode</title><ns>202</ns><id>11710</id><revision><id>51311</id><timestamp>2016-06-30T08:40:50Z</timestamp><text>{{DatatypeProperty
 | labels =
 {{label|en|Dutch artwork code}}
 {{label|nl|code RKD}}
@@ -17057,11 +17116,12 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 | rdfs:subPropertyOf = code
 | rdfs:comment@en = Dutch Winkel ID is a code for an underground publication, as attributed by Lydia Winkel's work on the underground WW II press in the Netherlands.
 | rdfs:comment@nl = Dutch Winkel ID is een code toegekend door Lydia Winkel in haar boek over De Ondergrondse Pers 1940-1945.
-}}</text></revision></page><page><title>OntologyProperty:Dynasty</title><ns>202</ns><id>5636</id><revision><id>33628</id><timestamp>2014-04-03T16:29:22Z</timestamp><text>{{ObjectProperty
+}}</text></revision></page><page><title>OntologyProperty:Dynasty</title><ns>202</ns><id>5636</id><revision><id>59729</id><timestamp>2024-07-27T22:54:52Z</timestamp><text>{{ObjectProperty
 | labels =
 {{label|en|dynasty}}
 {{label|de|Dynastie}}
 {{label|nl|dynastie}}
+{{label|am|ሥርወ-መንግሥት}}
 | rdfs:range = owl:Thing
 }}</text></revision></page><page><title>OntologyProperty:EMedicineSubject</title><ns>202</ns><id>833</id><revision><id>39146</id><timestamp>2015-01-11T15:50:50Z</timestamp><text>{{DatatypeProperty
 | labels =
@@ -17081,11 +17141,13 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 | rdfs:label@en = e-teatr.pl id
 | rdfs:domain = Film
 | rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:EastPlace</title><ns>202</ns><id>11084</id><revision><id>45597</id><timestamp>2015-03-08T14:11:16Z</timestamp><text>{{ObjectProperty
+}}</text></revision></page><page><title>OntologyProperty:EastPlace</title><ns>202</ns><id>11084</id><revision><id>59773</id><timestamp>2024-08-05T23:55:27Z</timestamp><text>{{ObjectProperty
 | rdfs:label@en = east place
 | rdfs:label@fr = lieu à l'est
+| rdfs:label@am = ምስራቅ
 | rdfs:comment@fr = indique un autre lieu situé à l'est.
 | rdfs:comment@en = indicates another place situated east.
+| rdfs:comment@am = በምስራቅ የሚገኝ ሌላ ቦታ ያመለክታል.
 | rdfs:domain = Place
 | rdfs:range = Place
 | owl:inverseOf = westPlace
@@ -17121,13 +17183,14 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 | rdfs:label@el = τίτλος συντάκτη
 | rdfs:domain = Magazine
 | rdfs:range = rdf:langString
-}}</text></revision></page><page><title>OntologyProperty:Education</title><ns>202</ns><id>831</id><revision><id>47569</id><timestamp>2015-04-03T09:18:55Z</timestamp><text>{{ObjectProperty
+}}</text></revision></page><page><title>OntologyProperty:Education</title><ns>202</ns><id>831</id><revision><id>59737</id><timestamp>2024-07-27T23:51:45Z</timestamp><text>{{ObjectProperty
 | labels =
 	{{label|en|education}}
 	{{label|de|Bildung}}
 	{{label|nl|opleiding}}
 	{{label|fr|éducation}}
 	{{label|ja|教育}}
+	{{label|am|ትምህርት}}
 | rdfs:domain = Person
 | rdfs:subPropertyOf = dul:sameSettingAs
 | owl:equivalentProperty = wikidata:P69
@@ -17202,15 +17265,15 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{label|pl|blok układu okresowego}}
 {{label|ru|блок периодической таблицы}}
 | comments =
-{{comment|en|A block of the periodic table of elements is a set of adjacent groups.&lt;ref&gt;https://en.wikipedia.org/wiki/Block_(periodic_table)&lt;/ref&gt;}}
-{{comment|ca|La taula periòdica dels elements es pot dividir en blocs d'elements segons l'orbital que estiguen ocupant els electrons més externs&lt;ref&gt;https://ca.wikipedia.org/wiki/Bloc_de_la_taula_peri%C3%B2dica&lt;/ref&gt;}}
-{{comment|de|Als Block im Periodensystem werden chemische Elemente nach den energiereichsten Atomorbitalen ihrer Elektronenhülle zusammengefasst.&lt;ref&gt;https://de.wikipedia.org/wiki/Block_des_Periodensystems&lt;/ref&gt;}}
-{{comment|ru|совокупность химических элементов со сходным расположением валентных электронов в атоме.&lt;ref&gt;https://ru.wikipedia.org/wiki/%D0%91%D0%BB%D0%BE%D0%BA_%D0%BF%D0%B5%D1%80%D0%B8%D0%BE%D0%B4%D0%B8%D1%87%D0%B5%D1%81%D0%BA%D0%BE%D0%B9_%D1%82%D0%B0%D0%B1%D0%BB%D0%B8%D1%86%D1%8B&lt;/ref&gt;}}
+{{comment|en|A block of the periodic table of elements is a set of adjacent groups.&lt;ref>https://en.wikipedia.org/wiki/Block_(periodic_table)&lt;/ref>}}
+{{comment|ca|La taula periòdica dels elements es pot dividir en blocs d'elements segons l'orbital que estiguen ocupant els electrons més externs&lt;ref>https://ca.wikipedia.org/wiki/Bloc_de_la_taula_peri%C3%B2dica&lt;/ref>}}
+{{comment|de|Als Block im Periodensystem werden chemische Elemente nach den energiereichsten Atomorbitalen ihrer Elektronenhülle zusammengefasst.&lt;ref>https://de.wikipedia.org/wiki/Block_des_Periodensystems&lt;/ref>}}
+{{comment|ru|совокупность химических элементов со сходным расположением валентных электронов в атоме.&lt;ref>https://ru.wikipedia.org/wiki/%D0%91%D0%BB%D0%BE%D0%BA_%D0%BF%D0%B5%D1%80%D0%B8%D0%BE%D0%B4%D0%B8%D1%87%D0%B5%D1%81%D0%BA%D0%BE%D0%B9_%D1%82%D0%B0%D0%B1%D0%BB%D0%B8%D1%86%D1%8B&lt;/ref>}}
 | rdfs:domain = ChemicalElement
 | rdfs:range = xsd:string
 }}
 
-&lt;references/&gt;</text></revision></page><page><title>OntologyProperty:ElementGroup</title><ns>202</ns><id>11022</id><revision><id>45308</id><timestamp>2015-02-13T16:45:16Z</timestamp><text>{{DatatypeProperty
+&lt;references/></text></revision></page><page><title>OntologyProperty:ElementGroup</title><ns>202</ns><id>11022</id><revision><id>45308</id><timestamp>2015-02-13T16:45:16Z</timestamp><text>{{DatatypeProperty
 |labels= 
 {{label|en|element group}}
 {{label|ca|grup de la taula periòdica}}
@@ -17219,17 +17282,17 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{label|pl|grupa układu okresowego}}
 {{label|ru|группа периодической системы}}
 | comments =
-{{comment|en|In chemistry, a group (also known as a family) is a column of elements in the periodic table of the chemical elements. &lt;ref&gt;https://en.wikipedia.org/wiki/Group_(periodic_table)&lt;/ref&gt;}}
-{{comment|ca|Un grup d'elements equival a una columna de la taula periòdica.&lt;ref&gt;https://ca.wikipedia.org/wiki/Grup_de_la_taula_peri%C3%B2dica&lt;/ref&gt;}}
-{{comment|de|Unter einer Gruppe des Periodensystems versteht man in der Chemie jede Spalte des Periodensystems.&lt;ref&gt;https://de.wikipedia.org/wiki/Gruppe_des_Periodensystems&lt;/ref&gt;}}
-{{comment|ga|Séard atá i gceist le grúpa sa choimhthéacs seo ná colún ceartingearach i dtábla peiriadach na ndúl ceimiceach.&lt;ref&gt;https://ga.wikipedia.org/wiki/Gr%C3%BApa%C3%AD_an_t%C3%A1bla_pheiriadaigh&lt;/ref&gt;}}
-{{comment|pl|grupa jest pionową kolumną w układzie okresowym pierwiastków chemicznych.&lt;ref&gt;https://pl.wikipedia.org/wiki/Grupa_uk%C5%82adu_okresowego&lt;/ref&gt;}}
-{{comment|ru|последовательность атомов по возрастанию заряда ядра, обладающих однотипным электронным строением.&lt;ref&gt;https://ru.wikipedia.org/wiki/%D0%93%D1%80%D1%83%D0%BF%D0%BF%D0%B0_%D0%BF%D0%B5%D1%80%D0%B8%D0%BE%D0%B4%D0%B8%D1%87%D0%B5%D1%81%D0%BA%D0%BE%D0%B9_%D1%81%D0%B8%D1%81%D1%82%D0%B5%D0%BC%D1%8B&lt;/ref&gt;}}
+{{comment|en|In chemistry, a group (also known as a family) is a column of elements in the periodic table of the chemical elements. &lt;ref>https://en.wikipedia.org/wiki/Group_(periodic_table)&lt;/ref>}}
+{{comment|ca|Un grup d'elements equival a una columna de la taula periòdica.&lt;ref>https://ca.wikipedia.org/wiki/Grup_de_la_taula_peri%C3%B2dica&lt;/ref>}}
+{{comment|de|Unter einer Gruppe des Periodensystems versteht man in der Chemie jede Spalte des Periodensystems.&lt;ref>https://de.wikipedia.org/wiki/Gruppe_des_Periodensystems&lt;/ref>}}
+{{comment|ga|Séard atá i gceist le grúpa sa choimhthéacs seo ná colún ceartingearach i dtábla peiriadach na ndúl ceimiceach.&lt;ref>https://ga.wikipedia.org/wiki/Gr%C3%BApa%C3%AD_an_t%C3%A1bla_pheiriadaigh&lt;/ref>}}
+{{comment|pl|grupa jest pionową kolumną w układzie okresowym pierwiastków chemicznych.&lt;ref>https://pl.wikipedia.org/wiki/Grupa_uk%C5%82adu_okresowego&lt;/ref>}}
+{{comment|ru|последовательность атомов по возрастанию заряда ядра, обладающих однотипным электронным строением.&lt;ref>https://ru.wikipedia.org/wiki/%D0%93%D1%80%D1%83%D0%BF%D0%BF%D0%B0_%D0%BF%D0%B5%D1%80%D0%B8%D0%BE%D0%B4%D0%B8%D1%87%D0%B5%D1%81%D0%BA%D0%BE%D0%B9_%D1%81%D0%B8%D1%81%D1%82%D0%B5%D0%BC%D1%8B&lt;/ref>}}
 | rdfs:domain = ChemicalElement
 | rdfs:range = xsd:nonNegativeInteger
 }}
 
-&lt;references/&gt;</text></revision></page><page><title>OntologyProperty:ElementPeriod</title><ns>202</ns><id>11024</id><revision><id>45315</id><timestamp>2015-02-13T17:35:20Z</timestamp><text>{{DatatypeProperty
+&lt;references/></text></revision></page><page><title>OntologyProperty:ElementPeriod</title><ns>202</ns><id>11024</id><revision><id>45315</id><timestamp>2015-02-13T17:35:20Z</timestamp><text>{{DatatypeProperty
 |labels= 
 {{label|en|element period}}
 {{label|ca|període de la taula periòdica}}
@@ -17238,15 +17301,15 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{label|pl|okres układu okresowego}}
 {{label|ru|период периодической таблицы}}
 | comments =
-{{comment|en|In the periodic table of the elements, elements are arranged in a series of rows (or periods) so that those with similar properties appear in a column.&lt;ref&gt;https://en.wikipedia.org/wiki/Period_(periodic_table)&lt;/ref&gt;}}
-{{comment|ca|En la taula periòdica dels elements, un període és una filera de la taula&lt;ref&gt;https://ca.wikipedia.org/wiki/Per%C3%ADode_de_la_taula_peri%C3%B2dica&lt;/ref&gt;}}
-{{comment|de|Unter einer Periode des Periodensystems versteht man in der Chemie jede Zeile des Periodensystems der Elemente.&lt;ref&gt;https://de.wikipedia.org/wiki/Periode_des_Periodensystems&lt;/ref&gt;}}
-{{comment|ru|строка периодической системы химических элементов, последовательность атомов по возрастанию заряда ядра и заполнению электронами внешней электронной оболочки.&lt;ref&gt;https://ru.wikipedia.org/wiki/%D0%9F%D0%B5%D1%80%D0%B8%D0%BE%D0%B4_%D0%BF%D0%B5%D1%80%D0%B8%D0%BE%D0%B4%D0%B8%D1%87%D0%B5%D1%81%D0%BA%D0%BE%D0%B9_%D1%81%D0%B8%D1%81%D1%82%D0%B5%D0%BC%D1%8B&lt;/ref&gt;}}
+{{comment|en|In the periodic table of the elements, elements are arranged in a series of rows (or periods) so that those with similar properties appear in a column.&lt;ref>https://en.wikipedia.org/wiki/Period_(periodic_table)&lt;/ref>}}
+{{comment|ca|En la taula periòdica dels elements, un període és una filera de la taula&lt;ref>https://ca.wikipedia.org/wiki/Per%C3%ADode_de_la_taula_peri%C3%B2dica&lt;/ref>}}
+{{comment|de|Unter einer Periode des Periodensystems versteht man in der Chemie jede Zeile des Periodensystems der Elemente.&lt;ref>https://de.wikipedia.org/wiki/Periode_des_Periodensystems&lt;/ref>}}
+{{comment|ru|строка периодической системы химических элементов, последовательность атомов по возрастанию заряда ядра и заполнению электронами внешней электронной оболочки.&lt;ref>https://ru.wikipedia.org/wiki/%D0%9F%D0%B5%D1%80%D0%B8%D0%BE%D0%B4_%D0%BF%D0%B5%D1%80%D0%B8%D0%BE%D0%B4%D0%B8%D1%87%D0%B5%D1%81%D0%BA%D0%BE%D0%B9_%D1%81%D0%B8%D1%81%D1%82%D0%B5%D0%BC%D1%8B&lt;/ref>}}
 | rdfs:domain = ChemicalElement
 | rdfs:range = xsd:nonNegativeInteger
 }}
 
-&lt;references/&gt;</text></revision></page><page><title>OntologyProperty:Elevation</title><ns>202</ns><id>832</id><revision><id>53808</id><timestamp>2020-12-01T18:03:02Z</timestamp><text>{{DatatypeProperty
+&lt;references/></text></revision></page><page><title>OntologyProperty:Elevation</title><ns>202</ns><id>832</id><revision><id>59688</id><timestamp>2024-06-18T08:25:11Z</timestamp><text>{{DatatypeProperty
 | labels =
 {{label|el|υψόμετρο}}
 {{label|en|elevation}}
@@ -17256,6 +17319,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{label|nl|hoogte}}
 {{label|pt|altitude}}
 {{label|hi|ऊँचाई}}
+{{label|am|ከፍታ}}
 | rdfs:domain = Place
 | rdfs:range = Length
 | rdfs:comment@en = average elevation above the sea level
@@ -17284,9 +17348,13 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 	| rdfs:domain = ChessPlayer
 	| rdfs:range = xsd:nonNegativeInteger
 
-}}</text></revision></page><page><title>OntologyProperty:Emblem</title><ns>202</ns><id>7307</id><revision><id>47573</id><timestamp>2015-04-03T09:21:12Z</timestamp><text>{{DatatypeProperty
+}}</text></revision></page><page><title>OntologyProperty:Emblem</title><ns>202</ns><id>7307</id><revision><id>59685</id><timestamp>2024-06-17T19:57:28Z</timestamp><text>{{DatatypeProperty
 | labels =
 {{label|en|emblem}}
+{{label|am|አርማ}}
+| comments =
+{{comment|en|A symbolic object used as a distinctive badge of a nation, organization, or family.}}
+{{comment|am|ለአገር ፣ ለቡድን፣ ድርጅት ወይም ቤተሰብ እንደ መለያ ምልክት የሚያገለግል ተምሳሌታዊ ነገር።}}
 | rdfs:domain = PopulatedPlace
 | rdfs:range = xsd:string
 | owl:equivalentProperty = wikidata:P158
@@ -17832,11 +17900,12 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 | rdfs:label@de = Schicksal
 | rdfs:domain = Company
 | rdfs:range = rdf:langString
-}}</text></revision></page><page><title>OntologyProperty:Father</title><ns>202</ns><id>7545</id><revision><id>57433</id><timestamp>2022-04-17T21:04:57Z</timestamp><text>{{ObjectProperty
+}}</text></revision></page><page><title>OntologyProperty:Father</title><ns>202</ns><id>7545</id><revision><id>59671</id><timestamp>2024-06-17T06:33:35Z</timestamp><text>{{ObjectProperty
 | labels =
 	{{label|en|father}}
 	{{label|fr|père}}
 	{{label|de|Vater}}
+    {{label|am|አባት}}
 | rdfs:domain = Man
 | rdfs:range = Person
 | rdfs:subPropertyOf = dul:sameSettingAs
@@ -18100,7 +18169,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 | rdfs:label@en = first appearance
 | rdfs:domain = FictionalCharacter
 | rdfs:range = xsd:string
-| rdfs:subPropertyOf = &lt;!-- dul:isParticipantIn -- defined as object property, see https://github.com/dbpedia/ontology-tracker/issues/9 --&gt;
+| rdfs:subPropertyOf = &lt;!-- dul:isParticipantIn -- defined as object property, see https://github.com/dbpedia/ontology-tracker/issues/9 -->
 }}</text></revision></page><page><title>OntologyProperty:FirstAscent</title><ns>202</ns><id>7919</id><revision><id>33679</id><timestamp>2014-04-03T16:33:10Z</timestamp><text>{{DatatypeProperty
 | labels =
 {{label|en|first ascent}}
@@ -18289,7 +18358,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 | rdfs:domain = Race
 | rdfs:range = Person
 | rdfs:subPropertyOf = dul:hasParticipant
-}}</text></revision></page><page><title>OntologyProperty:Flag</title><ns>202</ns><id>4544</id><revision><id>59635</id><timestamp>2024-06-04T10:27:21Z</timestamp><text>{{DatatypeProperty
+}}</text></revision></page><page><title>OntologyProperty:Flag</title><ns>202</ns><id>4544</id><revision><id>59661</id><timestamp>2024-06-16T13:13:08Z</timestamp><text>{{DatatypeProperty
 | labels =
 {{label|en|flag (image)}}
 {{label|it|bandiera}}
@@ -18297,7 +18366,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{label|el|σημαία}}
 {{label|nl|vlag (afbeelding)}}
 {{label|tr|göndere çekmek}}
-{{label|am|ባንዲራ}}
+{{label|am|ሰንደቅ ዓላማ}}
 | comments =
 {{comment|en|Wikimedia Commons file name representing the subject's flag}}
 | rdfs:domain = owl:Thing
@@ -18417,15 +18486,15 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 {{label|nl|afbeelding}}
 }}</text></revision></page><page><title>OntologyProperty:Foaf:isPrimaryTopicOf</title><ns>202</ns><id>5758</id><revision><id>18491</id><timestamp>2012-05-19T15:40:20Z</timestamp><text>{{ObjectProperty
 |labels = 
-{{label|en|A document that this thing is the primary topic of. &lt;ref name="foaf:isPrimaryTopicOf"&gt;http://xmlns.com/foaf/spec/#term_isPrimaryTopicOf&lt;/ref&gt;}}
+{{label|en|A document that this thing is the primary topic of. &lt;ref name="foaf:isPrimaryTopicOf">http://xmlns.com/foaf/spec/#term_isPrimaryTopicOf&lt;/ref>}}
 |comments = 
-{{comment|en|Inverse of [[OntologyProperty:Foaf:primaryTopic|foaf:primaryTopic]]. &lt;ref name="foaf:isPrimaryTopicOf"/&gt;}}
+{{comment|en|Inverse of [[OntologyProperty:Foaf:primaryTopic|foaf:primaryTopic]]. &lt;ref name="foaf:isPrimaryTopicOf"/>}}
 |rdfs:domain = owl:Thing
 |rdfs:range = foaf:Document
 }}
 
 ==References==
-&lt;references/&gt;</text></revision></page><page><title>OntologyProperty:Foaf:logo</title><ns>202</ns><id>2922</id><revision><id>12105</id><timestamp>2011-04-12T14:40:52Z</timestamp><text>{{ObjectProperty
+&lt;references/></text></revision></page><page><title>OntologyProperty:Foaf:logo</title><ns>202</ns><id>2922</id><revision><id>12105</id><timestamp>2011-04-12T14:40:52Z</timestamp><text>{{ObjectProperty
 |rdfs:label@en = logo
 }}</text></revision></page><page><title>OntologyProperty:Foaf:mbox</title><ns>202</ns><id>10990</id><revision><id>43320</id><timestamp>2015-02-06T13:28:12Z</timestamp><text>{{DatatypeProperty
 | labels =
@@ -18451,7 +18520,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 | rdfs:domain = owl:Thing
 | rdfs:range = rdf:langString
 | owl:equivalentProperty = schema:name
-}}</text></revision></page><page><title>OntologyProperty:Foaf:nick</title><ns>202</ns><id>2294</id><revision><id>34815</id><timestamp>2014-05-14T11:25:50Z</timestamp><text>{{DatatypeProperty
+}}</text></revision></page><page><title>OntologyProperty:Foaf:nick</title><ns>202</ns><id>2294</id><revision><id>59664</id><timestamp>2024-06-17T05:21:23Z</timestamp><text>{{DatatypeProperty
 |labels=
   {{label|en|nickname}}
 {{label|de|Spitzname}}
@@ -18459,18 +18528,19 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
   {{label|fr|surnom}}
   {{label|nl|bijnaam}}
   {{label|ja|ニックネーム}}
+  {{label|am|ቅጽል ስም}}
 |rdfs:domain = owl:Thing
 |rdfs:range = rdf:langString
 }}</text></revision></page><page><title>OntologyProperty:Foaf:page</title><ns>202</ns><id>1616</id><revision><id>22408</id><timestamp>2013-01-11T22:19:37Z</timestamp><text>{{ObjectProperty
 |labels=
-{{label|en|A page or document about this thing.&lt;ref name="foaf:page"&gt;http://xmlns.com/foaf/spec/#term_page&lt;/ref&gt;}}
+{{label|en|A page or document about this thing.&lt;ref name="foaf:page">http://xmlns.com/foaf/spec/#term_page&lt;/ref>}}
 {{label|nl|document}}
 |comments = 
-{{comment|en|Inverse of [[OntologyProperty:Foaf:topic|foaf:topic]]. &lt;ref name="foaf:page"/&gt;}}
+{{comment|en|Inverse of [[OntologyProperty:Foaf:topic|foaf:topic]]. &lt;ref name="foaf:page"/>}}
 |rdfs:range = foaf:Document
 }}
 ==References==
-&lt;references/&gt;</text></revision></page><page><title>OntologyProperty:Foaf:phone</title><ns>202</ns><id>10991</id><revision><id>43324</id><timestamp>2015-02-06T13:37:22Z</timestamp><text>{{DatatypeProperty
+&lt;references/></text></revision></page><page><title>OntologyProperty:Foaf:phone</title><ns>202</ns><id>10991</id><revision><id>43324</id><timestamp>2015-02-06T13:37:22Z</timestamp><text>{{DatatypeProperty
 | labels =
 {{label|en|Telephone (phone) number}}
 |comments=
@@ -18478,14 +18548,14 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 |rdfs:range=xsd:string
 }}</text></revision></page><page><title>OntologyProperty:Foaf:primaryTopic</title><ns>202</ns><id>2308</id><revision><id>18496</id><timestamp>2012-05-19T15:42:23Z</timestamp><text>{{ObjectProperty
 |labels=
-{{label|en|The primary topic of some page or document. &lt;ref name="foaf:primaryTopic"&gt;http://xmlns.com/foaf/spec/#term_primaryTopic&lt;/ref&gt;}}
+{{label|en|The primary topic of some page or document. &lt;ref name="foaf:primaryTopic">http://xmlns.com/foaf/spec/#term_primaryTopic&lt;/ref>}}
 |comments=
-{{comment|en|Inverse of [[OntologyProperty:Foaf:isPrimaryTopicOf|foaf:isPrimaryTopicOf]]. &lt;ref name="foaf:primaryTopic"/&gt;}}
+{{comment|en|Inverse of [[OntologyProperty:Foaf:isPrimaryTopicOf|foaf:isPrimaryTopicOf]]. &lt;ref name="foaf:primaryTopic"/>}}
 |rdfs:domain = foaf:Document
 }}
 
 ==References==
-&lt;references/&gt;</text></revision></page><page><title>OntologyProperty:Foaf:surname</title><ns>202</ns><id>1618</id><revision><id>36761</id><timestamp>2014-07-09T10:32:50Z</timestamp><text>{{DatatypeProperty
+&lt;references/></text></revision></page><page><title>OntologyProperty:Foaf:surname</title><ns>202</ns><id>1618</id><revision><id>36761</id><timestamp>2014-07-09T10:32:50Z</timestamp><text>{{DatatypeProperty
 |labels=
   {{label|en|surname}}
 {{label|el|Επίθετο}}  
@@ -18502,16 +18572,16 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 |rdfs:range = Image
 }}</text></revision></page><page><title>OntologyProperty:Foaf:topic</title><ns>202</ns><id>5759</id><revision><id>56785</id><timestamp>2022-02-28T21:12:35Z</timestamp><text>{{ObjectProperty
 |labels=
-{{label|en|A topic of some page or document. &lt;ref name="foaf:topic"&gt;http://xmlns.com/foaf/spec/#term_topic&lt;/ref&gt;}}
-{{label|fr|Un sujet d'une page ou d'un document. &lt;ref name="foaf:topic"&gt;http://xmlns.com/foaf/spec/#term_topic&lt;/ref&gt;}}
+{{label|en|A topic of some page or document. &lt;ref name="foaf:topic">http://xmlns.com/foaf/spec/#term_topic&lt;/ref>}}
+{{label|fr|Un sujet d'une page ou d'un document. &lt;ref name="foaf:topic">http://xmlns.com/foaf/spec/#term_topic&lt;/ref>}}
 |comments=
-{{comment|en|Inverse of [[OntologyProperty:Foaf:page|foaf:page]]. &lt;ref name="foaf:topic"/&gt;}}
-{{comment|fr|Inverse de [[OntologyProperty:Foaf:page|foaf:page]]. &lt;ref name="foaf:topic"/&gt;}}
+{{comment|en|Inverse of [[OntologyProperty:Foaf:page|foaf:page]]. &lt;ref name="foaf:topic"/>}}
+{{comment|fr|Inverse de [[OntologyProperty:Foaf:page|foaf:page]]. &lt;ref name="foaf:topic"/>}}
 |rdfs:domain = owl:Thing
 }}
 
 ==References==
-&lt;references/&gt;</text></revision></page><page><title>OntologyProperty:FoalDate</title><ns>202</ns><id>6177</id><revision><id>20756</id><timestamp>2012-12-23T14:03:04Z</timestamp><text>{{DatatypeProperty
+&lt;references/></text></revision></page><page><title>OntologyProperty:FoalDate</title><ns>202</ns><id>6177</id><revision><id>20756</id><timestamp>2012-12-23T14:03:04Z</timestamp><text>{{DatatypeProperty
 | labels =
 {{label|en|foal date}}
 | rdfs:domain = Animal
@@ -18737,13 +18807,15 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 	{{comment|en|Ein Gründer oder Gründungsmitglied einer Organisation, Religion oder eines Ortes.}}
 | rdfs:subPropertyOf = dul:sameSettingAs
 | owl:equivalentProperty = wikidata:P112
-}}</text></revision></page><page><title>OntologyProperty:FoundingDate</title><ns>202</ns><id>910</id><revision><id>53737</id><timestamp>2020-09-28T19:29:08Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = founding date
-| rdfs:label@de = Gründungsdatum
-| rdfs:label@el = ημερομηνία ίδρυσης
-| rdfs:label@ga = dáta bunaithe
-| rdfs:label@ja = 創立日
-| rdfs:label@pl = data założenia
+}}</text></revision></page><page><title>OntologyProperty:FoundingDate</title><ns>202</ns><id>910</id><revision><id>59693</id><timestamp>2024-06-18T08:38:32Z</timestamp><text>{{DatatypeProperty
+|labels =
+ {{label|en|founding date}}
+ {{label|de|Gründungsdatum}}
+ {{label|el|ημερομηνία ίδρυσης}}
+ {{label|ga|dáta bunaithe}}
+ {{label|ja|創立日}}
+ {{label|pl|data założenia}}
+ {{label|am|የምሥረታ ቀን}}
 | rdfs:range = xsd:date
 | owl:equivalentProperty = schema:foundingDate, wikidata:P571
 }}</text></revision></page><page><title>OntologyProperty:FoundingYear</title><ns>202</ns><id>912</id><revision><id>53749</id><timestamp>2020-09-30T12:14:36Z</timestamp><text>{{DatatypeProperty
@@ -18882,7 +18954,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 | rdfs:label@de = Kraftstofftyp
 | rdfs:domain = owl:Thing
 | rdfs:range = owl:Thing
-&lt;!-- | rdfs:subPropertyOf = dul:isClassifiedBy -- defined as object property, see https://github.com/dbpedia/ontology-tracker/issues/9 --&gt;
+&lt;!-- | rdfs:subPropertyOf = dul:isClassifiedBy -- defined as object property, see https://github.com/dbpedia/ontology-tracker/issues/9 -->
 }}</text></revision></page><page><title>OntologyProperty:FuelTypeName</title><ns>202</ns><id>9588</id><revision><id>35518</id><timestamp>2014-06-28T22:37:59Z</timestamp><text>{{DatatypeProperty
 | labels =
 {{label|en|fuel type}}
@@ -19101,14 +19173,14 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 	{{label|nl|geslacht}}
 	{{label|ja|属_(分類学)}}
 | comments =
-	{{comment|en|A rank in the classification of organisms, below family and above species; a taxon at that rank&lt;ref&gt;https://en.wiktionary.org/wiki/genus&lt;/ref&gt;}}
-	{{comment|fr|Rang taxinomique (ou taxonomique) qui regroupe un ensemble d'espèces ayant en commun plusieurs caractères similaires.&lt;ref&gt;https://fr.wikipedia.org/wiki/Genre_(biologie)&lt;/ref&gt;}}
+	{{comment|en|A rank in the classification of organisms, below family and above species; a taxon at that rank&lt;ref>https://en.wiktionary.org/wiki/genus&lt;/ref>}}
+	{{comment|fr|Rang taxinomique (ou taxonomique) qui regroupe un ensemble d'espèces ayant en commun plusieurs caractères similaires.&lt;ref>https://fr.wikipedia.org/wiki/Genre_(biologie)&lt;/ref>}}
 | rdfs:domain = Species
 | owl:equivalentProperty = wikidata:P74
 | rdfs:subPropertyOf = dul:specializes
 }}
 == references ==
-&lt;references/&gt;</text></revision></page><page><title>OntologyProperty:Geo:lat</title><ns>202</ns><id>1620</id><revision><id>13649</id><timestamp>2011-06-14T13:45:19Z</timestamp><text>{{DatatypeProperty
+&lt;references/></text></revision></page><page><title>OntologyProperty:Geo:lat</title><ns>202</ns><id>1620</id><revision><id>13649</id><timestamp>2011-06-14T13:45:19Z</timestamp><text>{{DatatypeProperty
 |rdfs:label@en		= latitude
 |rdfs:domain	= gml:_Feature
 |rdfs:range		= xsd:float
@@ -19310,12 +19382,13 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 | rdfs:comment@en = broadly, the type of structure of its government
 | rdfs:range = GovernmentType
 | rdfs:subPropertyOf = dul:isClassifiedBy
-}}</text></revision></page><page><title>OntologyProperty:Governor</title><ns>202</ns><id>2343</id><revision><id>36130</id><timestamp>2014-07-08T13:30:18Z</timestamp><text>
+}}</text></revision></page><page><title>OntologyProperty:Governor</title><ns>202</ns><id>2343</id><revision><id>59767</id><timestamp>2024-08-05T07:15:28Z</timestamp><text>
 {{ObjectProperty
 | rdfs:label@en = governor
 | rdfs:label@de = Gouverneur
 | rdfs:label@el = κυβερνήτης
 | rdfs:label@fr = gouverneur
+| rdfs:label@am = አገረ ገዥ
 | rdfs:range = Person
 | rdfs:subPropertyOf = dul:coparticipatesWith
 }}</text></revision></page><page><title>OntologyProperty:GovernorGeneral</title><ns>202</ns><id>2322</id><revision><id>36131</id><timestamp>2014-07-08T13:30:28Z</timestamp><text>
@@ -19566,7 +19639,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 | rdfs:label@en = has channel
 | rdfs:domain = owl:Thing
 | rdfs:range = owl:Thing
-&lt;!--| rdfs:subPropertyOf = foaf:homepage --&gt;
+&lt;!--| rdfs:subPropertyOf = foaf:homepage -->
 }}</text></revision></page><page><title>OntologyProperty:HasInput</title><ns>202</ns><id>6764</id><revision><id>25013</id><timestamp>2013-04-18T10:45:37Z</timestamp><text>{{ObjectProperty
 | rdfs:label@en = has input
 | rdfs:domain = owl:Thing
@@ -19609,7 +19682,7 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 }}</text></revision></page><page><title>OntologyProperty:HasSurfaceForm</title><ns>202</ns><id>2441</id><revision><id>18830</id><timestamp>2012-06-28T13:37:18Z</timestamp><text>'''{{Reserved for DBpedia}}'''
 
 {{DatatypeProperty
-| rdfs:label@en = surface form, i.e the string after the pipe in internal links: &lt;nowiki&gt;[[resource|string]]&lt;/nowiki&gt;
+| rdfs:label@en = surface form, i.e the string after the pipe in internal links: &lt;nowiki>[[resource|string]]&lt;/nowiki>
 | rdfs:label@el = επιφάνεια από
 | comments = 
 {{comment|en|Reserved for DBpedia. {{Reserved for DBpedia}}}}
@@ -19720,13 +19793,13 @@ Includes concentration, extermination, transit, detention, internment, (forced) 
 	{{label|en|heritage register}}
 	{{label|fr|inventaire du patrimoine}}
 | comments =
-	{{comment|en|registered in a heritage register : inventory of cultural properties, natural and man-made, tangible and intangible, movable and immovable, that are deemed to be of sufficient heritage value to be separately identified and recorded.&lt;ref&gt;http://en.wikipedia.org/wiki/List_of_heritage_registers&lt;/ref&gt;}}
-	{{comment|fr|inscrit à un inventaires dédiés à la conservation du patrimoine, naturel ou culturel, existants dans le monde.&lt;ref&gt;http://fr.wikipedia.org/wiki/Liste_des_inventaires_du_patrimoine&lt;/ref&gt;}}
+	{{comment|en|registered in a heritage register : inventory of cultural properties, natural and man-made, tangible and intangible, movable and immovable, that are deemed to be of sufficient heritage value to be separately identified and recorded.&lt;ref>http://en.wikipedia.org/wiki/List_of_heritage_registers&lt;/ref>}}
+	{{comment|fr|inscrit à un inventaires dédiés à la conservation du patrimoine, naturel ou culturel, existants dans le monde.&lt;ref>http://fr.wikipedia.org/wiki/Liste_des_inventaires_du_patrimoine&lt;/ref>}}
 | rdfs:range = owl:Thing
 | rdfs:domain = Place
 | rdfs:subPropertyOf = dul:isMemberOf
 }}
-&lt;references/&gt;</text></revision></page><page><title>OntologyProperty:Hgncid</title><ns>202</ns><id>967</id><revision><id>19131</id><timestamp>2012-07-31T11:18:32Z</timestamp><text>{{DatatypeProperty
+&lt;references/></text></revision></page><page><title>OntologyProperty:Hgncid</title><ns>202</ns><id>967</id><revision><id>19131</id><timestamp>2012-07-31T11:18:32Z</timestamp><text>{{DatatypeProperty
 | rdfs:label@en = HGNCid
 | rdfs:label@ja = HGNCid
 | rdfs:domain = Biomolecule
@@ -20508,20 +20581,20 @@ See also [[OntologyProperty:CurrentlyUsedFor]]</text></revision></page><page><ti
 | rdfs:subPropertyOf = code
 }}</text></revision></page><page><title>OntologyProperty:Iso31661Code</title><ns>202</ns><id>5679</id><revision><id>45634</id><timestamp>2015-03-12T09:21:01Z</timestamp><text>{{DatatypeProperty
 | rdfs:label@en = ISO 3166-1 code
-| rdfs:comment@en = defines codes for the names of countries, dependent territories, and special areas of geographical interest&lt;ref name="iso31661Code"&gt;http://en.wikipedia.org/wiki/ISO_3166-1&lt;/ref&gt;
+| rdfs:comment@en = defines codes for the names of countries, dependent territories, and special areas of geographical interest&lt;ref name="iso31661Code">http://en.wikipedia.org/wiki/ISO_3166-1&lt;/ref>
 | rdfs:domain = Place
 | rdfs:range = xsd:string
 | owl:equivalentProperty = wikidata:P297, wikidata:P298, wikidata:P299
 }}
 ==References==
-&lt;references/&gt;</text></revision></page><page><title>OntologyProperty:Iso6391Code</title><ns>202</ns><id>3701</id><revision><id>50346</id><timestamp>2016-02-12T20:57:19Z</timestamp><text>{{DatatypeProperty
+&lt;references/></text></revision></page><page><title>OntologyProperty:Iso6391Code</title><ns>202</ns><id>3701</id><revision><id>50346</id><timestamp>2016-02-12T20:57:19Z</timestamp><text>{{DatatypeProperty
 | labels =
 	{{label|en|ISO 639-1 code}}
 	{{label|nl|ISO 639-1 code}}
 	{{label|pl|kod ISO 639-1}}
 | rdfs:domain = Language
 | rdfs:range = xsd:string
-| rdfs:subPropertyOf = LanguageCode &lt;!-- dul:isClassifiedBy -- defined as object property, see https://github.com/dbpedia/ontology-tracker/issues/9 --&gt;
+| rdfs:subPropertyOf = LanguageCode &lt;!-- dul:isClassifiedBy -- defined as object property, see https://github.com/dbpedia/ontology-tracker/issues/9 -->
 | owl:equivalentProperty = wikidata:P218
 }}</text></revision></page><page><title>OntologyProperty:Iso6392Code</title><ns>202</ns><id>3700</id><revision><id>50347</id><timestamp>2016-02-12T20:58:02Z</timestamp><text>{{DatatypeProperty
 | labels =
@@ -20530,7 +20603,7 @@ See also [[OntologyProperty:CurrentlyUsedFor]]</text></revision></page><page><ti
 	{{label|pl|kod ISO 639-2}}
 | rdfs:domain = Language
 | rdfs:range = xsd:string
-| rdfs:subPropertyOf = LanguageCode &lt;!-- dul:isClassifiedBy -- defined as object property, see https://github.com/dbpedia/ontology-tracker/issues/9 --&gt;
+| rdfs:subPropertyOf = LanguageCode &lt;!-- dul:isClassifiedBy -- defined as object property, see https://github.com/dbpedia/ontology-tracker/issues/9 -->
 | owl:equivalentProperty = wikidata:P219
 }}</text></revision></page><page><title>OntologyProperty:Iso6393Code</title><ns>202</ns><id>3693</id><revision><id>50348</id><timestamp>2016-02-12T20:59:06Z</timestamp><text>{{DatatypeProperty
 | labels =
@@ -20539,7 +20612,7 @@ See also [[OntologyProperty:CurrentlyUsedFor]]</text></revision></page><page><ti
 	{{label|pl|kod ISO 639-3}}
 | rdfs:domain = Language
 | rdfs:range = xsd:string
-| rdfs:subPropertyOf = LanguageCode &lt;!-- dul:isClassifiedBy -- defined as object property, see https://github.com/dbpedia/ontology-tracker/issues/9 --&gt;
+| rdfs:subPropertyOf = LanguageCode &lt;!-- dul:isClassifiedBy -- defined as object property, see https://github.com/dbpedia/ontology-tracker/issues/9 -->
 | owl:equivalentProperty = wikidata:P220
 }}</text></revision></page><page><title>OntologyProperty:IsoCode</title><ns>202</ns><id>6868</id><revision><id>33811</id><timestamp>2014-04-04T14:24:23Z</timestamp><text>{{DatatypeProperty
 | labels =
@@ -20555,7 +20628,7 @@ See also [[OntologyProperty:CurrentlyUsedFor]]</text></revision></page><page><ti
 	{{label|nl|ISO regiocode}}
 | rdfs:domain = Settlement
 | rdfs:range = xsd:string
-| rdfs:subPropertyOf = &lt;!-- dul:isPartOf -- defined as object property, see https://github.com/dbpedia/ontology-tracker/issues/9 --&gt;
+| rdfs:subPropertyOf = &lt;!-- dul:isPartOf -- defined as object property, see https://github.com/dbpedia/ontology-tracker/issues/9 -->
 }}</text></revision></page><page><title>OntologyProperty:IssDockings</title><ns>202</ns><id>1004</id><revision><id>10354</id><timestamp>2010-11-10T14:09:54Z</timestamp><text>{{DatatypeProperty
 | rdfs:label@en = iss dockings
 | rdfs:domain = SpaceShuttle
@@ -20743,14 +20816,14 @@ See also [[OntologyProperty:CurrentlyUsedFor]]</text></revision></page><page><ti
 	{{label|nl|rijk}}
 	{{label|ja|界_(分類学)}}
 | comments =
-	{{comment|en|In biology, kingdom (Latin: regnum, pl. regna) is a taxonomic rank, which is either the highest rank or in the more recent three-domain system, the rank below domain.&lt;ref&gt;https://en.wikipedia.org/wiki/Kingdom_%28biology%29&lt;/ref&gt;}}
-	{{comment|fr|Le règne (du latin « regnum ») est, dans les taxinomies classiques, le plus haut niveau de classification des êtres vivants, en raison de leurs caractères communs.&lt;ref&gt;https://fr.wikipedia.org/wiki/R%C3%A8gne_%28biologie%29&lt;/ref&gt;}}
+	{{comment|en|In biology, kingdom (Latin: regnum, pl. regna) is a taxonomic rank, which is either the highest rank or in the more recent three-domain system, the rank below domain.&lt;ref>https://en.wikipedia.org/wiki/Kingdom_%28biology%29&lt;/ref>}}
+	{{comment|fr|Le règne (du latin « regnum ») est, dans les taxinomies classiques, le plus haut niveau de classification des êtres vivants, en raison de leurs caractères communs.&lt;ref>https://fr.wikipedia.org/wiki/R%C3%A8gne_%28biologie%29&lt;/ref>}}
 | rdfs:domain = Species
 | owl:equivalentProperty = wikidata:P75
 | rdfs:subPropertyOf = dul:specializes
 }}
 == references ==
-&lt;references/&gt;</text></revision></page><page><title>OntologyProperty:KnownFor</title><ns>202</ns><id>1010</id><revision><id>57224</id><timestamp>2022-03-24T19:21:52Z</timestamp><text>{{ObjectProperty
+&lt;references/></text></revision></page><page><title>OntologyProperty:KnownFor</title><ns>202</ns><id>1010</id><revision><id>57224</id><timestamp>2022-03-24T19:21:52Z</timestamp><text>{{ObjectProperty
 | labels =
 	{{label|en|known for}}
 	{{label|nl|bekend om}}
@@ -20836,7 +20909,7 @@ See also [[OntologyProperty:CurrentlyUsedFor]]</text></revision></page><page><ti
 {{label|en|austrian land tag mandate}}
 | rdfs:domain = AdministrativeRegion
 | rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Language</title><ns>202</ns><id>1015</id><revision><id>53696</id><timestamp>2020-09-04T15:21:30Z</timestamp><text>{{ObjectProperty
+}}</text></revision></page><page><title>OntologyProperty:Language</title><ns>202</ns><id>1015</id><revision><id>59726</id><timestamp>2024-07-27T21:51:01Z</timestamp><text>{{ObjectProperty
 | labels =
 	{{label|en|language}}
 	{{label|gl|lingua}}
@@ -20847,26 +20920,29 @@ See also [[OntologyProperty:CurrentlyUsedFor]]</text></revision></page><page><ti
 	{{label|el|γλώσσα}}
 	{{label|ga|teanga}}
 	{{label|pl|język}}
+	{{label|am|ቋንቋ}}
 | rdfs:comment@en = Use dc:language for literal, language for object
 | rdfs:domain = owl:Thing
 | rdfs:range = Language
 | rdfs:subPropertyOf = dul:coparticipatesWith
 | owl:equivalentProperty = schema:inLanguage, ceo:taal
-}}</text></revision></page><page><title>OntologyProperty:LanguageCode</title><ns>202</ns><id>3704</id><revision><id>50354</id><timestamp>2016-02-12T21:09:02Z</timestamp><text>
+}}</text></revision></page><page><title>OntologyProperty:LanguageCode</title><ns>202</ns><id>3704</id><revision><id>59711</id><timestamp>2024-07-27T19:09:27Z</timestamp><text>
 {{DatatypeProperty
 | rdfs:label@en = language code
 | rdfs:label@de = Sprachcode
 | rdfs:label@pl = kod językowy
+| rdfs:label@am = የቋንቋ ኮድ
 | rdfs:domain = Language
 | rdfs:range = xsd:string
-| rdfs:subPropertyOf = &lt;!-- dul:sameSettingAs -- defined as object property, see https://github.com/dbpedia/ontology-tracker/issues/9 --&gt;
-}}</text></revision></page><page><title>OntologyProperty:LanguageFamily</title><ns>202</ns><id>3703</id><revision><id>36202</id><timestamp>2014-07-08T13:57:45Z</timestamp><text>
+| rdfs:subPropertyOf = &lt;!-- dul:sameSettingAs -- defined as object property, see https://github.com/dbpedia/ontology-tracker/issues/9 -->
+}}</text></revision></page><page><title>OntologyProperty:LanguageFamily</title><ns>202</ns><id>3703</id><revision><id>59709</id><timestamp>2024-07-27T18:56:43Z</timestamp><text>
 {{ObjectProperty
 | labels =
 	{{label|en|family}}
 	{{label|de|Familie}}
 	{{label|nl|taalfamilie}}
 	{{label|pl|rodzina}}
+    {{label|am|የቋንቋ ቤተሰብ}}
 | rdfs:domain = Language
 | rdfs:subPropertyOf = dul:specializes
 }}</text></revision></page><page><title>OntologyProperty:LanguageRegulator</title><ns>202</ns><id>4140</id><revision><id>36203</id><timestamp>2014-07-08T13:57:47Z</timestamp><text>
@@ -21174,12 +21250,13 @@ See also [[OntologyProperty:CurrentlyUsedFor]]</text></revision></page><page><ti
 {{label|de|Führung}}
 | rdfs:domain = Person
 | rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:League</title><ns>202</ns><id>1051</id><revision><id>56814</id><timestamp>2022-02-28T22:30:51Z</timestamp><text>{{ObjectProperty
+}}</text></revision></page><page><title>OntologyProperty:League</title><ns>202</ns><id>1051</id><revision><id>59742</id><timestamp>2024-07-28T00:15:27Z</timestamp><text>{{ObjectProperty
 | labels =
 	{{label|en|league}}
 	{{label|fr|ligue}}
 	{{label|de|Liga}}
 	{{label|el|πρωτάθλημα}}
+	{{label|am|ሊግ}}
 | rdfs:range = SportsLeague
 | rdfs:subPropertyOf = dul:sameSettingAs
 | owl:equivalentProperty = wikidata:P118
@@ -21241,13 +21318,14 @@ See also [[OntologyProperty:CurrentlyUsedFor]]</text></revision></page><page><ti
 	{{label|de|Gesetzgeber}}
 | rdfs:domain = PopulatedPlace
 | rdfs:range = Legislature
-}}</text></revision></page><page><title>OntologyProperty:Length</title><ns>202</ns><id>1056</id><revision><id>57376</id><timestamp>2022-03-31T12:58:15Z</timestamp><text>{{DatatypeProperty
+}}</text></revision></page><page><title>OntologyProperty:Length</title><ns>202</ns><id>1056</id><revision><id>59715</id><timestamp>2024-07-27T19:49:14Z</timestamp><text>{{DatatypeProperty
 | labels =
   {{label|en|length}}
   {{label|nl|lengte}}
   {{label|de|Länge}}
   {{label|el|μήκος}}
   {{label|fr|longueur}}
+  {{label|am|ርዝመት}}
 | rdfs:range = Length
 | rdf:type = owl:FunctionalProperty
 | owl:equivalentProperty = wikidata:P2043
@@ -21514,12 +21592,13 @@ See also [[OntologyProperty:CurrentlyUsedFor]]</text></revision></page><page><ti
 | rdfs:label@en = locus supplementary data
 | rdfs:domain = Protein
 | rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Logo</title><ns>202</ns><id>5647</id><revision><id>57438</id><timestamp>2022-04-17T21:15:39Z</timestamp><text>{{ DatatypeProperty
+}}</text></revision></page><page><title>OntologyProperty:Logo</title><ns>202</ns><id>5647</id><revision><id>59752</id><timestamp>2024-07-28T23:26:54Z</timestamp><text>{{ DatatypeProperty
 | labels =
   {{label|en|logo}}
   {{label|fr|logo}}
   {{label|el|λογότυπο}}
   {{label|nl|logo}}
+  {{label|am| አርማ}}
 | rdfs:domain = owl:Thing
 | rdfs:range = xsd:string
 }}</text></revision></page><page><title>OntologyProperty:LongDistancePisteKilometre</title><ns>202</ns><id>7204</id><revision><id>26188</id><timestamp>2013-06-18T11:05:22Z</timestamp><text>{{DatatypeProperty
@@ -21931,13 +22010,13 @@ See also [[OntologyProperty:CurrentlyUsedFor]]</text></revision></page><page><ti
   {{label|pt|mascote}}
   {{label|fr|mascotte}}
 | comments = 
-  {{comment|en|something, especially a person or animal, used to symbolize a sports team, company, organization or other group.&lt;ref&gt;http://en.wiktionary.org/wiki/mascot&lt;/ref&gt;}}
-  {{comment|fr|Animal, poupée, objets divers servant de porte-bonheur ou d’emblème.&lt;ref&gt;http://fr.wiktionary.org/wiki/mascotte&lt;/ref&gt;}}
+  {{comment|en|something, especially a person or animal, used to symbolize a sports team, company, organization or other group.&lt;ref>http://en.wiktionary.org/wiki/mascot&lt;/ref>}}
+  {{comment|fr|Animal, poupée, objets divers servant de porte-bonheur ou d’emblème.&lt;ref>http://fr.wiktionary.org/wiki/mascotte&lt;/ref>}}
 | rdfs:range = xsd:string
 }}
 
 == References ==
-&lt;references/&gt;</text></revision></page><page><title>OntologyProperty:Mass</title><ns>202</ns><id>1107</id><revision><id>33875</id><timestamp>2014-04-04T14:57:05Z</timestamp><text>{{DatatypeProperty
+&lt;references/></text></revision></page><page><title>OntologyProperty:Mass</title><ns>202</ns><id>1107</id><revision><id>33875</id><timestamp>2014-04-04T14:57:05Z</timestamp><text>{{DatatypeProperty
 | rdfs:label@en = mass
 | rdfs:label@de = Masse
 | rdfs:label@el = μάζα
@@ -22007,9708 +22086,4 @@ See also [[OntologyProperty:CurrentlyUsedFor]]</text></revision></page><page><ti
 | rdfs:label@el = μέγιστο_πλάτος_πλοίου
 | rdfs:domain = Canal
 | rdfs:range = Length
-}}</text></revision></page><page><title>OntologyProperty:MaximumBoatLength</title><ns>202</ns><id>1110</id><revision><id>11549</id><timestamp>2011-04-01T11:11:11Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = maximum boat length
-| rdfs:label@el = μέγιστο_μήκος_πλοίου
-| rdfs:domain = Canal
-| rdfs:range = Length
-}}</text></revision></page><page><title>OntologyProperty:MaximumDepth</title><ns>202</ns><id>1111</id><revision><id>49326</id><timestamp>2015-10-23T13:00:29Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|de|maximale Tiefe}}
-{{label|el|μέγιστο_βάθος}}
-{{label|en|maximum depth}}
-{{label|fr|profondeur maximale}}
-| comments =
-{{comment|en|Source of the value can be declare by {{linkProperties|maximumDepthQuote|}}.}}
-| rdfs:domain = Place
-| rdfs:range = Length
-| rdfs:subPropertyOf = depth
-| owl:propertyDisjointWith = averageDepth
-}}</text></revision></page><page><title>OntologyProperty:MaximumDepthQuote</title><ns>202</ns><id>7092</id><revision><id>49325</id><timestamp>2015-10-23T12:51:24Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|maximum depth quote}}
-| comments =
-{{comment|en|Source of the {{linkProperties|maximumDepth|}} value.}}
-| rdfs:domain = Place
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:MaximumDischarge</title><ns>202</ns><id>1112</id><revision><id>8118</id><timestamp>2010-05-28T13:20:59Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = maximum discharge
-| rdfs:range = FlowRate
-}}</text></revision></page><page><title>OntologyProperty:MaximumElevation</title><ns>202</ns><id>1113</id><revision><id>11272</id><timestamp>2011-03-30T09:40:00Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = maximum elevation
-| rdfs:label@el = κορυφή
-| rdfs:domain = Place
-| rdfs:range = Length
-| rdfs:comment@en = maximum elevation above the sea level
-}}</text></revision></page><page><title>OntologyProperty:MaximumInclination</title><ns>202</ns><id>1114</id><revision><id>8120</id><timestamp>2010-05-28T13:21:16Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = maximum inclination
-| rdfs:domain = LaunchPad
-| rdfs:range = xsd:float
-}}</text></revision></page><page><title>OntologyProperty:MaximumTemperature</title><ns>202</ns><id>1115</id><revision><id>33880</id><timestamp>2014-04-04T14:57:26Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = maximum temperature
-| rdfs:label@de = Maximaltemperatur
-| rdfs:label@el = μέγιστη θερμοκρασία
-| rdfs:domain = Planet
-| rdfs:range = Temperature
-}}</text></revision></page><page><title>OntologyProperty:Mayor</title><ns>202</ns><id>1116</id><revision><id>52308</id><timestamp>2017-10-09T12:55:27Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|mayor}}
-	{{label|de|Bürgermeister}}
-	{{label|el|δήμαρχος}}
-	{{label|nl|burgemeester}}
-	{{label|fr|maire}}
-| rdfs:range = Mayor
-| rdfs:subPropertyOf = dul:coparticipatesWith
-| rdfs:subPropertyOf = Leader
-}}</text></revision></page><page><title>OntologyProperty:MayorArticle</title><ns>202</ns><id>7156</id><revision><id>25697</id><timestamp>2013-05-26T16:39:32Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|mayor article}}
-| rdfs:domain = Place
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:MayorCouncillor</title><ns>202</ns><id>6879</id><revision><id>27428</id><timestamp>2013-07-12T10:19:17Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|mayor councillor}}
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:MayorFunction</title><ns>202</ns><id>6941</id><revision><id>25412</id><timestamp>2013-05-25T12:04:48Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|mayor function of a switzerland settlement}}
-| rdfs:domain = SwitzerlandSettlement
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:MayorMandate</title><ns>202</ns><id>6779</id><revision><id>25066</id><timestamp>2013-04-21T14:35:49Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|mayorMandate}}
-| rdfs:domain = Mayor
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:MayorTitle</title><ns>202</ns><id>6903</id><revision><id>34847</id><timestamp>2014-05-15T05:19:31Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|mayor title of a hungarian settlement}}
-| rdfs:domain = HungarySettlement
-| rdfs:range = rdf:langString
-}}</text></revision></page><page><title>OntologyProperty:MbaId</title><ns>202</ns><id>8428</id><revision><id>52879</id><timestamp>2018-02-13T10:47:58Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|MBA Id}}
-| comments =
-{{comment|en|MusicBrainz is an open music encyclopedia that collects music metadata and makes it available to the public.}}
-| rdfs:range = xsd:string
-| rdfs:subPropertyOf = code
-}}</text></revision></page><page><title>OntologyProperty:MeanRadius</title><ns>202</ns><id>1118</id><revision><id>33952</id><timestamp>2014-04-04T15:06:20Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = mean radius
-| rdfs:label@de = durchschnittlicher Radius
-| rdfs:label@el = μέση ακτίνα
-| rdfs:domain = Planet
-| rdfs:range = Length
-}}</text></revision></page><page><title>OntologyProperty:MeanTemperature</title><ns>202</ns><id>1119</id><revision><id>33883</id><timestamp>2014-04-04T14:57:39Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = mean temperature
-| rdfs:label@de = Durchschnittstemperatur
-| rdfs:label@el = μέση θερμοκρασία
-| rdfs:domain = Planet
-| rdfs:range = Temperature
-}}</text></revision></page><page><title>OntologyProperty:Meaning</title><ns>202</ns><id>1117</id><revision><id>46253</id><timestamp>2015-03-18T14:40:38Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = meaning
-| rdfs:label@de = Bedeutung
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Measurements</title><ns>202</ns><id>3290</id><revision><id>33885</id><timestamp>2014-04-04T14:57:48Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = measurements    
-| rdfs:label@de = Messungen
-| rdfs:label@pt = medidas
-| rdfs:domain = Person
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Medalist</title><ns>202</ns><id>5669</id><revision><id>36273</id><timestamp>2014-07-08T14:02:14Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = medalist
-| rdfs:label@de = Medaillengewinner
-| rdfs:label@pt = medalhista
-| rdfs:domain = SportsEvent
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:hasParticipant
-}}</text></revision></page><page><title>OntologyProperty:Media</title><ns>202</ns><id>7701</id><revision><id>33887</id><timestamp>2014-04-04T14:57:56Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|media}}
-{{label|de|Medien}}
-| rdfs:domain = Person
-}}</text></revision></page><page><title>OntologyProperty:MediaItem</title><ns>202</ns><id>11724</id><revision><id>51366</id><timestamp>2016-07-10T20:04:12Z</timestamp><text>{{ObjectProperty
-| labels=
-  {{label|en|media item}}
-  {{label|de|Multimediaelement}}
-| comments= 
-  {{comment|en|A media file (such as audio, video or images) associated with the subject}}
-| rdfs:domain = owl:Thing
-| rdfs:range = File
-}}</text></revision></page><page><title>OntologyProperty:MediaType</title><ns>202</ns><id>1120</id><revision><id>56807</id><timestamp>2022-02-28T22:15:55Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|media type}}
-        {{label|fr|type de média}}
-	{{label|de|Medientyp}}
-	{{label|nl|mediatype}}
-| rdfs:domain = WrittenWork
-| owl:equivalentProperty = 
-| rdfs:subPropertyOf = 
-| comments = 
-    {{comment|en|Print / On-line (then binding types etc. if relevant)}}
-    {{comment|fr|Imprimer / En-ligne (puis types associés etc. si nécessaire)}}
-}}</text></revision></page><page><title>OntologyProperty:MedicalCause</title><ns>202</ns><id>11862</id><revision><id>52199</id><timestamp>2017-10-07T14:20:14Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|medical cause}}
-	{{label|fr|médical cause}}
-	{{label|de|medizinische Ursache}}
-	{{label|el|αιτία Ιατρικός}}
-| rdfs:domain = Disease
-| rdfs:range = owl:Thing
-}}</text></revision></page><page><title>OntologyProperty:MedicalDiagnosis</title><ns>202</ns><id>11864</id><revision><id>52201</id><timestamp>2017-10-07T14:35:55Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|medical diagnosis}}
-	{{label|fr|diagnostic médical}}
-	{{label|de|medizinische Diagnose}}
-| rdfs:domain = Disease
-| rdfs:range = owl:Thing
-}}</text></revision></page><page><title>OntologyProperty:MedicalSpecialty</title><ns>202</ns><id>11868</id><revision><id>52205</id><timestamp>2017-10-07T14:57:35Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|de|medizinisches Fachgebiet}}
-	{{label|en|medical specialty}}
-	{{label|nl|medisch specialisme}}
-	{{label|el|ιατρική ειδικότητα}}
-	{{label|fr|spécialité médicale}}
-	{{label|ko|진료과}}
-	{{label|ja|診療科}}
-	{{label|it|specializzazione medica}}
-| rdfs:domain = Disease
-| rdfs:range = MedicalSpecialty
-}}</text></revision></page><page><title>OntologyProperty:Medication</title><ns>202</ns><id>11866</id><revision><id>52203</id><timestamp>2017-10-07T14:40:02Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|medication}}
-	{{label|fr|médication}}
-	{{label|de|Medikation}}
-| rdfs:domain = Disease
-| rdfs:range = owl:Thing
-}}</text></revision></page><page><title>OntologyProperty:MedlinePlus</title><ns>202</ns><id>1121</id><revision><id>52395</id><timestamp>2017-10-15T12:20:36Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|MedlinePlus}}
-{{label|nl|MedlinePlus}}
-| rdfs:domain = owl:Thing
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:MeetingBuilding</title><ns>202</ns><id>1122</id><revision><id>36275</id><timestamp>2014-07-08T14:02:20Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = meeting building
-| rdfs:label@de = Tagungsgebäude
-| rdfs:domain = Legislature
-| rdfs:range = Building
-| rdfs:subPropertyOf = dul:hasLocation
-}}</text></revision></page><page><title>OntologyProperty:MeetingCity</title><ns>202</ns><id>1123</id><revision><id>36276</id><timestamp>2014-07-08T14:02:23Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = meeting city
-| rdfs:domain = Legislature
-| rdfs:range = Settlement
-| rdfs:subPropertyOf = dul:hasLocation
-}}</text></revision></page><page><title>OntologyProperty:MeetingRoad</title><ns>202</ns><id>3381</id><revision><id>36277</id><timestamp>2014-07-08T14:02:37Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = meeting road 
-| rdfs:label@de = zusammentreffende Straße
-| rdfs:domain = RoadJunction
-| rdfs:range = Road
-| rdfs:comment@en = A road that crosses another road at the junction.
-| rdfs:comment@de = Eine Straße die an der Kreuzung eine andere Straße kreuzt.
-| rdfs:subPropertyOf = dul:hasCommonBoundary
-}}</text></revision></page><page><title>OntologyProperty:MeltingPoint</title><ns>202</ns><id>1124</id><revision><id>19112</id><timestamp>2012-07-31T07:47:44Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = melting point
-| rdfs:label@de = Schmelzpunkt
-| rdfs:label@fr = point de fusion
-| rdfs:label@ja = 融点
-| rdfs:range = Temperature
-}}</text></revision></page><page><title>OntologyProperty:Member</title><ns>202</ns><id>6823</id><revision><id>58790</id><timestamp>2022-05-31T15:05:41Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|member}}
-{{label|de|Mitglied}}
-{{label|nl|lid van}}
-| rdfs:domain = Person
-| rdfs:range = xsd:string
-| owl:equivalentProperty = wikidata:P463
-}}</text></revision></page><page><title>OntologyProperty:MemberOfParliament</title><ns>202</ns><id>1125</id><revision><id>36278</id><timestamp>2014-07-08T14:02:40Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = Member of Parliament
-| rdfs:label@de = Abgeordnete
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:hasMember
-}}</text></revision></page><page><title>OntologyProperty:Membership</title><ns>202</ns><id>1126</id><revision><id>35704</id><timestamp>2014-06-30T21:32:17Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|membership}}
-{{label|de|Mitgliedschaft}}
-{{label|nl|lidmaatschap}}
-| rdfs:domain = Organisation
-| rdfs:range = rdf:langString
-}}</text></revision></page><page><title>OntologyProperty:MembershipAsOf</title><ns>202</ns><id>6478</id><revision><id>23748</id><timestamp>2013-02-15T12:00:03Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|date membership established}}
-{{label|nl|datum vaststellen ledental}}
-| rdfs:domain = Organisation, Parish
-| rdfs:range = xsd:date
-}}</text></revision></page><page><title>OntologyProperty:Mentor</title><ns>202</ns><id>7336</id><revision><id>36279</id><timestamp>2014-07-08T14:02:43Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|mentor}}
-	{{label|de|Mentor}}
-	{{label|fr|maître}}
-	{{label|fr|mentor}}
-| rdfs:domain = Artist
-| rdfs:range = Artist
-| comments =
-	{{comment|en|A wise and trusted counselor or teacher&lt;ref&gt;http://en.wiktionary.org/wiki/mentor&lt;/ref&gt;}}
-	{{comment|fr|Celui qui sert de guide, de conseiller à quelqu’un. &lt;ref&gt;http://fr.wiktionary.org/wiki/mentor&lt;/ref&gt;}}
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}
-&lt;references/&gt;</text></revision></page><page><title>OntologyProperty:MergedIntoParty</title><ns>202</ns><id>11952</id><revision><id>52500</id><timestamp>2017-10-17T22:49:21Z</timestamp><text>#REDIRECT [[OntologyProperty:MergedWith]]</text></revision></page><page><title>OntologyProperty:MergedSettlement</title><ns>202</ns><id>7900</id><revision><id>27425</id><timestamp>2013-07-12T10:15:10Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|merged settlement}}
-| rdfs:domain = Settlement
-| rdfs:range = Settlement
-}}</text></revision></page><page><title>OntologyProperty:MergedWith</title><ns>202</ns><id>3725</id><revision><id>52502</id><timestamp>2017-10-17T22:50:47Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = merged with
-| rdfs:label@de = zusammengeschlossen
-| rdfs:domain = Organisation
-| rdfs:range = Organisation
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:MergerDate</title><ns>202</ns><id>7107</id><revision><id>25634</id><timestamp>2013-05-26T13:54:39Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|merger date}}
-| rdfs:domain = Place
-| rdfs:range = xsd:date
-}}</text></revision></page><page><title>OntologyProperty:MeshId</title><ns>202</ns><id>1127</id><revision><id>47609</id><timestamp>2015-04-03T10:01:48Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|MeSH ID}}
-{{label|nl|MeSH ID}}
-| rdfs:domain = Disease
-| rdfs:range = xsd:string
-| owl:equivalentProperty = wikidata:P486
-}}</text></revision></page><page><title>OntologyProperty:MeshName</title><ns>202</ns><id>1128</id><revision><id>34824</id><timestamp>2014-05-15T05:05:55Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = MeSH name
-| rdfs:domain = AnatomicalStructure
-| rdfs:range = rdf:langString
-}}</text></revision></page><page><title>OntologyProperty:MeshNumber</title><ns>202</ns><id>1129</id><revision><id>50152</id><timestamp>2016-01-04T20:18:55Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = MeSH number
-| rdfs:domain = AnatomicalStructure
-| rdfs:range = xsd:string
-| rdfs:subPropertyOf = code
-}}</text></revision></page><page><title>OntologyProperty:MessierName</title><ns>202</ns><id>8922</id><revision><id>30753</id><timestamp>2014-01-22T11:52:39Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = Messier name
-| rdfs:comment@en = Name for Messier objects
-| rdfs:subPropertyOf = name
-| rdfs:domain = CelestialBody
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:MetropolitanBorough</title><ns>202</ns><id>2141</id><revision><id>36281</id><timestamp>2014-07-08T14:02:49Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|metropolitan borough}}
-	{{label|nl|stadswijk}}
-| rdfs:domain = PopulatedPlace
-| rdfs:range = PopulatedPlace
-| rdfs:subPropertyOf = dul:isPartOf
-}}</text></revision></page><page><title>OntologyProperty:Mgiid</title><ns>202</ns><id>5029</id><revision><id>19132</id><timestamp>2012-07-31T11:18:56Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = mgiid
-| rdfs:label@ja = mgiid
-| rdfs:comment@en = Mouse Genomic Informatics ID
-| rdfs:domain = Biomolecule
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:MilitaryBranch</title><ns>202</ns><id>1703</id><revision><id>58791</id><timestamp>2022-05-31T15:09:37Z</timestamp><text>{{ObjectProperty
-| rdfs:label@en = military branch
-| rdfs:comment@en = The service branch (Army, Navy, etc.) a person is part of.
-| rdfs:domain = MilitaryPerson
-| rdfs:range = MilitaryUnit
-| owl:equivalentProperty = wikidata:P7779
-| rdfs:subPropertyOf = dul:isMemberOf
-}}</text></revision></page><page><title>OntologyProperty:MilitaryCommand</title><ns>202</ns><id>1700</id><revision><id>33894</id><timestamp>2014-04-04T14:58:26Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = military command
-| rdfs:label@de = Militärkommando
-| rdfs:domain = MilitaryPerson
-| rdfs:comment@en =  For persons who are notable as commanding officers, the units they commanded. Dates should be given if multiple notable commands were held.
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:MilitaryFunction</title><ns>202</ns><id>7886</id><revision><id>49150</id><timestamp>2015-10-13T10:04:44Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|military function}}
-{{label|de|militärische Funktion}}
-| rdfs:domain = MilitaryPerson
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:MilitaryGovernment</title><ns>202</ns><id>7555</id><revision><id>33896</id><timestamp>2014-04-04T14:58:35Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|military government}}
-{{label|de|Militärregierung}}
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:MilitaryRank</title><ns>202</ns><id>1130</id><revision><id>36283</id><timestamp>2014-07-08T14:02:56Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = military rank
-| rdfs:label@de = militärischer Rang
-| rdfs:comment@en = The highest rank achieved by a person.
-| rdfs:domain = MilitaryPerson
-| rdfs:subPropertyOf = dul:isMemberOf
-}}</text></revision></page><page><title>OntologyProperty:MilitaryService</title><ns>202</ns><id>11951</id><revision><id>52490</id><timestamp>2017-10-16T17:16:02Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|military service}}
-	{{label|de|Militärdienst}}
-	{{label|de|service militaire}}
-| rdfs:domain = Person
-| rdfs:range = MilitaryService
-}}</text></revision></page><page><title>OntologyProperty:MilitaryUnit</title><ns>202</ns><id>1699</id><revision><id>36284</id><timestamp>2014-07-08T14:02:59Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = military unit
-| rdfs:label@de = Militäreinheit
-| rdfs:domain = MilitaryPerson
-| rdfs:comment@en = For persons who are not notable as commanding officers, the unit (company, battalion, regiment, etc.) in which they served.
-| rdfs:range = MilitaryUnit
-| rdfs:subPropertyOf = dul:isMemberOf
-}}</text></revision></page><page><title>OntologyProperty:MilitaryUnitSize</title><ns>202</ns><id>2108</id><revision><id>8361</id><timestamp>2010-05-28T13:53:52Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = military unit size
-| rdfs:comment@en = the size of the military unit
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:MillSpan</title><ns>202</ns><id>6012</id><revision><id>22349</id><timestamp>2013-01-11T20:35:27Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|mill span}}
-{{label|nl|vlucht}}
-{{label|el|Εκπέτασμα}}
-| rdfs:domain = Mill
-| rdfs:range = Length
-}}</text></revision></page><page><title>OntologyProperty:MillType</title><ns>202</ns><id>6011</id><revision><id>36285</id><timestamp>2014-07-08T14:03:02Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|el|τύπος μύλου}}
-	{{label|en|mill type}}
-	{{label|nl|molen-type}}
-| rdfs:domain = Mill
-| rdfs:subPropertyOf = dul:isClassifiedBy
-}}</text></revision></page><page><title>OntologyProperty:MillsCodeBE</title><ns>202</ns><id>6316</id><revision><id>22365</id><timestamp>2013-01-11T20:52:16Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|mill code BE}}
-{{label|nl|molen code BE}}
-| comments =
-{{comment|en|mills code from the Belgian database on mills}}
-{{comment|nl|unieke code voor molens in database www.molenechos.org}}
-| rdfs:domain = Mill
-| rdfs:range = xsd:string
-| rdfs:comment@en = 
-}}</text></revision></page><page><title>OntologyProperty:MillsCodeDutch</title><ns>202</ns><id>6052</id><revision><id>22364</id><timestamp>2013-01-11T20:50:22Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|mill code NL}}
-{{label|nl|molen code NL}}
-| rdfs:domain = Mill
-| rdfs:range = xsd:string
-| rdfs:comment@en = 
-}}</text></revision></page><page><title>OntologyProperty:MillsCodeNL</title><ns>202</ns><id>6050</id><revision><id>22360</id><timestamp>2013-01-11T20:45:13Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|mill code NL}}
-{{label|nl|molen code NL}}
-| rdfs:domain = Mill
-| rdfs:range = xsd:string
-| comments =
-{{comment|en|mills code from the central Dutch database on mills}}
-{{comment|nl|unieke code voor molens in www.molendatabase.nl}}
-}}</text></revision></page><page><title>OntologyProperty:MillsCodeNLVerdwenen</title><ns>202</ns><id>6051</id><revision><id>22362</id><timestamp>2013-01-11T20:48:23Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|mill dissapeared code NL }}
-{{label|nl|verdwenen molen code NL}}
-| rdfs:domain = Mill
-| rdfs:range = xsd:string
-| rdfs:comment@en = 
-}}</text></revision></page><page><title>OntologyProperty:MillsCodeNLWindmotoren</title><ns>202</ns><id>6053</id><revision><id>22366</id><timestamp>2013-01-11T20:52:55Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|millsCodeNLWindmotoren}}
-{{label|nl|millsCodeNLWindmotoren}}
-| rdfs:domain = Mill
-| rdfs:range = xsd:string
-| rdfs:comment@en = 
-}}</text></revision></page><page><title>OntologyProperty:Min</title><ns>202</ns><id>7918</id><revision><id>27623</id><timestamp>2013-07-15T13:27:38Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|min}}
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:MinTime</title><ns>202</ns><id>11299</id><revision><id>48772</id><timestamp>2015-08-13T10:24:01Z</timestamp><text>{{DatatypeProperty
-| labels =
-   {{label|en|minimum preparation time}}
-| comments =
-   {{comment|en|Minimum preparation time of a recipe / Food}}
-| rdfs:domain = Food
-| rdfs:range = Time
-}}</text></revision></page><page><title>OntologyProperty:MinimumArea</title><ns>202</ns><id>7086</id><revision><id>33899</id><timestamp>2014-04-04T14:58:47Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|minimum area}}
-{{label|de|Mindestfläche}}
-| rdfs:domain = Place
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:MinimumAreaQuote</title><ns>202</ns><id>7087</id><revision><id>25611</id><timestamp>2013-05-26T13:28:25Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|minimum area quote}}
-| rdfs:domain = Place
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:MinimumDischarge</title><ns>202</ns><id>1131</id><revision><id>8131</id><timestamp>2010-05-28T13:22:50Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = minimum discharge
-| rdfs:range = FlowRate
-}}</text></revision></page><page><title>OntologyProperty:MinimumElevation</title><ns>202</ns><id>1132</id><revision><id>11274</id><timestamp>2011-03-30T09:41:32Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = minimum elevation
-| rdfs:label@el = βάση
-| rdfs:domain = Place
-| rdfs:range = Length
-| rdfs:comment@en = minimum elevation above the sea level
-}}</text></revision></page><page><title>OntologyProperty:MinimumInclination</title><ns>202</ns><id>1133</id><revision><id>8133</id><timestamp>2010-05-28T13:23:05Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = minimum inclination
-| rdfs:domain = LaunchPad
-| rdfs:range = xsd:float
-}}</text></revision></page><page><title>OntologyProperty:MinimumTemperature</title><ns>202</ns><id>1134</id><revision><id>33900</id><timestamp>2014-04-04T14:58:52Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = minimum temperature
-| rdfs:label@de = geringste Temperatur
-| rdfs:label@el = ελάχιστη θερμοκρασία
-| rdfs:domain = Planet
-| rdfs:range = Temperature
-}}</text></revision></page><page><title>OntologyProperty:Minister</title><ns>202</ns><id>11949</id><revision><id>52488</id><timestamp>2017-10-16T16:44:23Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|minister}}
-	{{label|de|Minister}}
-	{{label|fr|ministre}}
-| rdfs:range = Politician
-}}</text></revision></page><page><title>OntologyProperty:Minority</title><ns>202</ns><id>6909</id><revision><id>33901</id><timestamp>2014-04-04T14:58:56Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|minority}}
-{{label|de|Minderheit}}
-| rdfs:domain = Settlement
-| rdfs:range = Group
-}}</text></revision></page><page><title>OntologyProperty:MinorityFloorLeader</title><ns>202</ns><id>2363</id><revision><id>8402</id><timestamp>2010-05-28T13:59:28Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = minority floor leader
-| rdfs:comment@en = number of office holder
-| rdfs:range = xsd:integer
-}}</text></revision></page><page><title>OntologyProperty:MinorityLeader</title><ns>202</ns><id>2361</id><revision><id>8400</id><timestamp>2010-05-28T13:59:12Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = minority leader
-| rdfs:comment@en = number of office holder
-| rdfs:range = xsd:integer
-}}</text></revision></page><page><title>OntologyProperty:MirDockings</title><ns>202</ns><id>1135</id><revision><id>10385</id><timestamp>2010-11-10T14:33:03Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = mir dockings
-| rdfs:domain = SpaceShuttle
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:Mission</title><ns>202</ns><id>1136</id><revision><id>51585</id><timestamp>2016-11-04T12:53:04Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = mission
-| rdfs:label@de = Mission
-| rdfs:label@el = αποστολή
-| rdfs:domain =
-| rdfs:range = SpaceMission
-| rdfs:subPropertyOf = dul:isParticipantIn
-}}</text></revision></page><page><title>OntologyProperty:MissionDuration</title><ns>202</ns><id>1137</id><revision><id>33903</id><timestamp>2014-04-04T14:59:06Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = mission duration
-| rdfs:label@de = Missionsdauer
-| rdfs:domain = SpaceMission
-| rdfs:range = Time
-}}</text></revision></page><page><title>OntologyProperty:Missions</title><ns>202</ns><id>1138</id><revision><id>33904</id><timestamp>2014-04-04T14:59:11Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = missions
-| rdfs:label@de = Missionen
-| rdfs:label@el = αποστολές
-| rdfs:domain = SpaceShuttle
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:Model</title><ns>202</ns><id>1139</id><revision><id>33905</id><timestamp>2014-04-04T14:59:15Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = model
-| rdfs:label@de = Modell
-| rdfs:label@fr = modèle
-| rdfs:domain = Sales
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:ModelEndDate</title><ns>202</ns><id>1140</id><revision><id>8139</id><timestamp>2010-05-28T13:23:50Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = model end date
-| rdfs:domain = MeanOfTransportation
-| rdfs:range = xsd:date
-}}</text></revision></page><page><title>OntologyProperty:ModelEndYear</title><ns>202</ns><id>1141</id><revision><id>8140</id><timestamp>2010-05-28T13:23:56Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = model end year
-| rdfs:domain = MeanOfTransportation
-| rdfs:range = xsd:gYear
-}}</text></revision></page><page><title>OntologyProperty:ModelLineVehicle</title><ns>202</ns><id>11176</id><revision><id>48523</id><timestamp>2015-08-05T14:54:18Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|type series}}
-{{label|de|Baureihe}}
-| rdfs:domain =  MeanOfTransportation
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:ModelStartDate</title><ns>202</ns><id>1142</id><revision><id>8141</id><timestamp>2010-05-28T13:24:05Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = model start date
-| rdfs:domain = MeanOfTransportation
-| rdfs:range = xsd:date
-}}</text></revision></page><page><title>OntologyProperty:ModelStartYear</title><ns>202</ns><id>1143</id><revision><id>8142</id><timestamp>2010-05-28T13:24:12Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = model start year
-| rdfs:domain = MeanOfTransportation
-| rdfs:range = xsd:gYear
-}}</text></revision></page><page><title>OntologyProperty:Moderna</title><ns>202</ns><id>13126</id><revision><id>56977</id><timestamp>2022-03-09T10:37:47Z</timestamp><text>{{DatatypeProperty
-| labels =
-    {{label|en|Moderna}}
-    {{label|fr|Moderna}}
-    {{label|zh|莫德纳}}
-| comments =
-	{{comment|en|Moderna, Inc is an American pharmaceutical and biotechnology company based in Cambridge, Massachusetts.}}
-	{{comment|fr|Moderna, Inc et une compagnie américaine pharmaceutique et de biotechnologie basée à Cambridge, Massachusetts.}}
-	{{comment|zh|莫德纳，是一家总部位于美国马萨诸塞州剑桥市的跨国制药、生物技术公司，专注于癌症免疫治疗，包括基于mRNA的药物发现、药物研发和疫苗技术}}
-| rdfs:range = xsd:string
-| owl:equivalentProperty = vaccine
-| rdfs:domain = owl:Thing
-}}</text></revision></page><page><title>OntologyProperty:ModernaCumul</title><ns>202</ns><id>13127</id><revision><id>54913</id><timestamp>2021-08-12T06:23:43Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|ModernaCumulativeDoses}}
-| comments =
-	{{comment|en|Moderna, Inc is an American pharmaceutical and biotechnology company based in Cambridge, Massachusetts. }}
-	{{comment|en|莫德纳，是一家总部位于美国马萨诸塞州剑桥市的跨国制药、生物技术公司，专注于癌症免疫治疗，包括基于mRNA的药物发现、药物研发和疫苗技术}}
-| rdfs:range = xsd:integer
-| owl:equivalentProperty = moderna
-| rdfs:domain = owl:Thing
-}}</text></revision></page><page><title>OntologyProperty:MolarMass</title><ns>202</ns><id>12041</id><revision><id>53184</id><timestamp>2018-09-28T14:26:56Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|molar mass}}
-{{label|de|Molare Masse}}
-{{label|nl|Molaire massa}}
-| rdfs:domain = ChemicalSubstance
-| rdfs:range = xsd:double
-| rdfs:subPropertyOf  = mass
-}}</text></revision></page><page><title>OntologyProperty:MolecularWeight</title><ns>202</ns><id>9141</id><revision><id>33906</id><timestamp>2014-04-04T14:59:21Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|molecular weight}}
-{{label|de|Molekulargewicht}}
-{{label|nl|molgewicht}}
-| rdfs:domain = ChemicalSubstance
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:Monarch</title><ns>202</ns><id>2327</id><revision><id>36287</id><timestamp>2014-07-08T14:03:08Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|monarch}}
-	{{label|de|Monarch}}
-	{{label|nl|monarch}}
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:Month</title><ns>202</ns><id>5344</id><revision><id>22574</id><timestamp>2013-01-14T21:24:19Z</timestamp><text>{{ DatatypeProperty
-
-	| rdfs:label@en = month
-	| rdfs:label@el = μήνας
-        | rdfs:label@de = Monat
-	| rdfs:domain = owl:Thing
-	| rdfs:range = xsd:string
-
-}}</text></revision></page><page><title>OntologyProperty:Mood</title><ns>202</ns><id>7766</id><revision><id>33908</id><timestamp>2014-04-04T14:59:29Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|mood}}
-{{label|de|Stimmung}}
-| rdfs:domain = Person
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:MostDownPoint</title><ns>202</ns><id>6916</id><revision><id>36288</id><timestamp>2014-07-08T14:03:11Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|most down point of a norwegian settlement}}
-| rdfs:domain = NorwaySettlement
-| rdfs:range = Place
-| rdfs:subPropertyOf = dul:hasPart
-}}</text></revision></page><page><title>OntologyProperty:MostSuccessfulPlayer</title><ns>202</ns><id>11839</id><revision><id>52041</id><timestamp>2017-05-06T16:23:13Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|most successful player}}
-	{{label|es|mejor jugador}}
-| rdfs:domain = SportsEvent
-| rdfs:range = Athlete
-| comments =
-	{{comment|en|the best player in a certain sport competition. E.g, in a football competition, the player that scored more goals.}}
-        {{comment|es|el mejor jugador de una cierta competición deportiva. Por ejemplo, en una competición de fútbol, aquel jugador que ha marcado más goles. }}
-}}</text></revision></page><page><title>OntologyProperty:MostWins</title><ns>202</ns><id>1144</id><revision><id>36289</id><timestamp>2014-07-08T14:03:15Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = most wins
-| rdfs:label@de = die meisten Siege
-| rdfs:domain = Race
-| rdfs:subPropertyOf = dul:hasParticipant
-}}</text></revision></page><page><title>OntologyProperty:Mother</title><ns>202</ns><id>7546</id><revision><id>53585</id><timestamp>2020-01-30T18:04:33Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|mother}}
-	{{label|de|Mutter}}
-| rdfs:domain = Woman
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:sameSettingAs
-| owl:equivalentProperty = wikidata:P25
-}}</text></revision></page><page><title>OntologyProperty:Motive</title><ns>202</ns><id>11897</id><revision><id>56822</id><timestamp>2022-03-01T00:09:04Z</timestamp><text>{{DatatypeProperty
-| labels =
-    {{label|en|motive}}
-    {{label|fr|motif}}
-    {{label|de|Motiv}}
-| rdfs:domain = Criminal
-| rdfs:range = xsd:string
-| comments = 
-    {{comment|en|The motive of the crime(s) this individual is known for.}}
-    {{comment|fr|Motif du ou des crimes pour lesquels cette personne est connue.}}
-}}</text></revision></page><page><title>OntologyProperty:Motto</title><ns>202</ns><id>1146</id><revision><id>33913</id><timestamp>2014-04-04T15:00:15Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|motto}}
-{{label|de|Motto}}
-{{label|nl|motto}}
-{{label|el|σύνθημα}}
-{{label|pt|lema}}
-{{label|fr|devise}}
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Mount</title><ns>202</ns><id>7851</id><revision><id>27249</id><timestamp>2013-07-09T14:23:13Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = mount
-| rdfs:domain = Person
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:MountainRange</title><ns>202</ns><id>2415</id><revision><id>36291</id><timestamp>2014-07-08T14:03:22Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|mountain range}}
-	{{label|de|Gebirge}}
-	{{label|nl|bergketen}}
-| rdfs:domain = Mountain
-| rdfs:range = MountainRange
-| rdfs:subPropertyOf = dul:isPartOf
-}}</text></revision></page><page><title>OntologyProperty:MouthCountry</title><ns>202</ns><id>1148</id><revision><id>36292</id><timestamp>2014-07-08T14:03:25Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = mouth country
-| rdfs:label@el = χώρες_λεκάνης
-| rdfs:domain = River
-| rdfs:range = Country
-| rdfs:subPropertyOf = dul:hasLocation
-}}</text></revision></page><page><title>OntologyProperty:MouthDistrict</title><ns>202</ns><id>1149</id><revision><id>36293</id><timestamp>2014-07-08T14:03:28Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = mouth district
-| rdfs:domain = River
-| rdfs:range = PopulatedPlace
-| rdfs:subPropertyOf = dul:hasLocation
-}}</text></revision></page><page><title>OntologyProperty:MouthElevation</title><ns>202</ns><id>1150</id><revision><id>11462</id><timestamp>2011-03-31T21:54:23Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = mouth elevation
-| rdfs:label@el = ύψος_εκβολών
-| rdfs:range = Length
-}}</text></revision></page><page><title>OntologyProperty:MouthMountain</title><ns>202</ns><id>1151</id><revision><id>36294</id><timestamp>2014-07-08T14:03:31Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = mouth mountain
-| rdfs:domain = River
-| rdfs:range = Mountain
-| rdfs:subPropertyOf = dul:hasLocation
-}}</text></revision></page><page><title>OntologyProperty:MouthPlace</title><ns>202</ns><id>1152</id><revision><id>36295</id><timestamp>2014-07-08T14:03:48Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = mouth place
-| rdfs:domain = River
-| rdfs:range = PopulatedPlace
-| rdfs:subPropertyOf = dul:hasLocation
-}}</text></revision></page><page><title>OntologyProperty:MouthPosition</title><ns>202</ns><id>1153</id><revision><id>36296</id><timestamp>2014-07-08T14:03:52Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = mouth position
-| rdfs:label@it = foce (di un fiume)
-| rdfs:label@es = lugar de desembocadura
-| rdfs:domain = River
-| rdfs:range = geo:SpatialThing
-| rdfs:subPropertyOf = dul:hasLocation
-}}</text></revision></page><page><title>OntologyProperty:MouthRegion</title><ns>202</ns><id>1154</id><revision><id>36297</id><timestamp>2014-07-08T14:03:56Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = mouth region
-| rdfs:domain = River
-| rdfs:range = PopulatedPlace
-| rdfs:subPropertyOf = dul:hasLocation
-}}</text></revision></page><page><title>OntologyProperty:MouthState</title><ns>202</ns><id>1155</id><revision><id>36298</id><timestamp>2014-07-08T14:03:59Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = mouth state
-| rdfs:domain = River
-| rdfs:range = PopulatedPlace
-| rdfs:subPropertyOf = dul:hasLocation
-}}</text></revision></page><page><title>OntologyProperty:Movement</title><ns>202</ns><id>1156</id><revision><id>47610</id><timestamp>2015-04-03T10:03:18Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|movement}}
-	{{label|de|Bewegung}}
-	{{label|nl|beweging}}
-	{{label|fr|mouvement artistique}}
-| rdfs:domain = Artist
-| rdfs:comment@en = artistic movement or school with which artist is associated
-| rdfs:subPropertyOf = dul:isMemberOf
-| owl:equivalentProperty = wikidata:P135
-}}</text></revision></page><page><title>OntologyProperty:Movie</title><ns>202</ns><id>6825</id><revision><id>36300</id><timestamp>2014-07-08T14:04:06Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|movie}}
-	{{label|de|Film}}
-| rdfs:domain = Person
-| rdfs:range = Film
-| rdfs:subPropertyOf = dul:isParticipantIn
-}}</text></revision></page><page><title>OntologyProperty:Mukhtar</title><ns>202</ns><id>6960</id><revision><id>25434</id><timestamp>2013-05-25T13:45:32Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|mukthar of a lebanon settlement}}
-| rdfs:domain = LebanonSettlement
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Municipality</title><ns>202</ns><id>1157</id><revision><id>53698</id><timestamp>2020-09-04T15:25:28Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|municipality}}
-	{{label|de|Gemeinde}}
-	{{label|nl|plaats}}
-	{{label|fr|municipalité}}
-| rdfs:range = PopulatedPlace
-| rdfs:subPropertyOf = dul:isPartOf
-| owl:equivalentProperty = ceo:heeftGemeente
-}}</text></revision></page><page><title>OntologyProperty:MunicipalityAbsorbedBy</title><ns>202</ns><id>8145</id><revision><id>33951</id><timestamp>2014-04-04T15:04:04Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|absorbed by}}
-{{label|nl|opgegaan in}}
-| rdfs:domain = FormerMunicipality
-| rdfs:range = Municipality
-}}</text></revision></page><page><title>OntologyProperty:MunicipalityCode</title><ns>202</ns><id>2439</id><revision><id>53699</id><timestamp>2020-09-04T15:26:26Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|municipality code}}
-{{label|de|Gemeindecode}}
-{{label|nl|gemeente-code}}
-| rdfs:comment@en = The [http://en.wikipedia.org/wiki/Community_Identification_Number Official Municipality Key], formerly also known as the Official Municipality Characteristic Number or Municipality Code Number, is a number sequence for the identification of politically independent municipalities or unincorporated areas. It is used in Germany, Austria and Switzerland.
-| rdfs:domain = Place
-| rdfs:range = xsd:string
-| owl:equivalentProperty = ceo:gemeenteCode
-}}</text></revision></page><page><title>OntologyProperty:MunicipalityRenamedTo</title><ns>202</ns><id>8148</id><revision><id>33920</id><timestamp>2014-04-04T15:00:55Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|a municipality's new name}}
-{{label|de|neuer Name einer Gemeinde}}
-{{label|nl|nieuwe gemeentenaam}}
-| rdfs:domain = Municipality
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:MunicipalityType</title><ns>202</ns><id>4203</id><revision><id>33921</id><timestamp>2014-04-04T15:01:03Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|type of municipality}}
-{{label|de|Gemeindetyp}}
-{{label|nl|type gemeente}}
-| rdfs:domain = Municipality
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Museum</title><ns>202</ns><id>5622</id><revision><id>36302</id><timestamp>2014-07-08T14:04:12Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|museum}}
-	{{label|el|μουσείο}}
-	{{label|de|museum}}
-	{{label|ja|博物館}}
-| rdfs:domain = Artwork
-| rdfs:range = Museum
-| rdfs:subPropertyOf = dul:hasLocation
-}}</text></revision></page><page><title>OntologyProperty:MuseumType</title><ns>202</ns><id>6271</id><revision><id>36303</id><timestamp>2014-07-08T14:04:15Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|museumType}}
-	{{label|nl|soort museum}}
-| comments =
-	{{comment|en|This property has been added  because 'buildingType' is much more about the place, whereas 'museumType' is about the way the place is being (or:was) used}}
-	{{comment|nl|Nieuw type is nodig omdat Museum eigenlijk geen subklasse van Building is, maar meer te maken heeft met de functie van het gebouw. 'Museumtype' is dan ook meer thema- en collectiegerelateerd }}
-| rdfs:domain = Museum
-| rdfs:range = owl:Thing
-| rdf:type = | rdfs:subPropertyOf     = Type
-| owl:equivalentProperty = 
-| rdfs:subPropertyOf = dul:isClassifiedBy
-}}</text></revision></page><page><title>OntologyProperty:MusicBand</title><ns>202</ns><id>9274</id><revision><id>56885</id><timestamp>2022-03-02T17:34:26Z</timestamp><text>{{ObjectProperty
-| labels =
-    {{label|en|Music Band}}
-    {{label|fr|orchestre}}
-| rdfs:domain = MusicalArtist
-| rdfs:range = Band
-}}</text></revision></page><page><title>OntologyProperty:MusicBrainzArtistId</title><ns>202</ns><id>12328</id><revision><id>53648</id><timestamp>2020-07-12T09:50:34Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|MusicBrainz artist id}}
-{{label|nl|MusicBrainz artist id}}
-{{label|el|MusicBrainz artist id}}
-{{label|ja|MusicBrainz artist id}}
-|comments=
-{{comment|en|MusicBrainz artist. Applies to artists}}
-| rdfs:range = xsd:string
-| owl:equivalentProperty = wikidata:P434
-| rdfs:subPropertyOf = code
-}}</text></revision></page><page><title>OntologyProperty:MusicBy</title><ns>202</ns><id>1161</id><revision><id>47611</id><timestamp>2015-04-03T10:04:05Z</timestamp><text>{{ObjectProperty
-| rdfs:label@en = music by
-| rdfs:label@de = Musik von
-| rdfs:domain = Musical
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:coparticipatesWith
-| owl:equivalentProperty = wikidata:P86
-}}</text></revision></page><page><title>OntologyProperty:MusicComposer</title><ns>202</ns><id>1158</id><revision><id>59618</id><timestamp>2024-05-31T19:32:20Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|music composer}}
-	{{label|de|komponist}}
-	{{label|nl|componist}}
-	{{label|el|μουσική}}
-    {{label|am|የሙዚቃ አቀናባሪ}}
-| rdfs:domain = Work
-| rdfs:range = MusicalArtist
-| owl:equivalentProperty = schema:musicBy
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:MusicFormat</title><ns>202</ns><id>6433</id><revision><id>57104</id><timestamp>2022-03-12T19:33:50Z</timestamp><text>{{DatatypeProperty 
-| labels = 
-  {{label|en|musicFormat}}
-  {{label|de|musikFormate}}
-  {{label|fr|format de la musique}}
-| comments = 
-  {{comment|en|The format of the album: EP, Single etc.}}
-  {{comment|fr|Format de l'album: EP, 45tours (single), etc.}}
-| rdfs:domain = Album
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:MusicFusionGenre</title><ns>202</ns><id>1162</id><revision><id>36306</id><timestamp>2014-07-08T14:04:25Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = music fusion genre
-| rdfs:domain = MusicGenre
-| rdfs:range = MusicGenre
-| rdfs:subPropertyOf = dul:overlaps
-}}</text></revision></page><page><title>OntologyProperty:MusicSubgenre</title><ns>202</ns><id>1163</id><revision><id>36307</id><timestamp>2014-07-08T14:04:28Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = music subgenre
-| rdfs:label@de = Musik Subgenre
-| rdfs:domain = MusicGenre
-| rdfs:range = MusicGenre
-| rdfs:subPropertyOf = dul:isSpecializedBy
-}}</text></revision></page><page><title>OntologyProperty:MusicType</title><ns>202</ns><id>6258</id><revision><id>36308</id><timestamp>2014-07-08T14:04:31Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|musicType}}
-	{{label|nl|soort muziekwerk}}
-| comments =
-	{{comment|en|Type is too general. We should be able to distinguish types of music from types of architecture}}
-	{{comment|nl|Type is te algemeen. We moeten soorten muziek van soorten gebouwen kunnen onderscheiden}}
-| rdfs:domain = MusicalWork
-| rdfs:range = owl:Thing
-| rdf:type = | rdfs:subPropertyOf     = Type
-| owl:equivalentProperty = 
-| rdfs:subPropertyOf = dul:isClassifiedBy
-}}</text></revision></page><page><title>OntologyProperty:MusicalArtist</title><ns>202</ns><id>1159</id><revision><id>47612</id><timestamp>2015-04-03T10:04:50Z</timestamp><text>{{ObjectProperty
-| rdfs:label@en = musical artist
-| rdfs:domain = Single
-| rdfs:range = MusicalArtist
-| rdfs:subPropertyOf = dul:coparticipatesWith
-| owl:equivalentProperty = wikidata:P175
-}}</text></revision></page><page><title>OntologyProperty:MusicalBand</title><ns>202</ns><id>1160</id><revision><id>36310</id><timestamp>2014-07-08T14:04:39Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = musical band
-| rdfs:domain = Single
-| rdfs:range = Band
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:MusicalKey</title><ns>202</ns><id>6285</id><revision><id>39116</id><timestamp>2015-01-09T18:33:18Z</timestamp><text>{{DatatypeProperty
-| labels                 =
-{{label|en|musical key}}
-{{label|de|Tonart}}
-{{label|el|μουσικό κλειδί}}
-{{label|nl|toonsoort}}
-| rdfs:domain            = MusicalWork
-| rdfs:range             = xsd:string
-| rdf:type               =
-| rdfs:subPropertyOf     = 
-| owl:equivalentProperty = 
-}}</text></revision></page><page><title>OntologyProperty:Musicians</title><ns>202</ns><id>2635</id><revision><id>57439</id><timestamp>2022-04-17T21:18:37Z</timestamp><text>
-{{ObjectProperty
-| labels =
-  {{label|en|musicians}}
-  {{label|fr|musiciens}}
-  {{label|de|Musiker}}
-  {{label|el|μουσικοί}}
-| rdfs:domain = Instrument
-| rdfs:comment@en = | rdfs:range = MusicalArtist
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:MuteCharacterInPlay</title><ns>202</ns><id>3826</id><revision><id>13346</id><timestamp>2011-06-06T10:22:32Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = mute character in play
-| rdfs:domain = Play
-| rdfs:range = xsd:string
-| rdfs:subPropertyOf = characterInPlay
-| rdfs:comment@en = Name of a mute character in play.
-}}</text></revision></page><page><title>OntologyProperty:Mvp</title><ns>202</ns><id>7688</id><revision><id>26960</id><timestamp>2013-07-04T09:29:48Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|mvp}}
-| rdfs:domain = Athlete
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Mythology</title><ns>202</ns><id>8200</id><revision><id>33926</id><timestamp>2014-04-04T15:01:31Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|mythology}}
-{{label|de|Mythologie}}
-{{label|it|mitologia}}
-{{label|el|μυθολογία}}
-| rdfs:domain = MythologicalFigure
-| rdfs:range = owl:Thing
-}}</text></revision></page><page><title>OntologyProperty:NaacpImageAward</title><ns>202</ns><id>1164</id><revision><id>36312</id><timestamp>2014-07-08T14:04:47Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = NAACP Image Award
-| rdfs:domain = Actor
-| rdfs:range = Award
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:Name</title><ns>202</ns><id>6811</id><revision><id>59628</id><timestamp>2024-06-04T08:36:32Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|name}}
-{{label|de|Name}}
-{{label|am|ስም}}
-| rdfs:range = rdf:langString
-| owl:equivalentProperty = schema:name
-}}</text></revision></page><page><title>OntologyProperty:NameAsOf</title><ns>202</ns><id>8912</id><revision><id>33928</id><timestamp>2014-04-04T15:01:50Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|so named since}}
-{{label|de|so genannt seit}}
-{{label|nl|zo genoemd sinds}}
-| rdfs:domain = owl:Thing
-| rdfs:range = xsd:gYear
-}}</text></revision></page><page><title>OntologyProperty:NameDay</title><ns>202</ns><id>4133</id><revision><id>23153</id><timestamp>2013-01-18T11:10:49Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = name day
-| rdfs:label@el = ονομαστική εορτή
-| rdfs:label@pl = imieniny
-| rdfs:domain = GivenName
-| rdfs:range = xsd:date
-}}</text></revision></page><page><title>OntologyProperty:NameInCantoneseChinese</title><ns>202</ns><id>11716</id><revision><id>51330</id><timestamp>2016-06-30T11:15:09Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|name in Yue Chinese}}
-{{label|nl|naam in het Kantonees Chinees}}
-| rdfs:range = rdf:langString
-| rdfs:subPropertyOf = name
-}}</text></revision></page><page><title>OntologyProperty:NameInHangulKorean</title><ns>202</ns><id>11720</id><revision><id>51341</id><timestamp>2016-06-30T11:37:05Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|name in Hangul-written Korean}}
-{{label|nl|naam in Hangul-geschreven Koreaans}}
-| rdfs:range = rdf:langString
-| rdfs:subPropertyOf = name
-}}</text></revision></page><page><title>OntologyProperty:NameInHanjaKorean</title><ns>202</ns><id>11721</id><revision><id>51342</id><timestamp>2016-06-30T11:38:08Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|name in Hanja-written (traditional) Korean}}
-{{label|nl|naam in Hanja-geschreven Koreaans}}
-| rdfs:range = rdf:langString
-| rdfs:subPropertyOf = name
-}}</text></revision></page><page><title>OntologyProperty:NameInJapanese</title><ns>202</ns><id>11712</id><revision><id>51318</id><timestamp>2016-06-30T10:14:23Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|name in Japanese}}
-{{label|de|Name auf japanisch}}
-{{label|nl|naam in het Japans}}
-| rdfs:range = rdf:langString
-| rdfs:subPropertyOf = name
-}}</text></revision></page><page><title>OntologyProperty:NameInMindongyuChinese</title><ns>202</ns><id>11718</id><revision><id>51334</id><timestamp>2016-06-30T11:22:05Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|name in Mindongyu Chinese}}
-{{label|nl|naam in Mindongyu Chinees}}
-| rdfs:range = rdf:langString
-| rdfs:subPropertyOf = name
-}}</text></revision></page><page><title>OntologyProperty:NameInMinnanyuChinese</title><ns>202</ns><id>11719</id><revision><id>51336</id><timestamp>2016-06-30T11:27:30Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|name in Minnanyu Chinese}}
-{{label|nl|naam in Minnanyu Chinees}}
-| rdfs:range = rdf:langString
-| rdfs:subPropertyOf = name
-}}</text></revision></page><page><title>OntologyProperty:NameInPinyinChinese</title><ns>202</ns><id>11714</id><revision><id>51326</id><timestamp>2016-06-30T11:06:09Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|name in Pinyin Chinese}}
-{{label|nl|naam in het Pinyin Chinees}}
-| rdfs:range = rdf:langString
-| rdfs:subPropertyOf = name
-}}</text></revision></page><page><title>OntologyProperty:NameInSimplifiedChinese</title><ns>202</ns><id>11715</id><revision><id>51327</id><timestamp>2016-06-30T11:08:35Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|name in Simplified Chinese}}
-{{label|nl|naam in het Vereenvoudigd Chinees}}
-| rdfs:range = rdf:langString
-| rdfs:subPropertyOf = name
-}}</text></revision></page><page><title>OntologyProperty:NameInTraditionalChinese</title><ns>202</ns><id>11713</id><revision><id>51325</id><timestamp>2016-06-30T11:04:00Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|name in Traditional Chinese}}
-{{label|nl|naam in het Traditioneel Chinees}}
-| rdfs:range = rdf:langString
-| rdfs:subPropertyOf = name
-}}</text></revision></page><page><title>OntologyProperty:NameInWadeGilesChinese</title><ns>202</ns><id>11717</id><revision><id>51332</id><timestamp>2016-06-30T11:18:01Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|name in the Wade-Giles transscription of Chinese}}
-{{label|nl|naam in het Wade-Giles transscriptie van het Chinees}}
-| rdfs:range = rdf:langString
-| rdfs:subPropertyOf = name
-}}</text></revision></page><page><title>OntologyProperty:NamedAfter</title><ns>202</ns><id>1165</id><revision><id>47613</id><timestamp>2015-04-03T10:05:58Z</timestamp><text>{{ObjectProperty
-| rdfs:label@en = named after
-| rdfs:label@de = benannt nach
-| rdfs:domain = owl:Thing
-| rdfs:subPropertyOf = dul:sameSettingAs
-| owl:equivalentProperty = wikidata:P138
-}}</text></revision></page><page><title>OntologyProperty:NamedByLanguage</title><ns>202</ns><id>7931</id><revision><id>27704</id><timestamp>2013-07-16T09:25:15Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|named by language}}
-| rdfs:domain = Place
-| rdfs:range = Place
-}}</text></revision></page><page><title>OntologyProperty:Names</title><ns>202</ns><id>6138</id><revision><id>46214</id><timestamp>2015-03-18T11:03:53Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = names
-| rdfs:label@de = Namen
-| rdfs:domain = Openswarm
-| rdfs:range = rdf:langString
-}}</text></revision></page><page><title>OntologyProperty:Narrator</title><ns>202</ns><id>1166</id><revision><id>56797</id><timestamp>2022-02-28T21:42:04Z</timestamp><text>{{ObjectProperty
-| labels = 
-    {{label|en|narrator}}
-    {{label|fr|narrateur}}
-    {{label|de|Erzähler}}
-| rdfs:domain = Work
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:Nation</title><ns>202</ns><id>7300</id><revision><id>33932</id><timestamp>2014-04-04T15:02:08Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|nation}}
-{{label|de|Nation}}
-| rdfs:domain = PopulatedPlace
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:NationalAffiliation</title><ns>202</ns><id>3340</id><revision><id>52841</id><timestamp>2018-02-08T20:31:05Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|national affiliation}}
-	{{label|pt|afiliacao nacional}}
-| rdfs:domain = PoliticalParty
-| rdfs:subPropertyOf = 
-}}</text></revision></page><page><title>OntologyProperty:NationalChampionship</title><ns>202</ns><id>8054</id><revision><id>33933</id><timestamp>2014-04-04T15:02:12Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|national championship}}
-{{label|de|nationale Meisterschaft}}
-| rdfs:domain = Athlete
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:NationalFilmAward</title><ns>202</ns><id>1167</id><revision><id>36316</id><timestamp>2014-07-08T14:05:02Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = National Film Award
-| rdfs:label@de = Nationaler Filmpreis
-| rdfs:domain = Actor
-| rdfs:range = Award
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:NationalOlympicCommittee</title><ns>202</ns><id>1169</id><revision><id>36317</id><timestamp>2014-07-08T14:05:07Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = National Olympic Committee
-| rdfs:label@de = Nationales Olympisches Komitee
-| rdfs:label@nl = nationaal Olympisch commité
-| rdfs:domain = OlympicResult
-| rdfs:subPropertyOf = dul:hasParticipant
-}}</text></revision></page><page><title>OntologyProperty:NationalRanking</title><ns>202</ns><id>1171</id><revision><id>52588</id><timestamp>2017-10-31T08:54:03Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = national ranking
-| rdfs:domain = EducationalInstitution
-| rdfs:range = xsd:positiveInteger
-}}</text></revision></page><page><title>OntologyProperty:NationalSelection</title><ns>202</ns><id>7875</id><revision><id>33936</id><timestamp>2014-04-04T15:02:25Z</timestamp><text>{{ObjectProperty
-| rdfs:label@en = national selection
-| rdfs:label@de = nationale Auswahl
-| rdfs:domain = Agent
-}}</text></revision></page><page><title>OntologyProperty:NationalTeam</title><ns>202</ns><id>1172</id><revision><id>51440</id><timestamp>2016-08-16T07:33:29Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|national team}}
-	{{label|de|Nationalmannschaft}}
-	{{label|nl|nationaal team}}
-	{{label|ja|代表国}}
-| rdfs:domain = Athlete
-| rdfs:range = SportsTeam
-| rdfs:subPropertyOf = dul:isMemberOf
-}}</text></revision></page><page><title>OntologyProperty:NationalTeamMatchPoint</title><ns>202</ns><id>7828</id><revision><id>27141</id><timestamp>2013-07-05T15:25:34Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|national team match point}}
-| rdfs:domain = Person
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:NationalTeamYear</title><ns>202</ns><id>7827</id><revision><id>27140</id><timestamp>2013-07-05T15:25:11Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|national team year}}
-| rdfs:domain = Person
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:NationalTopographicSystemMapNumber</title><ns>202</ns><id>2417</id><revision><id>9049</id><timestamp>2010-06-01T15:06:17Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = National Topographic System map number
-| rdfs:domain = Place
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:NationalTournament</title><ns>202</ns><id>7569</id><revision><id>52000</id><timestamp>2017-03-22T16:48:30Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|National tournament}}
-| rdfs:range = Tournament
-| rdfs:domain = Person
-}}</text></revision></page><page><title>OntologyProperty:NationalTournamentBronze</title><ns>202</ns><id>7581</id><revision><id>26807</id><timestamp>2013-07-02T10:03:09Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|national tournament bronze}}
-| rdfs:domain = Person
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NationalTournamentGold</title><ns>202</ns><id>7579</id><revision><id>26805</id><timestamp>2013-07-02T10:02:11Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|national tournament gold}}
-| rdfs:domain = Person
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NationalTournamentSilver</title><ns>202</ns><id>7580</id><revision><id>26806</id><timestamp>2013-07-02T10:02:48Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|national tournament silver}}
-| rdfs:domain = Person
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NationalYears</title><ns>202</ns><id>1173</id><revision><id>51441</id><timestamp>2016-08-16T07:34:18Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = national years
-| rdfs:label@ja = 代表年
-| rdfs:domain = SoccerPlayer
-| rdfs:range = xsd:gYear
-}}</text></revision></page><page><title>OntologyProperty:Nationality</title><ns>202</ns><id>1168</id><revision><id>58778</id><timestamp>2022-05-31T13:55:16Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|nationality}}
-	{{label|nl|nationaliteit}}
-	{{label|de|Nationalität}}
-	{{label|fr|nationalité}}
-	{{label|pt|nacionalidade}}
-	{{label|el|εθνικότητα}}
-	{{label|ja|国籍}}
-| rdfs:domain = Person
-| rdfs:range = Country
-| owl:equivalentProperty = schema:nationality, wikidata:P27
-| rdfs:subPropertyOf = dul:hasLocation
-}}</text></revision></page><page><title>OntologyProperty:NbRevPerMonth</title><ns>202</ns><id>14281</id><revision><id>59135</id><timestamp>2022-12-02T12:01:11Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en| Number of revision per month }}
-{{label|fr| Nombre de révisions par mois}}
-| comments =
-{{comment|en| used for DBpedia History &gt; Subject must be a blank node containing a dc:date and a rdfs:value  }}
-{{comment|fr| utilisé par DBpedia Historique &gt; Le sujet de cette relation doit être un noeud blanc contenant une  dc:date et une rdfs:value  }}
-| rdfs:domain = prov:Entity
-| rdfs:range = xsd:anyURI
-}}</text></revision></page><page><title>OntologyProperty:NbRevPerYear</title><ns>202</ns><id>14283</id><revision><id>59134</id><timestamp>2022-12-02T12:01:01Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en| Number of revision per year }}
-{{label|fr| Nombre de révisions par année}}
-| comments =
-{{comment|en| used for DBpedia History &gt; Subject must be a blank node containing a dc:date and a rdfs:value  }}
-{{comment|fr| utilisé par DBpedia Historique &gt; Le sujet de cette relation doit être un noeud blanc contenant une  dc:date et une rdfs:value  }}
-| rdfs:domain = prov:Entity
-| rdfs:range = xsd:anyURI
-}}</text></revision></page><page><title>OntologyProperty:NbUniqueContrib</title><ns>202</ns><id>14286</id><revision><id>59127</id><timestamp>2022-12-01T17:35:03Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en| Number of unique contributors }}
-{{label|fr| Nombre de contributeurs uniques }}
-| comments =
-{{comment|en| used for DBpedia History }}
-{{comment|fr| utilisé par DBpedia Historique }}
-| rdfs:domain = prov:Entity
-| rdfs:range = xsd:integer
-}}</text></revision></page><page><title>OntologyProperty:NcaaSeason</title><ns>202</ns><id>7680</id><revision><id>26952</id><timestamp>2013-07-04T09:25:39Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|ncaa season}}
-| rdfs:domain = Athlete
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:NcaaTeam</title><ns>202</ns><id>7681</id><revision><id>52007</id><timestamp>2017-03-22T20:23:52Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|ncaa team}}
-| rdfs:domain = Athlete
-| rdfs:range = SportsTeam
-}}</text></revision></page><page><title>OntologyProperty:Ncbhof</title><ns>202</ns><id>7676</id><revision><id>26946</id><timestamp>2013-07-04T08:02:04Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|ncbhof}}
-| rdfs:range = xsd:string
-| rdfs:domain = Athlete
-}}</text></revision></page><page><title>OntologyProperty:NciId</title><ns>202</ns><id>11877</id><revision><id>52214</id><timestamp>2017-10-07T15:53:42Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|NCI}}
-{{label|nl|NCI}}
-{{label|de|NCI}}
-{{label|fr|NCI}}
-| rdfs:domain = Disease
-| rdfs:range = xsd:string
-| owl:equivalentProperty = wikidata:P1395
-}}</text></revision></page><page><title>OntologyProperty:NdlId</title><ns>202</ns><id>11042</id><revision><id>52880</id><timestamp>2018-02-13T10:49:24Z</timestamp><text>{{DatatypeProperty
-| labels = 
-{{label|en|NDL id}}
-| comments =
-{{comment|en|National Diet Library of Japan identificator. http://id.ndl.go.jp/auth/ndlna/$1}}
-| rdfs:domain = owl:Thing
-| rdfs:range = xsd:string
-| owl:equivalentProperty = wikidata:P349
-| rdfs:subPropertyOf = code
-}}</text></revision></page><page><title>OntologyProperty:NearestCity</title><ns>202</ns><id>1175</id><revision><id>36320</id><timestamp>2014-07-08T14:05:19Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|nearest city}}
-	{{label|de|nächstgelegene Stadt}}
-	{{label|nl|dichtstbijzijnde stad}}
-	{{label|el|πόλη}}
-| rdfs:domain = Place
-| rdfs:range = PopulatedPlace
-| rdfs:subPropertyOf = dul:nearTo
-}}</text></revision></page><page><title>OntologyProperty:NeighboringMunicipality</title><ns>202</ns><id>1176</id><revision><id>36321</id><timestamp>2014-07-08T14:05:24Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|neighboring municipality}}
-	{{label|de|Nachbargemeinde}}
-	{{label|nl|aangrenzende gemeente}}
-	{{label|pt|municipío adjacente}}
-| rdfs:domain = PopulatedPlace
-| rdfs:range = PopulatedPlace
-| rdfs:subPropertyOf = dul:nearTo
-}}</text></revision></page><page><title>OntologyProperty:NeighbourConstellations</title><ns>202</ns><id>5341</id><revision><id>33940</id><timestamp>2014-04-04T15:02:41Z</timestamp><text>{{ DatatypeProperty
-
-	| rdfs:label@en = neighbour constellations
-| rdfs:label@de = Nachbarsternbilder
-	| rdfs:domain = Constellation
-	| rdfs:range = xsd:string
-
-}}</text></revision></page><page><title>OntologyProperty:NeighbourRegion</title><ns>202</ns><id>7149</id><revision><id>33941</id><timestamp>2014-04-04T15:02:46Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|neighbour region}}
-{{label|de|Nachbarregion}}
-| rdfs:domain = Place
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Neighbourhood</title><ns>202</ns><id>6902</id><revision><id>25352</id><timestamp>2013-05-24T21:16:34Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|neighbourhood of a hungarian settlement}}
-| rdfs:domain = HungarySettlement
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Nerve</title><ns>202</ns><id>1177</id><revision><id>36322</id><timestamp>2014-07-08T14:05:40Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = nerve
-| rdfs:label@de = Nerv
-| rdfs:domain = AnatomicalStructure
-| rdfs:range = Nerve
-| rdfs:subPropertyOf = dul:isLocationOf
-}}</text></revision></page><page><title>OntologyProperty:NetIncome</title><ns>202</ns><id>1178</id><revision><id>52782</id><timestamp>2018-01-23T15:30:31Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = net income
-| rdfs:label@de = Nettoergebnis
-| rdfs:domain = Company
-| rdfs:range = Currency
-| rdf:type = owl:FunctionalProperty
-| owl:equivalentProperty = wikidata:P2295
-}}</text></revision></page><page><title>OntologyProperty:Network</title><ns>202</ns><id>1179</id><revision><id>36323</id><timestamp>2014-07-08T14:05:43Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = network
-| rdfs:label@de = Sendergruppe
-| rdfs:label@el = δίκτυο
-| rdfs:domain = Broadcaster
-| rdfs:range = Broadcaster
-| rdfs:subPropertyOf = dul:isMemberOf
-}}</text></revision></page><page><title>OntologyProperty:Networth</title><ns>202</ns><id>1180</id><revision><id>8148</id><timestamp>2010-05-28T13:25:00Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = networth
-| rdfs:domain = Person
-| rdfs:range = Currency
-}}</text></revision></page><page><title>OntologyProperty:Newspaper</title><ns>202</ns><id>7702</id><revision><id>52570</id><timestamp>2017-10-30T23:49:12Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|newspaper}}
-{{label|de|Zeitung}}
-| rdfs:range = PeriodicalLiterature
-}}</text></revision></page><page><title>OntologyProperty:NextEntity</title><ns>202</ns><id>7182</id><revision><id>36324</id><timestamp>2014-07-08T14:05:45Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|next entity}}
-| rdfs:domain = Place
-| rdfs:range = Place
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:NextEvent</title><ns>202</ns><id>6086</id><revision><id>36325</id><timestamp>2014-07-08T14:05:48Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|next event}}
-	{{label|de|nächste Veranstaltung}}
-	{{label|nl|volgende evenement}}
-	{{label|el|επόμενο γεγονός}}
-| rdfs:domain = Event
-| rdfs:range = Event
-| rdfs:subPropertyOf = followedBy, dul:precedes
-}}</text></revision></page><page><title>OntologyProperty:NextMission</title><ns>202</ns><id>1181</id><revision><id>36326</id><timestamp>2014-07-08T14:05:52Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|next mission}}
-	{{label|de|nächste Mission}}
-	{{label|fr|mission suivante}}
-	{{label|fr|mision siguiente}}
-| rdfs:domain = SpaceMission
-| rdfs:range = SpaceMission
-| rdfs:subPropertyOf = followedBy, dul:precedes
-}}</text></revision></page><page><title>OntologyProperty:NextTrackNumber</title><ns>202</ns><id>13813</id><revision><id>57065</id><timestamp>2022-03-09T19:04:19Z</timestamp><text>{{DatatypeProperty
-| labels =
-  {{label|en|number of the next track}}
-  {{label|fr|numéro de la piste suivante}}
-| rdfs:domain = Work
-| rdfs:range = xsd:nonNegativeInteger
-| comments = 
-  {{comment|en|number of the next track in the recorded work.}}
-  {{comment|fr|numéro de la piste suivante du support.}}
-}}</text></revision></page><page><title>OntologyProperty:NflCode</title><ns>202</ns><id>7690</id><revision><id>26964</id><timestamp>2013-07-04T09:32:39Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|nfl code}}
-| rdfs:domain = Athlete
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:NflSeason</title><ns>202</ns><id>7684</id><revision><id>26956</id><timestamp>2013-07-04T09:27:54Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|nfl season}}
-| rdfs:domain = Athlete
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:NflTeam</title><ns>202</ns><id>7685</id><revision><id>26957</id><timestamp>2013-07-04T09:28:24Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|nfl team}}
-| rdfs:domain = Athlete
-| rdfs:range = SportsTeam
-}}</text></revision></page><page><title>OntologyProperty:NgcName</title><ns>202</ns><id>8924</id><revision><id>30757</id><timestamp>2014-01-22T11:53:51Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = NGC name
-| rdfs:comment@en = Name for NGC objects
-| rdfs:subPropertyOf = name
-| rdfs:domain = CelestialBody
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:NisCode</title><ns>202</ns><id>5682</id><revision><id>51783</id><timestamp>2016-12-22T14:39:09Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = NIS code
-| rdfs:domain = PopulatedPlace
-| rdfs:range = xsd:string
-| rdfs:comment@en = Indexing code used by the Belgium National Statistical Institute to identify populated places.
-| rdfs:subPropertyOf = 
-| owl:equivalentProperty = wikidata:P1567
-}}</text></revision></page><page><title>OntologyProperty:NlaId</title><ns>202</ns><id>8429</id><revision><id>52881</id><timestamp>2018-02-13T10:51:13Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|NLA Id}}
-| comments =
-{{comment|en|NLA Trove’s People and Organisation view allows the discovery of biographical and other contextual information about people and organisations. Search also available via VIAF.}}
-| rdfs:range = xsd:string
-| owl:equivalentProperty = wikidata:P409
-| rdfs:subPropertyOf = code
-}}</text></revision></page><page><title>OntologyProperty:NndbId</title><ns>202</ns><id>3690</id><revision><id>13018</id><timestamp>2011-05-19T01:45:22Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = NNDB id
-| rdfs:domain = Person
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:NoContest</title><ns>202</ns><id>7590</id><revision><id>26818</id><timestamp>2013-07-02T10:54:34Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|no contest}}
-| rdfs:domain = Boxer
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NobelLaureates</title><ns>202</ns><id>1183</id><revision><id>36328</id><timestamp>2014-07-08T14:05:59Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = nobel laureates
-| rdfs:label@de = Nobelpreisträger
-| rdfs:domain = School
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:Nominee</title><ns>202</ns><id>2357</id><revision><id>36329</id><timestamp>2014-07-08T14:06:02Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = nominee
-| rdfs:label@de = Kandidat
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:NonFictionSubject</title><ns>202</ns><id>1484</id><revision><id>48689</id><timestamp>2015-08-10T10:12:28Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|non-fiction subject}}
-	{{label|nl|non-fictie onderwerp}}
-| rdfs:domain = WrittenWork
-| rdfs:range = owl:Thing
-| rdfs:comment@en = The subject of a non-fiction book (e.g.: History, Biography, Cookbook, Climate change, ...).
-| rdfs:subPropertyOf = dul:isAbout
-}}</text></revision></page><page><title>OntologyProperty:NonProfessionalCareer</title><ns>202</ns><id>7789</id><revision><id>27090</id><timestamp>2013-07-05T13:12:31Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|non professional career}}
-| rdfs:domain = Person
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Nord</title><ns>202</ns><id>11873</id><revision><id>52210</id><timestamp>2017-10-07T15:45:29Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|NORD}}
-{{label|nl|NORD}}
-{{label|de|NORD}}
-{{label|fr|NORD}}
-| rdfs:domain = Disease
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:NorthEastPlace</title><ns>202</ns><id>11089</id><revision><id>45592</id><timestamp>2015-03-08T14:06:23Z</timestamp><text>{{ObjectProperty
-| rdfs:label@en = north-east place
-| rdfs:label@fr = lieu au nord-est
-| rdfs:comment@fr = indique un autre lieu situé au nord-est.
-| rdfs:comment@en = indicates another place situated north-east.
-| rdfs:domain = Place
-| rdfs:range = Place
-| owl:inverseOf = southWestPlace
-| rdfs:subPropertyOf = closeTo
-}}</text></revision></page><page><title>OntologyProperty:NorthPlace</title><ns>202</ns><id>11082</id><revision><id>45591</id><timestamp>2015-03-08T14:05:31Z</timestamp><text>{{ObjectProperty
-| rdfs:label@en = north place
-| rdfs:label@fr = lieu au nord
-| rdfs:comment@fr = indique un autre lieu situé au nord.
-| rdfs:comment@en = indicates another place situated north.
-| rdfs:domain = Place
-| rdfs:range = Place
-| owl:inverseOf = southPlace
-| rdfs:subPropertyOf = closeTo
-}}</text></revision></page><page><title>OntologyProperty:NorthWestPlace</title><ns>202</ns><id>11087</id><revision><id>45593</id><timestamp>2015-03-08T14:07:04Z</timestamp><text>{{ObjectProperty
-| rdfs:label@en = north-west place
-| rdfs:label@fr = lieu au nord-ouest
-| rdfs:comment@fr = indique un autre lieu situé au nord-ouest.
-| rdfs:comment@en = indicates another place situated north-west.
-| rdfs:domain = Place
-| rdfs:range = Place
-| owl:inverseOf = southEastPlace
-| rdfs:subPropertyOf = closeTo
-
-}}</text></revision></page><page><title>OntologyProperty:NotSolubleIn</title><ns>202</ns><id>8932</id><revision><id>30782</id><timestamp>2014-01-22T13:43:01Z</timestamp><text>{{ObjectProperty
-| rdfs:label@en = not soluble in
-| rdfs:label@nl = niet oplosbaar in
-| rdfs:domain = ChemicalSubstance
-| rdfs:range = ChemicalSubstance
-}}</text></revision></page><page><title>OntologyProperty:NotableCommander</title><ns>202</ns><id>1184</id><revision><id>36331</id><timestamp>2014-07-08T14:06:08Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = notable commander
-| rdfs:domain = MilitaryUnit
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:NotableFeatures</title><ns>202</ns><id>4441</id><revision><id>15025</id><timestamp>2011-09-08T07:26:50Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = notable features
-| rdfs:label@tr = notlar
-| rdfs:domain = Galaxy
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:NotableIdea</title><ns>202</ns><id>2314</id><revision><id>36332</id><timestamp>2014-07-08T14:06:11Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = notableIdea
-| rdfs:domain = Person
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:NotableStudent</title><ns>202</ns><id>1185</id><revision><id>36333</id><timestamp>2014-07-08T14:06:15Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = notable student
-| rdfs:label@el = σημαντικοί_φοιτητές
-| rdfs:domain = Scientist
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:NotableWine</title><ns>202</ns><id>1186</id><revision><id>36334</id><timestamp>2014-07-08T14:06:18Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = notable wine
-| rdfs:domain = Grape
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:NotableWork</title><ns>202</ns><id>1187</id><revision><id>58795</id><timestamp>2022-05-31T15:22:30Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|notable work}}
-	{{label|fr|oeuvre majeure}}
-	{{label|ja|代表作}}
-	{{label|nl|bekende werken}}
-| rdfs:domain = owl:Thing
-| rdfs:range = Work
-| owl:equivalentProperty = wikidata:P800
-| rdfs:subPropertyOf = dul:coparticipatesWith
-| comments =
-  {{comment|en|Notable work created by the subject (eg Writer, Artist, Engineer) or about the subject (eg ConcentrationCamp)}}
-}}</text></revision></page><page><title>OntologyProperty:Note</title><ns>202</ns><id>1188</id><revision><id>33950</id><timestamp>2014-04-04T15:03:23Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = note
-| rdfs:label@de = Anmerkung
-| rdfs:domain = AutomobileEngine
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:NoteOnPlaceOfBurial</title><ns>202</ns><id>1189</id><revision><id>8150</id><timestamp>2010-05-28T13:25:18Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = note on place of burial
-| rdfs:domain = MilitaryPerson
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:NoteOnRestingPlace</title><ns>202</ns><id>1190</id><revision><id>34069</id><timestamp>2014-04-04T15:54:48Z</timestamp><text>Note: This property is currently (April 2012) not used anywhere. Maybe we should delete it.
-
-{{DatatypeProperty
-| rdfs:label@en = note on resting place
-| rdfs:domain = Person
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Notes</title><ns>202</ns><id>1191</id><revision><id>59649</id><timestamp>2024-06-04T21:13:59Z</timestamp><text>{{DatatypeProperty
-| labels =
-   {{label|en|notes}}
-{{label|de|Anmerkungen}}
-   {{label|el|σημειώσεις}}
-   {{label|fr|notes}}
-   {{label|am|ማስታወሻ}}
-| comments =
-   {{comment|en|additional notes that better describe the entity.}}
-   {{comment|el|συμπληρωματικές σημειώσεις που περιγράφουν καλύτερα την οντότητα.}}
-| rdfs:domain = owl:Thing
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:NotifyDate</title><ns>202</ns><id>1192</id><revision><id>33958</id><timestamp>2014-04-04T15:27:33Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = notify date
-| rdfs:label@de = Benachrichtigungsdatum
-| rdfs:domain = SiteOfSpecialScientificInterest
-| rdfs:range = xsd:date
-}}</text></revision></page><page><title>OntologyProperty:Novel</title><ns>202</ns><id>6826</id><revision><id>36336</id><timestamp>2014-07-08T14:06:25Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|novel}}
-	{{label|de|Roman}}
-| rdfs:domain = FictionalCharacter
-| rdfs:range = Novel
-| rdfs:subPropertyOf = dul:isParticipantIn
-}}</text></revision></page><page><title>OntologyProperty:NrhpReferenceNumber</title><ns>202</ns><id>3223</id><revision><id>53798</id><timestamp>2020-12-01T17:52:27Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = NRHP Reference Number
-| rdfs:domain = HistoricPlace
-| rdfs:range = xsd:string
-| owl:equivalentProperty=wikidata:P649
-}}</text></revision></page><page><title>OntologyProperty:NrhpType</title><ns>202</ns><id>3218</id><revision><id>36337</id><timestamp>2014-07-08T14:06:28Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = NRHP type
-| rdfs:domain = HistoricPlace
-| rdfs:range = owl:Thing
-| rdfs:comment@en = Type of historic place as defined by the US National Park Service. For instance National Historic Landmark, National Monument or National Battlefield.
-| rdfs:subPropertyOf = dul:isClassifiedBy
-}}</text></revision></page><page><title>OntologyProperty:NssdcId</title><ns>202</ns><id>1193</id><revision><id>8154</id><timestamp>2010-05-28T13:25:52Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = NSSDC ID
-| rdfs:domain = SpaceStation
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Number</title><ns>202</ns><id>1194</id><revision><id>53759</id><timestamp>2020-09-30T13:16:27Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|number}}
-{{label|de|Anzahl}}
-{{label|nl|nummer}}
-{{label|el|αριθμός}}
-{{label|ja|番号}}
-| rdfs:range = xsd:nonNegativeInteger
-| rdfs:domain = owl:Thing
-| owl:equivalentProperty=bag:huisnummer
-}}</text></revision></page><page><title>OntologyProperty:NumberBuilt</title><ns>202</ns><id>1195</id><revision><id>52931</id><timestamp>2018-03-01T11:12:21Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = number built
-| rdfs:label@de = Anzahl gebaut
-| rdfs:label@nl = aantal gebouwd
-| rdfs:domain = Aircraft
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfAcademicStaff</title><ns>202</ns><id>5300</id><revision><id>33962</id><timestamp>2014-04-04T15:27:47Z</timestamp><text>{{ DatatypeProperty
-
-	| rdfs:label@en = number of academic staff
-| rdfs:label@de = Anzahl der wissenschaftlichen Mitarbeiter
-        | rdfs:label@el = αριθμός ακαδημαϊκού προσωπικού
-        | rdfs:domain = EducationalInstitution
-	| rdfs:range = xsd:nonNegativeInteger
-
-}}</text></revision></page><page><title>OntologyProperty:NumberOfAlbums</title><ns>202</ns><id>5193</id><revision><id>56884</id><timestamp>2022-03-02T17:31:44Z</timestamp><text>{{DatatypeProperty
-| labels = 
-    {{label|en|number of albums}}
-    {{label|fr|nombre d'albums}}
-    {{label|de|Anzahl der Alben}}
-| comments =
-    {{comment|en|the total number of albums released by the musical artist}}
-    {{comment|fr|nombre total d'albums que cet artiste musical a réalisés}}
-| rdfs:domain = MusicalArtist
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfArrondissement</title><ns>202</ns><id>7954</id><revision><id>27895</id><timestamp>2013-07-17T08:43:29Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|number of arrondissement}}
-| rdfs:domain = Department
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfBombs</title><ns>202</ns><id>5625</id><revision><id>53175</id><timestamp>2018-07-19T08:51:56Z</timestamp><text>{{ DatatypeProperty
-
-	| rdfs:label@en = number of bombs
-| rdfs:label@de = Anzahl der Bomben
-        | rdfs:label@el = αριθμός των βομβών
-	| rdfs:domain = MilitaryAircraft
-	| rdfs:range = xsd:nonNegativeInteger
-
-}}</text></revision></page><page><title>OntologyProperty:NumberOfBronzeMedalsWon</title><ns>202</ns><id>1196</id><revision><id>33965</id><timestamp>2014-04-04T15:28:01Z</timestamp><text>{{DatatypeProperty
-|labels =
-  {{label|en|number of bronze medals won}}
-{{label|de|Anzahl der gewonnenen Bronzemedaillen}}
-  {{label|fr|nomber de médailles de bronze gagnées}}
-  {{label|es|cantidad de medallas de bronce ganadas}}
-  {{label|nl|aantal gewonnen bronzen medailles}}
-| rdfs:domain = SportCompetitionResult
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfCanton</title><ns>202</ns><id>7952</id><revision><id>27893</id><timestamp>2013-07-17T08:42:52Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|number of canton}}
-| rdfs:domain = Department
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfCantons</title><ns>202</ns><id>9302</id><revision><id>32718</id><timestamp>2014-03-14T10:38:17Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|Number Of Cantons}}
-{{label|nl|Aantal kantons}}
-| rdfs:domain = PopulatedPlace
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfCapitalDeputies</title><ns>202</ns><id>3360</id><revision><id>12247</id><timestamp>2011-04-15T14:07:48Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = Number Of Capital Deputies
-| rdfs:label@pt = numero de deputados distritais
-| rdfs:domain = PopulatedPlace
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfCity</title><ns>202</ns><id>7012</id><revision><id>25500</id><timestamp>2013-05-25T19:31:33Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|number of contries inside en continent}}
-| rdfs:domain = Continent
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfClasses</title><ns>202</ns><id>12240</id><revision><id>56909</id><timestamp>2022-03-02T19:27:59Z</timestamp><text>{{DatatypeProperty
-| labels =
-    {{label|en|numberOfClasses}}
-    {{label|fr|nombre de classes}}
-| comments =
-    {{comment|en|number of defined Classes}}
-    {{comment|fr|nombre de classes définies}}
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfClassesWithResource</title><ns>202</ns><id>12241</id><revision><id>56910</id><timestamp>2022-03-02T19:32:46Z</timestamp><text>{{DatatypeProperty 
-| labels =
-    {{label|en|numberOfClassesWithResource}}
-    {{label|fr|nombre de classes avec ressource}}
-| comments =
-    {{comment|en|number of class in DBpedia with at least single resource (class entity)}}
-    {{comment|fr|nombre de classes de DBpedia ayant au moins une ressource unique (entité de classe)}}
-| rdfs:range = xsd:nonNegativeInteger
-
-}}</text></revision></page><page><title>OntologyProperty:NumberOfClassrooms</title><ns>202</ns><id>3137</id><revision><id>57306</id><timestamp>2022-03-30T14:50:11Z</timestamp><text>{{ObjectProperty
-| labels =
-    {{label|en|number of classrooms}}
-    {{label|el|αριθμός αιθουσών}}
-    {{label|fr|nombre de salles de classe}}
-| rdfs:domain = School
-| rdfs:subPropertyOf = dul:hasRegion
-}}</text></revision></page><page><title>OntologyProperty:NumberOfClubs</title><ns>202</ns><id>6059</id><revision><id>33966</id><timestamp>2014-04-04T15:28:05Z</timestamp><text>{{DatatypeProperty
-|labels=
-{{label|en|number of clubs}}
-{{label|de|Anzahl der Clubs}}
-{{label|fr|nombre de clubs}}
-{{label|es|numero de clubs}}
-|comments=
-| rdfs:domain = Activity
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfCollectionItems</title><ns>202</ns><id>6403</id><revision><id>33967</id><timestamp>2014-04-04T15:28:10Z</timestamp><text>{{DatatypeProperty
-| labels                 =
-{{label|en|number of items in collection}}
-{{label|de|Anzahl der Elemente in der Sammlung}}
-{{label|nl|aantal titels/items}}
-| comments               =
-{{comment|en| Indication as to the size of the collection of this library }}
-{{comment|nl| Aanduiding van omvang van de collectie van deze bibliotheek}}
-| rdfs:domain            = Library
-| rdfs:range             = xsd:integer
-| rdf:type               =
-| rdfs:subPropertyOf     = 
-| owl:equivalentProperty = 
-}}</text></revision></page><page><title>OntologyProperty:NumberOfCompetitors</title><ns>202</ns><id>1197</id><revision><id>33968</id><timestamp>2014-04-04T15:28:14Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = number of competitors
-| rdfs:label@de = Anzahl der Wettbewerber
-| rdfs:domain = OlympicResult
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfCounties</title><ns>202</ns><id>3306</id><revision><id>33969</id><timestamp>2014-04-04T15:28:24Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = number of counties
-| rdfs:label@de = Anzahl der Landkreise
-| rdfs:label@pt = número de condados
-| rdfs:domain = PopulatedPlace
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfCountries</title><ns>202</ns><id>3321</id><revision><id>23311</id><timestamp>2013-01-20T10:43:32Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = number of countries
-| rdfs:label@el = αριθμός χωρών
-| rdfs:label@pt = número de países
-| rdfs:domain = AdministrativeRegion
-| rdfs:range = xsd:positiveInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfCrew</title><ns>202</ns><id>5629</id><revision><id>23313</id><timestamp>2013-01-20T10:51:15Z</timestamp><text>{{ DatatypeProperty
-
-	| rdfs:label@en = number of crew
-	| rdfs:label@el = αριθμός πληρώματος
-        | rdfs:label@nl = aantal bemanningsleden
-	| rdfs:domain = MeanOfTransportation
-	| rdfs:range = xsd:nonNegativeInteger
-
-}}</text></revision></page><page><title>OntologyProperty:NumberOfDeaths</title><ns>202</ns><id>10249</id><revision><id>38537</id><timestamp>2014-10-04T12:00:29Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|number of deaths}}
-{{label|de|Totenzahl}}
-{{label|nl|Aantal doden}}
-| rdfs:domain = ConcentrationCamp
-| rdfs:range = xsd:string}}</text></revision></page><page><title>OntologyProperty:NumberOfDependency</title><ns>202</ns><id>7011</id><revision><id>27887</id><timestamp>2013-07-17T08:33:37Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|number of dependency}}
-| rdfs:domain = Continent
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfDisambiguates</title><ns>202</ns><id>12266</id><revision><id>53494</id><timestamp>2018-11-30T20:21:24Z</timestamp><text>{{DatatypeProperty 
-| rdfs:label@en = numberOfDisambiguates
-| rdfs:comment@en = number of disambiguation pages in DBpedia
-| rdfs:range = xsd:nonNegativeInteger
-
-}}</text></revision></page><page><title>OntologyProperty:NumberOfDistrict</title><ns>202</ns><id>7953</id><revision><id>27894</id><timestamp>2013-07-17T08:43:16Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|number of district}}
-| rdfs:domain = Department
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfDistricts</title><ns>202</ns><id>6789</id><revision><id>33970</id><timestamp>2014-04-04T15:28:28Z</timestamp><text>{{DatatypeProperty
-| labels = 
-{{label|en|number of districts }}
-{{label|de|Anzahl der Bezirke}}
-{{label|id|jumlah kecamatan }}
-| comments =
-| rdfs:domain  = Regency
-| rdfs:range   = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfDoctoralStudents</title><ns>202</ns><id>812</id><revision><id>33971</id><timestamp>2014-04-04T15:28:31Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = number of doctoral students
-| rdfs:label@de = Anzahl der Doktoranden
-| rdfs:domain = University
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfDoors</title><ns>202</ns><id>11977</id><revision><id>52601</id><timestamp>2017-10-31T10:44:54Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = number of doors
-| rdfs:label@pt = Türenanzahl
-| rdfs:domain = Automobile
-| rdfs:range = xsd:positiveInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfEmployees</title><ns>202</ns><id>1198</id><revision><id>53805</id><timestamp>2020-12-01T17:59:59Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|number of employees}}
-{{label|de|Anzahl der Mitarbeiter}}
-{{label|el|αριθμός εργαζομένων}}
-{{label|nl|aantal medewerkers}}
-{{label|fr|nombre d'employés}}
-{{label|es|número de empleados}}
-| rdfs:domain = Organisation
-| rdfs:range = xsd:nonNegativeInteger
-| owl:equivalentProperty=wikidata:P1128
-}}</text></revision></page><page><title>OntologyProperty:NumberOfEntrances</title><ns>202</ns><id>1199</id><revision><id>33973</id><timestamp>2014-04-04T15:28:39Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = number of entrances
-| rdfs:label@de = Anzahl der Eingänge
-| rdfs:label@el = αριθμός εισόδων
-| rdfs:label@nl = aantal ingangen
-| rdfs:domain = Cave
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfEpisodes</title><ns>202</ns><id>846</id><revision><id>33974</id><timestamp>2014-04-04T15:28:44Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = number of episodes
-| rdfs:label@de = Anzahl der Episoden
-| rdfs:label@el = αριθμός επειδοδίων
-| rdfs:domain = TelevisionShow
-| rdfs:range = xsd:nonNegativeInteger
-| owl:equivalentProperty = schema:numberOfEpisodes
-}}</text></revision></page><page><title>OntologyProperty:NumberOfEtoilesMichelin</title><ns>202</ns><id>14266</id><revision><id>59096</id><timestamp>2022-10-13T09:39:42Z</timestamp><text>{{ DatatypeProperty
-
-	| labels =
-    {{label|en|number of étoiles Michelin}}
-    {{label|fr|nombre d'étoiles Michelin}}
-	| rdfs:domain = Restaurant
-	| rdfs:range = xsd:nonNegativeInteger
-
-}}</text></revision></page><page><title>OntologyProperty:NumberOfFederalDeputies</title><ns>202</ns><id>3359</id><revision><id>33975</id><timestamp>2014-04-04T15:28:49Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = Number Of Federal Deputies
-| rdfs:label@de = Anzahl der Bundesabgeordneten
-| rdfs:label@pt = numero de deputados federais
-| rdfs:domain = PopulatedPlace
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfFilms</title><ns>202</ns><id>1200</id><revision><id>33976</id><timestamp>2014-04-04T15:28:53Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = number of films
-| rdfs:label@de = Anzahl der Filme
-| rdfs:label@el = αριθμός ταινιών
-| rdfs:domain = AdultActor
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfGoals</title><ns>202</ns><id>6507</id><revision><id>48677</id><timestamp>2015-08-07T14:18:32Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|number of goals scored}}
-{{label|de|Anzahl der erzielten Tore}}
-{{label|it|numero di goal segnati}}
-| rdfs:domain = CareerStation
-| rdfs:range = xsd:integer
-}}</text></revision></page><page><title>OntologyProperty:NumberOfGoldMedalsWon</title><ns>202</ns><id>1201</id><revision><id>33978</id><timestamp>2014-04-04T15:29:02Z</timestamp><text>{{DatatypeProperty
-|labels =
-  {{label|en|number of gold medals won}}
-{{label|de|Anzahl der Goldmedaillen}}
-  {{label|fr|nomber de médailles d'or gagnées}}
-  {{label|es|cantidad de medallas de oro ganadas}}
-  {{label|nl|aantal gewonnen gouden medailles}}
-| rdfs:domain = SportCompetitionResult
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfGraduateStudents</title><ns>202</ns><id>949</id><revision><id>33979</id><timestamp>2014-04-04T15:29:05Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = number of graduate students
-| rdfs:label@de = Zahl der Studenten
-| rdfs:domain = EducationalInstitution
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfGraves</title><ns>202</ns><id>9256</id><revision><id>33980</id><timestamp>2014-04-04T15:29:18Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|number of graves}}
-{{label|de|Anzahl der Gräber}}
-{{label|nl|aantal graven}}
-| rdfs:domain = Cemetery
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:NumberOfHoles</title><ns>202</ns><id>10203</id><revision><id>57440</id><timestamp>2022-04-17T21:20:15Z</timestamp><text>{{DatatypeProperty
-| labels =
-  {{label|en|number of holes}}
-  {{label|fr|nombre de trous}}
-| rdfs:domain = GolfCourse
-| rdfs:range = xsd:integer
-}}</text></revision></page><page><title>OntologyProperty:NumberOfHouses</title><ns>202</ns><id>6294</id><revision><id>33981</id><timestamp>2014-04-04T15:29:22Z</timestamp><text>{{DatatypeProperty
-| labels                 =
-{{label|en|number of houses present)}}
-{{label|de|Anzahl der vorhandenen Häuser}}
-{{label|nl|aantal huizen aanwezig}}
-| comments               =
-{{comment|en| Count of the houses in the Protected Area }}
-{{comment|nl| Aantal huizen in afgegrensd gebied }}
-| rdfs:domain            = ProtectedArea
-| rdfs:range             = xsd:string
-| rdf:type               =
-| rdfs:subPropertyOf     = 
-| owl:equivalentProperty = 
-}}</text></revision></page><page><title>OntologyProperty:NumberOfIndegree</title><ns>202</ns><id>12248</id><revision><id>53431</id><timestamp>2018-10-25T21:21:49Z</timestamp><text>
-{{DatatypeProperty 
-| rdfs:label@en = number of all indegrees in dbpedia (same ourdegrees are counting repeatedly)
-| rdfs:label@cs = počet indegree odkazů v dbpedii (stejné započítané opakovaně)
-| rdfs:range = xsd:nonNegativeInteger
-
-}}</text></revision></page><page><title>OntologyProperty:NumberOfIntercommunality</title><ns>202</ns><id>7951</id><revision><id>27891</id><timestamp>2013-07-17T08:42:33Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|number of intercommunality}}
-| rdfs:domain = Department
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfIsland</title><ns>202</ns><id>7099</id><revision><id>33982</id><timestamp>2014-04-04T15:29:26Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|number of islands}}
-{{label|de|Anzahl der Inseln}}
-| rdfs:domain = Place
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:NumberOfIslands</title><ns>202</ns><id>1202</id><revision><id>33983</id><timestamp>2014-04-04T15:29:30Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|number of islands}}
-{{label|de|Anzahl der Inseln}}
-{{label|el|αριθμός νησιών}}
-{{label|nl|aantal eilanden}}
-| rdfs:domain = Island
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfLanes</title><ns>202</ns><id>3430</id><revision><id>19763</id><timestamp>2012-11-07T14:35:56Z</timestamp><text>{{DatatypeProperty
-|labels=
-   {{label|en|number of lanes}}
-   {{label|de|Anzahl der Fahrstreifen}}
-   {{label|fr|nombre de voies}}
-| rdfs:domain = RouteOfTransportation
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfLaps</title><ns>202</ns><id>5333</id><revision><id>33984</id><timestamp>2014-04-04T15:29:34Z</timestamp><text>{{ DatatypeProperty
-
-	| rdfs:label@en = number of laps
-| rdfs:label@de = Anzahl der Runden
-	| rdfs:domain = FormulaOneRacing
-	| rdfs:range = xsd:nonNegativeInteger
-
-}}</text></revision></page><page><title>OntologyProperty:NumberOfLaunches</title><ns>202</ns><id>5633</id><revision><id>33985</id><timestamp>2014-04-04T15:29:38Z</timestamp><text>{{ DatatypeProperty
-
-	| rdfs:label@en = number of launches
-| rdfs:label@de = Anzahl von Starts
-	| rdfs:domain = MeanOfTransportation
-	| rdfs:range = xsd:nonNegativeInteger
-
-}}</text></revision></page><page><title>OntologyProperty:NumberOfLawyers</title><ns>202</ns><id>3732</id><revision><id>13174</id><timestamp>2011-05-23T16:49:34Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = number of lawyers
-| rdfs:label@de = Anzahl Rechtsanwälte
-| rdfs:domain = LawFirm
-| rdfs:range = xsd:nonNegativeInteger
-| rdfs:comment@en = Number of lawyers or attorneys in the company.
-}}</text></revision></page><page><title>OntologyProperty:NumberOfLifts</title><ns>202</ns><id>11806</id><revision><id>51923</id><timestamp>2017-02-20T11:47:53Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = number of lifts
-| rdfs:label@ja = 索道数
-| rdfs:domain = SkiArea
-| rdfs:range = xsd:nonNegativeInteger
-| rdfs:comment@en = Number of lifts.
-}}</text></revision></page><page><title>OntologyProperty:NumberOfLines</title><ns>202</ns><id>3623</id><revision><id>57313</id><timestamp>2022-03-30T15:12:24Z</timestamp><text>{{DatatypeProperty
-| labels =
-    {{label|en|number of lines}}
-    {{label|de|Anzahl der Linien}}
-    {{label|fr|nombre de lignes}}
-| rdfs:domain = PublicTransitSystem
-| rdfs:range = xsd:nonNegativeInteger
-| comments = 
-    {{comment|en|Number of lines in the transit system.}}
-    {{comment|fr|Nombre de lignes dans le système de transport.}}
-}}</text></revision></page><page><title>OntologyProperty:NumberOfLiveAlbums</title><ns>202</ns><id>5195</id><revision><id>56806</id><timestamp>2022-02-28T22:12:30Z</timestamp><text>{{DatatypeProperty
-| labels = 
-    {{label|en|number of live albums}}
-    {{label|fr|nombre d'albums live}}
-    {{label|de|Anzahl von Live-Alben}}
-| comments =
-    {{comment|en|the number of live albums released by the musical artist}}
-    {{comment|fr|nombre d'albums enregistrés en public et réalisés par l'artiste de musique}}
-| rdfs:domain = MusicalArtist
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfLocations</title><ns>202</ns><id>6038</id><revision><id>33987</id><timestamp>2014-04-04T15:29:46Z</timestamp><text>{{ DatatypeProperty
-| labels =
-   {{label|en|number of locations}}
-{{label|de|Anzahl der Standorte}}
-   {{label|fr|nombre de sites}}
-| rdfs:domain = Organisation
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfMatches</title><ns>202</ns><id>6506</id><revision><id>23833</id><timestamp>2013-02-21T16:12:00Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|number of matches or caps}}
-| rdfs:domain = CareerStation
-| rdfs:range = xsd:integer
-}}</text></revision></page><page><title>OntologyProperty:NumberOfMembers</title><ns>202</ns><id>1203</id><revision><id>33988</id><timestamp>2014-04-04T15:29:51Z</timestamp><text>{{DatatypeProperty
-| labels =
-  {{label|en|number of members}}
-{{label|de|Anzahl der Mitglieder}}
-  {{label|el|αριθμός μελών}}
-{{label|pt|número de membros}}
-  {{label|fr|nombre de membres}}
-  {{label|es|numero de miembros}}
-| rdfs:domain = Legislature
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfMembersAsOf</title><ns>202</ns><id>3345</id><revision><id>12230</id><timestamp>2011-04-15T13:47:59Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = number of members as of
-| rdfs:label@pt = numero de membros em
-| rdfs:domain = PoliticalParty
-| rdfs:range = xsd:date
-}}</text></revision></page><page><title>OntologyProperty:NumberOfMinistries</title><ns>202</ns><id>3331</id><revision><id>33989</id><timestamp>2014-04-04T15:29:55Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = number of ministries
-| rdfs:label@de = Zahl der Ministerien
-| rdfs:label@pt = numero de ministerios
-| rdfs:domain = Country
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfMunicipalities</title><ns>202</ns><id>3357</id><revision><id>33990</id><timestamp>2014-04-04T15:30:00Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|Number Of Municipalities}}
-{{label|de|Anzahl der Gemeinden}}
-{{label|nl|Aantal gemeenten}}
-{{label|pt|numero de municipios}}
-| rdfs:domain = PopulatedPlace
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfMusicalArtistEntities</title><ns>202</ns><id>12258</id><revision><id>53451</id><timestamp>2018-10-28T12:23:04Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = number of MuscialArtist class (entities) in DBpedia
-| rdfs:label@cs = počet entit třídy MuscialArtist v DBpedii
-| rdfs:range = xsd:nonNegativeInteger
-| rdfs:domain = Country
-}}</text></revision></page><page><title>OntologyProperty:NumberOfMusicalArtistInstrument</title><ns>202</ns><id>12256</id><revision><id>53449</id><timestamp>2018-10-28T11:46:02Z</timestamp><text>
-{{DatatypeProperty 
-| rdfs:label@en = number of all MuscialArtist playing the instrument
-| rdfs:label@cs = počet hudebních umělců hrající na konkrétní nástroj
-| rdfs:range = xsd:nonNegativeInteger
-| rdfs:domain = Instrument
-}}</text></revision></page><page><title>OntologyProperty:NumberOfMusicalArtistStyle</title><ns>202</ns><id>12257</id><revision><id>53450</id><timestamp>2018-10-28T11:58:36Z</timestamp><text>
-{{DatatypeProperty 
-| rdfs:label@en = number of all MuscialArtist playing the style
-| rdfs:label@cs = počet hudebních umělců hrající konkrétní styl
-| rdfs:range = xsd:nonNegativeInteger
-| rdfs:domain = MusicGenre
-}}</text></revision></page><page><title>OntologyProperty:NumberOfNeighbourhood</title><ns>202</ns><id>6861</id><revision><id>25266</id><timestamp>2013-05-23T13:39:19Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|number of neighbourhood}}
-| rdfs:domain = GermanSettlement
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfNewlyIntroducedSports</title><ns>202</ns><id>6375</id><revision><id>22791</id><timestamp>2013-01-15T10:38:35Z</timestamp><text>{{DatatypeProperty
-| labels =
-  {{label|en|number of newly introduced sports}}
-  {{label|fr|numbre de sports nouvellement ajoutés}}
-  {{label|es|numero de deportes nuevamente añadidos}}
-| rdfs:domain = Olympics
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfOffices</title><ns>202</ns><id>3733</id><revision><id>23318</id><timestamp>2013-01-20T11:00:57Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = number of offices
-| rdfs:label@de = Anzahl Büros
-| rdfs:label@el = αριθμός γραφείων
-| rdfs:domain = LawFirm
-| rdfs:range = xsd:nonNegativeInteger
-| rdfs:comment@en = Number of the company's offices.
-| rdfs:comment@el = Αριθμός γραφείων εταιρείας.
-}}</text></revision></page><page><title>OntologyProperty:NumberOfOfficials</title><ns>202</ns><id>1204</id><revision><id>33991</id><timestamp>2014-04-04T15:30:04Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = number of officials
-| rdfs:label@de = Zahl der Beamten
-| rdfs:domain = OlympicResult
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfOrbits</title><ns>202</ns><id>1205</id><revision><id>33992</id><timestamp>2014-04-04T15:30:07Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = number of orbits
-| rdfs:label@de = Anzahl der Bahnen
-| rdfs:domain = SpaceMission
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfOutdegree</title><ns>202</ns><id>12247</id><revision><id>53495</id><timestamp>2018-11-30T20:21:56Z</timestamp><text>
-{{DatatypeProperty 
-| rdfs:label@en = numberOfOutdegree
-| rdfs:comment@en = number of all outdegrees in DBpedia (same ourdegrees are counting repeatedly). This number is equal to number of all links (every link is OutDegree link)
-| rdfs:range = xsd:nonNegativeInteger
-
-}}</text></revision></page><page><title>OntologyProperty:NumberOfPads</title><ns>202</ns><id>1206</id><revision><id>10399</id><timestamp>2010-11-10T14:41:04Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = number of pads
-| rdfs:domain = LaunchPad
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfPages</title><ns>202</ns><id>1255</id><revision><id>56815</id><timestamp>2022-02-28T22:33:03Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|number of pages}}
-{{label|fr|nombre de pages}}
-{{label|nl|aantal pagina's}}
-{{label|de|Anzahl der Seiten}}
-| rdfs:domain = WrittenWork
-| comments =
-    {{comment|en|The books number of pages.}}
-    {{comment|fr|Nombre de pages des livres.}}
-| rdfs:range = xsd:positiveInteger
-| owl:equivalentProperty = schema:numberOfPages
-}}</text></revision></page><page><title>OntologyProperty:NumberOfParkingSpaces</title><ns>202</ns><id>2744</id><revision><id>56824</id><timestamp>2022-03-01T00:18:41Z</timestamp><text>{{DatatypeProperty
-| labels =
-    {{label|en|number of parking spaces}}
-    {{label|fr|nombre de places de parking}}
-    {{label|de|Anzahl der Parkplätze}}
-| rdfs:domain = Hotel
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfParticipatingAthletes</title><ns>202</ns><id>1207</id><revision><id>33994</id><timestamp>2014-04-04T15:30:18Z</timestamp><text>{{DatatypeProperty
-| labels =
- {{label|en|number of participating athletes}}
-{{label|de|Anzahl der teilnehmenden Athleten}}
- {{label|fr|nombre d'athlètes participant}}
-| rdfs:domain = Olympics
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfParticipatingFemaleAthletes</title><ns>202</ns><id>6378</id><revision><id>33995</id><timestamp>2014-04-04T15:30:22Z</timestamp><text>{{DatatypeProperty
-| labels =
-   {{label|en|number of participating female athletes}}
-{{label|de|Zahl der teilnehmenden Sportlerinnen}}
-   {{label|el|αριθμός συμμετεχόντων γυναικών αθλητριών}}
-   {{label|fr|nombre d'athlètes participant féminins}}
-| rdfs:domain = Olympics
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfParticipatingMaleAthletes</title><ns>202</ns><id>6377</id><revision><id>33996</id><timestamp>2014-04-04T15:30:27Z</timestamp><text>{{DatatypeProperty
-| labels =
- {{label|en|number of participating male athletes}}
-{{label|de|Anzahl der teilnehmenden männlichen Athleten}}
- {{label|fr|nombre d'athlètes masculins participant}}
-| rdfs:domain = Olympics
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfParticipatingNations</title><ns>202</ns><id>1208</id><revision><id>33997</id><timestamp>2014-04-04T15:30:32Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = number of participating nations
-| rdfs:label@de = Anzahl der teilnehmenden Nationen
-| rdfs:domain = Olympics
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfPassengers</title><ns>202</ns><id>11850</id><revision><id>57303</id><timestamp>2022-03-30T14:45:56Z</timestamp><text>{{ DatatypeProperty
-| labels =
-    {{label|en|number of passengers}}
-    {{label|fr|nombre de passagers}}
-    {{label|nl|aantal passagiers}}
-| rdfs:domain = Ship
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfPeopleAttending</title><ns>202</ns><id>3307</id><revision><id>33998</id><timestamp>2014-04-04T15:30:37Z</timestamp><text>{{DatatypeProperty
-| labels = 
-  {{label|en|number of people attending}}
-{{label|de|Zahl der Teilnehmer}}
-  {{label|pt|número de participantes}}
-  {{label|fr|nombre de participants}}
-| rdfs:domain = Event
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfPeopleLicensed</title><ns>202</ns><id>5996</id><revision><id>20073</id><timestamp>2012-11-30T16:47:33Z</timestamp><text>{{DatatypeProperty
-|labels=
-{{label|en|number of licensed}}
-{{label|fr|nombre de licenciés}}
-|comments=
-{{comment|en|number of people that have a license to perform this activity}}
-{{comment|en|nombre de personnes ayant une license pour pratiquer cette activité}}
-| rdfs:domain = Activity
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfPersonBornInPlace</title><ns>202</ns><id>12254</id><revision><id>53446</id><timestamp>2018-10-28T11:07:17Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = number of entities of Person class born in the place
-| rdfs:label@cs = počet entit třídy Osoba narozených na konkrétním místě
-| rdfs:range = xsd:nonNegativeInteger
-| rdfs:domain = Place
-}}</text></revision></page><page><title>OntologyProperty:NumberOfPersonEntities</title><ns>202</ns><id>12251</id><revision><id>53443</id><timestamp>2018-10-28T10:09:20Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = number of Person class (entities) in DBpedia
-| rdfs:label@cs = počet entit třídy Osoba v DBpedii
-| rdfs:range = xsd:nonNegativeInteger
-| rdfs:domain = Country
-}}</text></revision></page><page><title>OntologyProperty:NumberOfPersonFromUniversity</title><ns>202</ns><id>12253</id><revision><id>53445</id><timestamp>2018-10-28T11:00:55Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = number of entities of Person class who graduated from the university
-| rdfs:label@cs = počet entit třídy Osoba s vystudovanou konkrétní univerzitou
-| rdfs:range = xsd:nonNegativeInteger
-| rdfs:domain = University
-}}</text></revision></page><page><title>OntologyProperty:NumberOfPersonInOccupation</title><ns>202</ns><id>12252</id><revision><id>53444</id><timestamp>2018-10-28T10:50:07Z</timestamp><text>
-{{DatatypeProperty 
-| rdfs:label@en = number of person in one occupation
-| rdfs:label@cs = počet lidí v konkrétním zaměstnání
-| rdfs:range = xsd:nonNegativeInteger
-| rdfs:domain = PersonFunction
-}}</text></revision></page><page><title>OntologyProperty:NumberOfPiersInWater</title><ns>202</ns><id>3438</id><revision><id>12456</id><timestamp>2011-04-27T14:30:45Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = number of piers in water
-| rdfs:label@de = Anzahl der Pfeiler in Wasser
-| rdfs:domain = Bridge
-| rdfs:range = xsd:nonNegativeInteger
-| rdfs:comment@en = Number of piers standing in a river or other water in normal conditions.
-}}</text></revision></page><page><title>OntologyProperty:NumberOfPixels</title><ns>202</ns><id>11545</id><revision><id>53553</id><timestamp>2019-08-26T13:15:29Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|number of pixels (millions)}}
-{{label|fr|nombre de pixels (millions)}}
-{{label|de|Anzahl der Pixel (Millionen)}}
-| rdfs:subPropertyOf     = number
-| rdfs:range             = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfPlatformLevels</title><ns>202</ns><id>3232</id><revision><id>12055</id><timestamp>2011-04-07T15:53:45Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = number of platform levels
-| rdfs:domain = Station
-| rdfs:range = xsd:integer
-| rdfs:comment@en = Number of levels of platforms at the station.
-}}</text></revision></page><page><title>OntologyProperty:NumberOfPlayers</title><ns>202</ns><id>6385</id><revision><id>33999</id><timestamp>2014-04-04T15:30:43Z</timestamp><text>{{DatatypeProperty
-| labels =
-  {{label|en|number of players}}
-{{label|de|Anzahl der Spieler}}
-  {{label|el|αριθμός παιχτών}}
-  {{label|fr|nombre de joueurs}}
-  {{label|es|numero de jugadores}}
-| comment = 
-  {{comment|en|number of people playing at some activity like sports or games.}}
-| rdfs:domain = Activity
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfPostgraduateStudents</title><ns>202</ns><id>1309</id><revision><id>10417</id><timestamp>2010-11-10T14:48:27Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = number of postgraduate students
-| rdfs:domain = University
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfPredicates</title><ns>202</ns><id>12236</id><revision><id>57309</id><timestamp>2022-03-30T15:02:39Z</timestamp><text>
-{{DatatypeProperty 
-| labels = 
-  {{label|en|numberOfPredicates}}
-  {{label|fr|nombre de prédicats}}
-| comments =
-  {{comment|en|number of predicates in DBpedia (including properties without rdf:type of rdf:Property)}}
-  {{comment|fr|nombre de prédicats dans DBpedia (y compris les propriétés sans rdf:type de rdf:Property)}}
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfProfessionals</title><ns>202</ns><id>6386</id><revision><id>34000</id><timestamp>2014-04-04T15:30:49Z</timestamp><text>{{DatatypeProperty
-| labels =
-  {{label|en|number of professionals}}
-{{label|de|Anzahl von Fachleuten}}
-  {{label|fr|nombre de professionnels}}
-  {{label|es|numero de profesionales}}
-| comments = 
-  {{comment|en|number of people who earns his living from a specified activity.&lt;ref&gt;http://en.wiktionary.org/wiki/professional&lt;/ref&gt;}}
-| rdfs:domain = Activity
-| rdfs:range = xsd:nonNegativeInteger
-}}
-
-== References ==
-&lt;references/&gt;</text></revision></page><page><title>OntologyProperty:NumberOfProperties</title><ns>202</ns><id>12243</id><revision><id>57310</id><timestamp>2022-03-30T15:05:11Z</timestamp><text>
-{{DatatypeProperty 
-| labels =
-  {{label|en|numberOfProperties}}
-  {{label|fr|nombre de propriétés}}
-| comments = 
-  {{comment|en|number of defined properties in DBpedia ontology}}
-  {{comment|fr|nombre de propriétés défines dans l'ontologie DBpedia}}
-| rdfs:range = xsd:nonNegativeInteger
-
-}}</text></revision></page><page><title>OntologyProperty:NumberOfPropertiesUsed</title><ns>202</ns><id>12244</id><revision><id>57311</id><timestamp>2022-03-30T15:07:03Z</timestamp><text>{{DatatypeProperty 
-| labels =
-  {{label|en|numberOfPropertiesUsed}}
-  {{label|fr|nombre de propriétés utilisées}}
-| comments =
-  {{comment|en|number of all properties used as predicate in DBpedia}}
-  {{comment|fr|nombre total de propriétés utilisées comme prédicat dans DBpedia}} 
-| rdfs:range = xsd:nonNegativeInteger
-
-}}</text></revision></page><page><title>OntologyProperty:NumberOfReactors</title><ns>202</ns><id>9145</id><revision><id>31722</id><timestamp>2014-02-11T10:55:21Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|number of reactors}}
-{{label|de|Anzahl der Reaktoren}}
-{{label|fr|nombre de réacteurs}}
-{{label|nl|aantal reactoren}}
-| rdfs:domain = NuclearPowerStation
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfRedirectedResource</title><ns>202</ns><id>12267</id><revision><id>57254</id><timestamp>2022-03-28T21:22:10Z</timestamp><text>
-{{DatatypeProperty 
-| labels = 
-  {{label|en|numberOfRedirectedResource}}
-  {{label|fr|nombre de ressources redirigées}}
-| comments =
-  {{comment|en|number of redirected resource to another one}}
-  {{comment|fr|nombre de ressources qui redirigent vers d'autres ressources}}
-  {{comment|cs|počet redirectů - zdrojů přesměrovaných na jiný zdroj}}
-| rdfs:range = xsd:nonNegativeInteger
-
-}}</text></revision></page><page><title>OntologyProperty:NumberOfResource</title><ns>202</ns><id>12235</id><revision><id>53489</id><timestamp>2018-11-30T20:17:43Z</timestamp><text>
-{{DatatypeProperty 
-| rdfs:label@en = numberOfResource
-| rdfs:comment@en = number of all resource in DBpedia (including disambiguation pages and rediretcs)
-| rdfs:range = xsd:nonNegativeInteger
-
-}}</text></revision></page><page><title>OntologyProperty:NumberOfResourceOfClass</title><ns>202</ns><id>12242</id><revision><id>53421</id><timestamp>2018-10-25T18:34:32Z</timestamp><text>
-{{DatatypeProperty 
-| rdfs:label@en = number of all resource / entities of a class
-| rdfs:label@cs = celkový počet zdrojů / entit v dané tříde
-| rdfs:range = xsd:nonNegativeInteger
-
-}}</text></revision></page><page><title>OntologyProperty:NumberOfResourceOfType</title><ns>202</ns><id>12239</id><revision><id>53413</id><timestamp>2018-10-24T20:01:03Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = number of resource / entities for concrete type of subject
-| rdfs:label@cs = počet zdrojů / entint pro konkrétní typ subjectu
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfResourceWithType</title><ns>202</ns><id>12264</id><revision><id>53491</id><timestamp>2018-11-30T20:18:54Z</timestamp><text>{{DatatypeProperty 
-| rdfs:label@en = nmberOfResourceWithType
-| rdfs:comment@en = number of resource in DBpedia with Class type (= Class entity)
-| rdfs:range = xsd:nonNegativeInteger
-
-}}</text></revision></page><page><title>OntologyProperty:NumberOfRestaurants</title><ns>202</ns><id>2512</id><revision><id>57251</id><timestamp>2022-03-28T21:11:32Z</timestamp><text>{{DatatypeProperty
-| labels = 
-  {{label|en|number of restaurants}}
-  {{label|fr|nombre de restaurants}}
-  {{label|de|Anzahl der Restaurants}}
-  {{label|el|αριθμός εστιατορίων}}
-| rdfs:domain = Hotel
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfRockets</title><ns>202</ns><id>5626</id><revision><id>53176</id><timestamp>2018-07-19T08:54:45Z</timestamp><text>{{ DatatypeProperty
-
-	| rdfs:label@en = number of rockets
-| rdfs:label@de = Anzahl der Raketen
-	| rdfs:domain = MilitaryAircraft
-	| rdfs:range = xsd:nonNegativeInteger
-
-}}</text></revision></page><page><title>OntologyProperty:NumberOfRooms</title><ns>202</ns><id>2513</id><revision><id>57302</id><timestamp>2022-03-30T14:42:23Z</timestamp><text>{{DatatypeProperty
-| labels =
-    {{label|en|number of rooms}}
-    {{label|fr|nombre de pièces}}
-    {{label|de|Anzahl der Zimmer}}
-    {{label|el|αριθμός δωματίων}}
-    {{label|nl|aantal kamers}}
-| rdfs:domain = Building
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfRun</title><ns>202</ns><id>7805</id><revision><id>27111</id><timestamp>2013-07-05T14:02:02Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|number of run}}
-| rdfs:range = xsd:nonNegativeInteger
-| rdfs:domain = Person
-}}</text></revision></page><page><title>OntologyProperty:NumberOfSeasons</title><ns>202</ns><id>1402</id><revision><id>57441</id><timestamp>2022-04-17T21:22:57Z</timestamp><text>{{DatatypeProperty
-| labels =
-  {{label|en|number of seasons}}
-  {{label|fr|nombre de saisons}}
-  {{label|de|Anzahl der Staffeln}}
-| rdfs:domain = TelevisionShow
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfSeats</title><ns>202</ns><id>9327</id><revision><id>57252</id><timestamp>2022-03-28T21:14:51Z</timestamp><text>{{ DatatypeProperty
-	| labels = 
-  {{label|en|number of seats}}
-  {{label|fr|nombre de places}}
-  {{label|de|Anzahl der Sitze}}
-  {{label|nl|aantal plaatsen}}
-	| rdfs:domain = MeanOfTransportation
-	| rdfs:range = xsd:nonNegativeInteger
-
-}}</text></revision></page><page><title>OntologyProperty:NumberOfSeatsInParliament</title><ns>202</ns><id>8265</id><revision><id>34006</id><timestamp>2014-04-04T15:31:24Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|number of seats in parliament}}
-{{label|de|Anzahl der Sitze im Parlament}}
-{{label|nl|aantal zetels in parlement}}
-| comments =
-{{comment|en| number of seats in House of Commons-like parliaments }}
-{{comment|nl| aantal zetels in Tweede-Kamer-achtig parlement }}
-| rdfs:domain = PoliticalParty
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfSettlement</title><ns>202</ns><id>7018</id><revision><id>34007</id><timestamp>2014-04-04T15:31:29Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|number of settlement}}
-{{label|de|Zahl der Siedlungen}}
-| rdfs:domain = Department
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfSettlementsInCountry</title><ns>202</ns><id>12255</id><revision><id>53447</id><timestamp>2018-10-28T11:30:23Z</timestamp><text>
-{{DatatypeProperty 
-| rdfs:label@en = number of entities of Settlement class in country
-| rdfs:label@cs = počet entit třídy Sídlo v dané zemi
-| rdfs:range = xsd:nonNegativeInteger
-| rdfs:domain = Country
-}}</text></revision></page><page><title>OntologyProperty:NumberOfSilverMedalsWon</title><ns>202</ns><id>1209</id><revision><id>34008</id><timestamp>2014-04-04T15:31:35Z</timestamp><text>{{DatatypeProperty
-|labels =
-  {{label|en|number of silver medals won}}
-{{label|de|Anzahl der Silbermedaillen}}
-  {{label|fr|nomber de médailles d'argent gagnées}}
-  {{label|es|cantidad de medallas de plata ganadas}}
-  {{label|nl|aantal gewonnen zilveren medailles}}
-| rdfs:domain = SportCompetitionResult
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfSoccerPlayerInCountryRepre</title><ns>202</ns><id>12260</id><revision><id>53453</id><timestamp>2018-10-28T21:05:00Z</timestamp><text>
-{{DatatypeProperty 
-| rdfs:label@en = number of SoccerPlayers in Country Repre
-| rdfs:label@cs = celkový počet fotbalový hráčů v reprezentaci
-| rdfs:range = xsd:nonNegativeInteger
-| rdfs:domain = SoccerClub
-}}</text></revision></page><page><title>OntologyProperty:NumberOfSoccerPlayersBornInPlace</title><ns>202</ns><id>12261</id><revision><id>53454</id><timestamp>2018-10-28T21:13:22Z</timestamp><text>
-{{DatatypeProperty 
-| rdfs:label@en = number of SoccerPlayers born in Place
-| rdfs:label@cs = počet fotbalistů narozen na daném místě
-| rdfs:range = xsd:nonNegativeInteger
-| rdfs:domain = Place
-}}</text></revision></page><page><title>OntologyProperty:NumberOfSoccerPlayersInTeam</title><ns>202</ns><id>12259</id><revision><id>53452</id><timestamp>2018-10-28T20:34:05Z</timestamp><text>
-{{DatatypeProperty 
-| rdfs:label@en = number of SoccerPlayers in entity of SoccerClub
-| rdfs:label@cs = počet fotbalových hráčů ve fotbalovém týmu
-| rdfs:range = xsd:nonNegativeInteger
-| rdfs:domain = SoccerClub
-}}</text></revision></page><page><title>OntologyProperty:NumberOfSpans</title><ns>202</ns><id>3439</id><revision><id>12458</id><timestamp>2011-04-27T14:31:38Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = number of spans
-| rdfs:label@de = Anzahl der Bögen
-| rdfs:domain = Bridge
-| rdfs:range = xsd:nonNegativeInteger
-| rdfs:comment@en = Number of spans or arches.
-}}</text></revision></page><page><title>OntologyProperty:NumberOfSpeakers</title><ns>202</ns><id>5290</id><revision><id>24805</id><timestamp>2013-04-09T11:17:16Z</timestamp><text>{{ DatatypeProperty
-| labels =
-{{label|en|number of speakers}}
-{{label|nl|aantal sprekers}}
-{{label|de|Anzahl Sprecher}}
-| rdfs:domain = Language
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfSports</title><ns>202</ns><id>1210</id><revision><id>22789</id><timestamp>2013-01-15T10:37:39Z</timestamp><text>{{DatatypeProperty
-| labels =
-  {{label|en|number of sports}}
-  {{label|fr|numbre de sports}}
-  {{label|es|numero de deportes}}
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfSportsEvents</title><ns>202</ns><id>6372</id><revision><id>52040</id><timestamp>2017-05-06T16:05:44Z</timestamp><text>{{DatatypeProperty
-| labels =
-  {{label|en|number of sports events}}
-{{label|de|Anzahl der Sportveranstaltungen}}
-  {{label|el|αριθμός αθλητικών γεγονότων}}
-  {{label|fr|numbre d'épreuves sportives}}
-  {{label|es|numero de pruebas deportivas}}
-| domain = SportsEvent
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfStaff</title><ns>202</ns><id>1211</id><revision><id>34010</id><timestamp>2014-04-04T15:31:47Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|number of staff}}
-{{label|de|Personalbestand}}
-{{label|el|αριθμός προσωπικού}}
-{{label|nl|aantal medewerkers}}
-| rdfs:domain = Organisation
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfStars</title><ns>202</ns><id>5340</id><revision><id>57255</id><timestamp>2022-03-28T21:24:28Z</timestamp><text>{{ DatatypeProperty
-
-	| labels =
-    {{label|en|number of stars}}
-    {{label|fr|nombre d'étoiles}}
-    {{label|de|Anzahl der Sterne}}
-	| rdfs:domain = Constellation
-	| rdfs:range = xsd:nonNegativeInteger
-
-}}</text></revision></page><page><title>OntologyProperty:NumberOfStateDeputies</title><ns>202</ns><id>3358</id><revision><id>12245</id><timestamp>2011-04-15T14:01:12Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = Number Of State Deputies
-| rdfs:label@pt = numero de deputados estaduais
-| rdfs:domain = PopulatedPlace
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfStations</title><ns>202</ns><id>3610</id><revision><id>57256</id><timestamp>2022-03-28T21:27:23Z</timestamp><text>{{DatatypeProperty
-| labels =
-  {{label|en|number of stations}}
-  {{label|fr|nombre de stations}}
-  {{label|de|Anzahl der Stationen}}
-| rdfs:domain = RouteOfTransportation
-| rdfs:range = xsd:nonNegativeInteger
-| comments =
-  {{comment|en|Number of stations or stops.}}
-  {{comment|fr|Nombre de stations, gares ou arrêts.}}
-}}</text></revision></page><page><title>OntologyProperty:NumberOfStores</title><ns>202</ns><id>11981</id><revision><id>52613</id><timestamp>2017-10-31T13:40:38Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = number of sores
-| rdfs:label@de = Anzahl an Geschäften
-| rdfs:domain = ShoppingMall
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfStudents</title><ns>202</ns><id>2149</id><revision><id>57245</id><timestamp>2022-03-28T20:58:10Z</timestamp><text>{{DatatypeProperty
-|labels=
-  {{label|en|number of students}}
-  {{label|fr|nombre d'étudiants}}
-  {{label|de|Zahl der Studierenden}}
-  {{label|el|αριθμός φοιτητών}}
-| rdfs:domain = EducationalInstitution
-| rdfs:range = xsd:nonNegativeInteger
-| owl:equivalentProperty=wikidata:P2196
-}}</text></revision></page><page><title>OntologyProperty:NumberOfStudioAlbums</title><ns>202</ns><id>5196</id><revision><id>56886</id><timestamp>2022-03-02T17:40:09Z</timestamp><text>{{DatatypeProperty
-| labels =
-    {{label|en|number of studio albums}}
-    {{label|fr|nombre d'albums studio}}
-    {{label|de|Zahl der Studio-Alben}}
-| comments =
-    {{comment|en|the number of studio albums released by the musical artist}}
-    {{comment|fr|nombre d'albums que l'artiste musical a réalisés en studio}}
-| rdfs:domain = MusicalArtist
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfSuites</title><ns>202</ns><id>2514</id><revision><id>10453</id><timestamp>2010-11-10T15:04:04Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = number of suites
-| rdfs:domain = Hotel
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfTeams</title><ns>202</ns><id>7316</id><revision><id>57246</id><timestamp>2022-03-28T21:00:59Z</timestamp><text>{{DatatypeProperty
-| labels = 
-    {{label|en|number of teams}}
-    {{label|fr|nombre d'équipes}}
-    {{label|de|Anzahl der Teams}}
-    {{label|it|numero di squadre}}
-| rdfs:domain = SportsLeague
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfTracks</title><ns>202</ns><id>3234</id><revision><id>57266</id><timestamp>2022-03-28T21:47:55Z</timestamp><text>{{DatatypeProperty
-| labels = 
-    {{label|en|number of tracks}}
-    {{label|fr|nombre de voies}}
-    {{label|de|Anzahl der Gleise}}
-| rdfs:domain = Infrastructure
-| rdfs:range = xsd:nonNegativeInteger
-| comments =
-    {{comment|en|Number of tracks of a railway or railway station.}}
-    {{comment|fr|Nombre de voies d'un chemin de fer ou d'une gare.}}
-}}</text></revision></page><page><title>OntologyProperty:NumberOfTrails</title><ns>202</ns><id>11804</id><revision><id>51921</id><timestamp>2017-02-20T11:21:21Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = number of trails
-| rdfs:label@ja = コース数
-| rdfs:domain = SkiArea
-| rdfs:range = xsd:nonNegativeInteger
-| rdfs:comment@en = Number of trails in ski area.
-}}</text></revision></page><page><title>OntologyProperty:NumberOfTriples</title><ns>202</ns><id>12237</id><revision><id>57257</id><timestamp>2022-03-28T21:30:10Z</timestamp><text>{{DatatypeProperty
-| labels =
-    {{label|en|numberOfTriples}}
-    {{label|fr|nombre de triplets}}
-| comments =
-    {{comment|en|number of triples in DBpedia}}
-    {{comment|fr|nombre de triplets dans DBpedia}}
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfTurns</title><ns>202</ns><id>5956</id><revision><id>19764</id><timestamp>2012-11-07T14:42:07Z</timestamp><text>{{DatatypeProperty
-|labels=
-   {{label|en|number of turns}}
-   {{label|fr|nombre de virages}}
-&lt;!--| rdfs:domain = RouteOfTransportation--&gt;
-| rdfs:domain = RaceTrack
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfUndergraduateStudents</title><ns>202</ns><id>1541</id><revision><id>34016</id><timestamp>2014-04-04T15:32:16Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = number of undergraduate students
-| rdfs:label@de = Zahl der Studenten
-| rdfs:domain = EducationalInstitution
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfUniqeResources</title><ns>202</ns><id>12265</id><revision><id>53490</id><timestamp>2018-11-30T20:18:14Z</timestamp><text>
-{{DatatypeProperty 
-| rdfs:label@en = numberOfUniqeResources
-| rdfs:comment@en = number of unique resource without redirecting
-| rdfs:range = xsd:nonNegativeInteger
-
-}}</text></revision></page><page><title>OntologyProperty:NumberOfUseOfProperty</title><ns>202</ns><id>12246</id><revision><id>53427</id><timestamp>2018-10-25T20:57:45Z</timestamp><text>
-{{DatatypeProperty 
-| rdfs:label@en = number of use of a property
-| rdfs:label@cs = počet použití property
-| rdfs:range = xsd:nonNegativeInteger
-
-}}</text></revision></page><page><title>OntologyProperty:NumberOfVehicles</title><ns>202</ns><id>3622</id><revision><id>56753</id><timestamp>2022-02-28T17:04:38Z</timestamp><text>{{DatatypeProperty
-| labels =
-    {{label|en|number of vehicles}}
-    {{label|de|Anzahl der Fahrzeuge}}
-    {{label|fr|nombre de véhicules}}
-| rdfs:domain = PublicTransitSystem
-| rdfs:range = xsd:nonNegativeInteger
-| comments =
-    {{comment|en|Number of vehicles used in the transit system.}}
-    {{comment|fr|Nombre de véhicules dans le système de transition.}}
-}}</text></revision></page><page><title>OntologyProperty:NumberOfVillages</title><ns>202</ns><id>6790</id><revision><id>34017</id><timestamp>2014-04-04T15:32:21Z</timestamp><text>{{DatatypeProperty
-| labels = 
-{{label|en|number of villages }}
-{{label|de|Anzahl der Dörfer}}
-{{label|id|jumlah desa/kelurahan }}
-| comments =
-| rdfs:domain  = District
-| rdfs:range   = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfVineyards</title><ns>202</ns><id>1212</id><revision><id>57265</id><timestamp>2022-03-28T21:43:35Z</timestamp><text>{{DatatypeProperty
-| labels =
-    {{label|en|number of vineyards}}
-    {{label|fr|nombre de vignobles}}
-    {{label|de|Anzahl von Weinbergen}}
-| rdfs:domain = WineRegion
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfVisitors</title><ns>202</ns><id>1213</id><revision><id>57264</id><timestamp>2022-03-28T21:41:28Z</timestamp><text>{{DatatypeProperty
-| labels =
-  {{label|en|number of visitors}}
-  {{label|fr|nombre de visiteurs}}
-  {{label|de|Besucherzahl}}
-  {{label|el|αριθμός επισκεπτών}}
-  {{label|nl|bezoekersaantal}}
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfVisitorsAsOf</title><ns>202</ns><id>3222</id><revision><id>12036</id><timestamp>2011-04-07T14:24:23Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = number of visitors as of
-| rdfs:domain = HistoricPlace
-| rdfs:range = xsd:gYear
-| rdfs:comment@en = The year in which number of visitors occurred.
-}}</text></revision></page><page><title>OntologyProperty:NumberOfVolumes</title><ns>202</ns><id>5988</id><revision><id>57262</id><timestamp>2022-03-28T21:37:53Z</timestamp><text>{{DatatypeProperty
-| labels = 
-    {{label|en|number of volumes}}
-    {{label|fr|nombre de volumes}}
-| rdfs:domain = WrittenWork
-| rdfs:range = xsd:nonNegativeInteger
-| rdfs:comment@en = 
-}}</text></revision></page><page><title>OntologyProperty:NumberOfVolunteers</title><ns>202</ns><id>1214</id><revision><id>57263</id><timestamp>2022-03-28T21:40:28Z</timestamp><text>{{DatatypeProperty
-| labels = 
-    {{label|en|number of volunteers}}
-    {{label|fr|nombre de bénévoles}}
-    {{label|de|Anzahl der Freiwilligen}}
-    {{label|el|αριθμός εθελοντών}}
-| rdfs:domain = Organisation
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberOfWineries</title><ns>202</ns><id>1215</id><revision><id>10408</id><timestamp>2010-11-10T14:43:26Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = number of wineries
-| rdfs:domain = WineRegion
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:NumberSold</title><ns>202</ns><id>11625</id><revision><id>50966</id><timestamp>2016-04-26T14:44:19Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = number sold
-| rdfs:domain = Sales
-| rdfs:range = xsd:nonNegativeInteger
-| rdfs:comment@en = Number of things (eg vehicles) sold
-}}</text></revision></page><page><title>OntologyProperty:NutsCode</title><ns>202</ns><id>2436</id><revision><id>48377</id><timestamp>2015-06-16T06:21:33Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|NUTS code}}
-{{label|nl|NUTS-code:}}
-| rdfs:comment@en = Nomenclature of Territorial Units for Statistics (NUTS) is a geocode  standard for referencing the subdivisions of countries  for statistical purposes. The standard is developed and regulated by the European Union, and thus only covers the member states of the EU in detail.
-| rdfs:domain = Place
-| rdfs:range = xsd:string
-| owl:equivalentProperty = wikidata:P605
-}}</text></revision></page><page><title>OntologyProperty:Observatory</title><ns>202</ns><id>7064</id><revision><id>57247</id><timestamp>2022-03-28T21:02:21Z</timestamp><text>{{DatatypeProperty
-| labels =
-    {{label|en|observatory}}
-    {{label|fr|observatoire}}
-    {{label|de|Observatorium}}
-    {{label|el|αστεροσκοπείο}}
-| comments =
-    {{comment|el|επιστημονικά ιδρύματα που παρατηρούν και μελετάνε ουράνια σώματα και φαινόμενα.}}
-| rdfs:domain = Island
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Occupation</title><ns>202</ns><id>1216</id><revision><id>58787</id><timestamp>2022-05-31T14:50:55Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|occupation}}
-	{{label|de|Beschäftigung}}
-	{{label|fr|activité}}
-	{{label|ja|職業}}
-	{{label|nl|beroep}}
-| rdfs:range = PersonFunction
-| owl:equivalentProperty = wikidata:P106, dbo:activity
-| rdfs:subPropertyOf = dul:hasRole
-}}</text></revision></page><page><title>OntologyProperty:Oclc</title><ns>202</ns><id>1718</id><revision><id>13206</id><timestamp>2011-05-25T16:50:57Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = OCLC
-| rdfs:domain = WrittenWork
-| rdfs:range = xsd:string
-| rdfs:comment@en = Online Computer Library Center number
-}}</text></revision></page><page><title>OntologyProperty:Odor</title><ns>202</ns><id>12044</id><revision><id>52800</id><timestamp>2018-02-07T19:10:39Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|Odor}}
-{{label|de|Geruch}}
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:OfferedClasses</title><ns>202</ns><id>1217</id><revision><id>52582</id><timestamp>2017-10-31T08:33:23Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = offered classes
-| rdfs:domain = EducationalInstitution
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Office</title><ns>202</ns><id>2324</id><revision><id>52482</id><timestamp>2017-10-16T07:27:04Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = (political) office
-| rdfs:label@el = υπηρεσία
-| rdfs:label@de = (politisches) Amt
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:OfficerInCharge</title><ns>202</ns><id>1218</id><revision><id>36340</id><timestamp>2014-07-08T14:06:39Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = officer in charge
-| rdfs:domain = University
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:OfficialLanguage</title><ns>202</ns><id>2763</id><revision><id>59633</id><timestamp>2024-06-04T10:26:09Z</timestamp><text>
-{{ObjectProperty
-| labels =
-    {{label|en|official language}}
-    {{label|fr|langue officielle}}
-    {{label|de|Amtssprache}}
-    {{label|am|ብሔራዊ ቋንቋ}}
-| rdfs:domain = PopulatedPlace
-| rdfs:range = Language
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:OfficialName</title><ns>202</ns><id>6939</id><revision><id>57258</id><timestamp>2022-03-28T21:31:43Z</timestamp><text>{{DatatypeProperty
-| labels =
-  {{label|en|official name}}
-  {{label|fr|nom officiel}}
-  {{label|de|offizieller Name}}
-| rdfs:domain = Settlement
-| rdfs:range = rdf:langString
-| owl:equivalentProperty = gn:officialName
-}}</text></revision></page><page><title>OntologyProperty:OfficialOpenedBy</title><ns>202</ns><id>1219</id><revision><id>36342</id><timestamp>2014-07-08T14:06:53Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = official opened by
-| rdfs:domain = Olympics
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:hasParticipant
-}}</text></revision></page><page><title>OntologyProperty:OfficialSchoolColour</title><ns>202</ns><id>700</id><revision><id>13123</id><timestamp>2011-05-23T10:45:01Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = official school colour
-| rdfs:label@de = offizielle Schulfarbe
-| rdfs:domain = EducationalInstitution
-| rdfs:range = xsd:string
-| rdfs:subPropertyOf = ColourName
-| rdfs:comment@en = The official colour of the EducationalInstitution represented by the colour name (e.g.: red or green).
-}}</text></revision></page><page><title>OntologyProperty:OfsCode</title><ns>202</ns><id>6942</id><revision><id>48374</id><timestamp>2015-06-16T06:14:48Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|ofs code of a settlement}}
-| rdfs:domain = Settlement
-| rdfs:range = xsd:string
-| rdfs:subPropertyOf = isoCode
-| rdfs:comment@en = Identifier used by the Swiss Federal Institute for Statistics
-| owl:equivalentProperty = wikidata:P771
-}}</text></revision></page><page><title>OntologyProperty:OilSystem</title><ns>202</ns><id>1220</id><revision><id>36343</id><timestamp>2014-07-08T14:06:56Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = oil system
-| rdfs:label@de = Ölsystem
-| rdfs:domain = AutomobileEngine
-| rdfs:subPropertyOf = dul:hasComponent
-}}</text></revision></page><page><title>OntologyProperty:OkatoCode</title><ns>202</ns><id>7280</id><revision><id>48375</id><timestamp>2015-06-16T06:16:20Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|okato code}}
-| rdfs:domain = PopulatedPlace
-| rdfs:range = xsd:string
-| rdfs:comment@en = Code used to indentify populated places in Russia
-| owl:equivalentProperty = wikidata:P721
-}}</text></revision></page><page><title>OntologyProperty:OldDistrict</title><ns>202</ns><id>6979</id><revision><id>57260</id><timestamp>2022-03-28T21:34:18Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|old district}}
-        {{label|fr|ancienne région}}
-	{{label|de|Altstadt}}
-| rdfs:range = PopulatedPlace
-| rdfs:domain = PopulatedPlace
-| rdfs:subPropertyOf = dul:isPartOf
-}}</text></revision></page><page><title>OntologyProperty:OldName</title><ns>202</ns><id>7278</id><revision><id>57248</id><timestamp>2022-03-28T21:03:31Z</timestamp><text>{{DatatypeProperty
-| labels =
-  {{label|en|old name}}
-  {{label|fr|ancien nom}}
-  {{label|el|παλιό όνομα}}
-  {{label|de|alter Name}}
-| rdfs:domain = PopulatedPlace
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:OldProvince</title><ns>202</ns><id>6978</id><revision><id>57259</id><timestamp>2022-03-28T21:32:57Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|old province}}
-	{{label|fr|ancienne province}}
-	{{label|de|alte Provinz}}
-| rdfs:range = PopulatedPlace
-| rdfs:domain = PopulatedPlace
-| rdfs:subPropertyOf = dul:isPartOf
-}}</text></revision></page><page><title>OntologyProperty:OldTeamCoached</title><ns>202</ns><id>7692</id><revision><id>26966</id><timestamp>2013-07-04T09:33:41Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|old team coached}}
-| rdfs:domain = Athlete
-| rdfs:range = SportsTeam
-}}</text></revision></page><page><title>OntologyProperty:Oldcode</title><ns>202</ns><id>1221</id><revision><id>57249</id><timestamp>2022-03-28T21:04:52Z</timestamp><text>{{DatatypeProperty
-| labels =
-  {{label|en|oldcode}}
-  {{label|fr|ancien code}}
-| rdfs:domain = OlympicResult
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:OlivierAward</title><ns>202</ns><id>1222</id><revision><id>36346</id><timestamp>2014-07-08T14:07:07Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = Olivier Award
-| rdfs:domain = Comedian
-| rdfs:range = Award
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:OlympicGames</title><ns>202</ns><id>7565</id><revision><id>34029</id><timestamp>2014-04-04T15:33:14Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|olympic games}}
-{{label|de|olympische Spiele}}
-{{label|nl|Olympische Spelen}}
-| rdfs:range = Tournament
-| rdfs:domain = Person
-}}</text></revision></page><page><title>OntologyProperty:OlympicGamesBronze</title><ns>202</ns><id>7572</id><revision><id>31735</id><timestamp>2014-02-11T13:32:23Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|olympic games bronze}}
-{{label|nl|brons op de Olympische Spelen}}
-| rdfs:domain = Person
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:OlympicGamesGold</title><ns>202</ns><id>7570</id><revision><id>31734</id><timestamp>2014-02-11T13:31:32Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|olympic games gold}}
-{{label|nl|goud op de Olympische Spelen}}
-| rdfs:domain = Person
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:OlympicGamesSilver</title><ns>202</ns><id>7571</id><revision><id>31733</id><timestamp>2014-02-11T13:30:23Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|olympic games silver}}
-{{label|nl|zilver op de Olympische Spelen}}
-| rdfs:domain = Person
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:OlympicGamesWins</title><ns>202</ns><id>7650</id><revision><id>31737</id><timestamp>2014-02-11T13:34:12Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|olympic games wins}}
-{{label|nl|overwinningen op de Olympische Spelen}}
-| rdfs:domain = Person
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:OlympicOathSwornBy</title><ns>202</ns><id>6374</id><revision><id>36347</id><timestamp>2014-07-08T14:07:10Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|de|Olympischer Eid}}
-	{{label|en|olympic oath sworn by}}
-	{{label|fr|lecteur du serment olympique}}
-| rdfs:domain = Olympics
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:hasParticipant
-}}</text></revision></page><page><title>OntologyProperty:OlympicOathSwornByAthlete</title><ns>202</ns><id>1223</id><revision><id>36348</id><timestamp>2014-07-08T14:07:13Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = olympic oath sworn by athlete
-| rdfs:domain = Olympics
-| rdfs:range = Person
-| rdfs:subPropertyOf = olympicOathSwornBy, dul:hasParticipant
-}}</text></revision></page><page><title>OntologyProperty:OlympicOathSwornByJudge</title><ns>202</ns><id>1224</id><revision><id>36349</id><timestamp>2014-07-08T14:07:17Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = olympic oath sworn by judge
-| rdfs:domain = Olympics
-| rdfs:range = Person
-| rdfs:subPropertyOf = olympicOathSwornBy, dul:hasParticipant
-}}</text></revision></page><page><title>OntologyProperty:Omim</title><ns>202</ns><id>1225</id><revision><id>23702</id><timestamp>2013-02-11T09:21:03Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|OMIM id}}
-{{label|nl|OMIM id}}
-{{label|ja|OMIM id}}
-| rdfs:domain = Biomolecule
-| rdfs:range = xsd:integer
-}}</text></revision></page><page><title>OntologyProperty:OnChromosome</title><ns>202</ns><id>5052</id><revision><id>39124</id><timestamp>2015-01-09T23:40:30Z</timestamp><text>{{DatatypeProperty 
-| rdfs:label@en = on chromosome
-| rdfs:label@nl = chromosoom nummer
-| rdfs:comment@en = the number corresponding to the chromosome on which the gene is located
-| rdfs:domain = GeneLocation
-| rdfs:range = xsd:integer
-}}</text></revision></page><page><title>OntologyProperty:Ons</title><ns>202</ns><id>6848</id><revision><id>52859</id><timestamp>2018-02-09T14:10:34Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|ONS ID (Office national des statistiques) Algeria}}
-| rdfs:domain = Settlement
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:OpenAccessContent</title><ns>202</ns><id>3745</id><revision><id>13201</id><timestamp>2011-05-25T16:48:41Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = open access content
-| rdfs:label@de = frei zugänglicher Inhalten
-| rdfs:domain = PeriodicalLiterature
-| rdfs:range = xsd:string
-| rdfs:comment@en = Availability of open access content.
-| rdfs:comment@de = Verfügbarkeit von frei zugänglichem Inhalten.
-}}</text></revision></page><page><title>OntologyProperty:OpeningDate</title><ns>202</ns><id>1226</id><revision><id>46258</id><timestamp>2015-03-18T14:56:38Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = opening date
-| rdfs:label@el = ημερομηνία ανοίγματος
-| rdfs:label@fr = date d'ouverture
-| rdfs:label@de = Eröffnungsdatum
-| rdfs:range = xsd:date
-}}</text></revision></page><page><title>OntologyProperty:OpeningFilm</title><ns>202</ns><id>1227</id><revision><id>36350</id><timestamp>2014-07-08T14:07:20Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = opening film
-| rdfs:label@de = Eröffnungsfilm
-| rdfs:domain = FilmFestival
-| rdfs:range = Film
-| rdfs:subPropertyOf = dul:hasParticipant
-}}</text></revision></page><page><title>OntologyProperty:OpeningTheme</title><ns>202</ns><id>1228</id><revision><id>36351</id><timestamp>2014-07-08T14:07:24Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = opening theme
-| rdfs:domain = TelevisionShow
-| rdfs:range = Work
-| rdfs:subPropertyOf = dul:hasPart
-}}</text></revision></page><page><title>OntologyProperty:OpeningYear</title><ns>202</ns><id>3382</id><revision><id>46260</id><timestamp>2015-03-18T14:58:20Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = opening year
-| rdfs:label@nl = openingsjaar
-| rdfs:label@de = Eröffnungsjahr
-| rdfs:range = xsd:gYear
-}}</text></revision></page><page><title>OntologyProperty:OperatingIncome</title><ns>202</ns><id>1229</id><revision><id>52777</id><timestamp>2018-01-23T15:03:10Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = operating income
-| rdfs:label@de = Betriebsergebnis
-| rdfs:domain = Company
-| rdfs:range = Currency
-| rdf:type = owl:FunctionalProperty
-| owl:equivalentProperty = wikidata:P3362
-}}</text></revision></page><page><title>OntologyProperty:OperatingSystem</title><ns>202</ns><id>1230</id><revision><id>36773</id><timestamp>2014-07-09T16:34:38Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|operating system}}
-        {{label|el|λειτουργικό σύστημα}}	
-        {{label|de|Betriebssystem}}
-	{{label|nl|besturingssysteem}}
-| rdfs:domain = Software
-| rdfs:subPropertyOf = dul:hasParticipant
-}}</text></revision></page><page><title>OntologyProperty:Operator</title><ns>202</ns><id>1231</id><revision><id>51201</id><timestamp>2016-06-08T13:09:23Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|operator}}
-	{{label|de|Betreiber}}
-	{{label|nl|exploitant}}
-| rdfs:domain = owl:Thing
-| rdfs:range = owl:Thing
-| rdfs:subPropertyOf = dul:coparticipatesWith
-| rdfs:comment@en = Organisation or City who is the operator of an ArchitecturalStructure, PublicTransitSystem, ConcentrationCamp, etc. Not to confuse with builder, owner or maintainer.
-Domain is unrestricted since Organization is Agent but City is Place. Range is unrestricted since anything can be operated.
-}}</text></revision></page><page><title>OntologyProperty:Opponent</title><ns>202</ns><id>1232</id><revision><id>36355</id><timestamp>2014-07-08T14:07:37Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = opponent
-| rdfs:label@ja = 敵対者
-| rdfs:label@de = Gegner
-| rdfs:domain = Person
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:Opponents</title><ns>202</ns><id>7467</id><revision><id>36356</id><timestamp>2014-07-08T14:07:41Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = opponents
-| rdfs:label@de = Gegner
-| rdfs:comment@en = "opponent in a military conflict, an organisation, country, or group of countries. "
-| rdfs:domain = MilitaryConflict
-| rdfs:range = owl:Thing
-| rdfs:subPropertyOf = dul:hasParticipant
-}}</text></revision></page><page><title>OntologyProperty:OrbitalEccentricity</title><ns>202</ns><id>7964</id><revision><id>56793</id><timestamp>2022-02-28T21:34:58Z</timestamp><text>{{DatatypeProperty
-| labels =
-    {{label|en|orbital eccentricity}}
-    {{label|fr|excentricité orbitale}}
-| rdfs:domain = CelestialBody
-| rdfs:range = xsd:float
-}}</text></revision></page><page><title>OntologyProperty:OrbitalFlights</title><ns>202</ns><id>1233</id><revision><id>10409</id><timestamp>2010-11-10T14:43:37Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = orbital flights
-| rdfs:domain = YearInSpaceflight
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:OrbitalInclination</title><ns>202</ns><id>1234</id><revision><id>34035</id><timestamp>2014-04-04T15:33:41Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = orbital inclination
-| rdfs:label@de = Bahnneigung
-| rdfs:domain = SpaceMission
-| rdfs:range = xsd:float
-}}</text></revision></page><page><title>OntologyProperty:OrbitalPeriod</title><ns>202</ns><id>1235</id><revision><id>34036</id><timestamp>2014-04-04T15:33:47Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = orbital period
-| rdfs:label@de = Umlaufzeit
-| rdfs:label@el = Περίοδος περιφοράς
-| rdfs:domain = Planet
-| rdfs:range = Time
-}}</text></revision></page><page><title>OntologyProperty:Orbits</title><ns>202</ns><id>1236</id><revision><id>34037</id><timestamp>2014-04-04T15:33:52Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = orbits
-| rdfs:label@de = Bahnen
-| rdfs:range = xsd:integer
-}}</text></revision></page><page><title>OntologyProperty:OrcidId</title><ns>202</ns><id>8421</id><revision><id>52882</id><timestamp>2018-02-13T10:53:15Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|ORCID Id}}
-| comments =
-{{comment|en|Authority data on researchers, academics, etc. The ID range has been defined as a subset of the forthcoming ISNI range.}}
-| rdfs:range = xsd:string
-| owl:equivalentProperty = wikidata:P496
-| rdfs:subPropertyOf = code
-}}</text></revision></page><page><title>OntologyProperty:Order</title><ns>202</ns><id>1237</id><revision><id>48618</id><timestamp>2015-08-06T12:36:58Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|order (taxonomy)}}
-	{{label|de|Ordnung}}
-	{{label|el|διαταγή}}
-	{{label|fr|ordre (taxonomie)}}
-	{{label|nl|orde}}
-	{{label|ja|目_(分類学)}}
-| rdfs:domain = Species
-| owl:equivalentProperty = wikidata:P70
-| rdfs:subPropertyOf = dul:isSpecializedBy
-}}</text></revision></page><page><title>OntologyProperty:OrderDate</title><ns>202</ns><id>3110</id><revision><id>11655</id><timestamp>2011-04-02T11:06:18Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en=order date
-| rdfs:domain = Ship
-| rdfs:range = xsd:date
-}}</text></revision></page><page><title>OntologyProperty:OrderInOffice</title><ns>202</ns><id>2323</id><revision><id>8391</id><timestamp>2010-05-28T13:57:55Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = order in office
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Ordination</title><ns>202</ns><id>2666</id><revision><id>9567</id><timestamp>2010-09-20T08:24:07Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = Ordination
-| rdfs:domain = Priest
-| rdfs:range = xsd:date
-}}</text></revision></page><page><title>OntologyProperty:Organ</title><ns>202</ns><id>9342</id><revision><id>32981</id><timestamp>2014-03-26T11:49:20Z</timestamp><text>{{ObjectProperty
-| labels                 =
-{{label|en|organ}}
-{{label|nl|orgel}}
-| comments               =
-{{comment|en|Name and/or description of the organ}}
-{{comment|nl|Naam en/of beschrijving van het orgel}}
-| rdfs:domain            = ReligiousBuilding
-| rdfs:range             = Organ
-| rdf:type               =
-| rdfs:subPropertyOf     = 
-| owl:equivalentProperty = 
-}}</text></revision></page><page><title>OntologyProperty:OrganSystem</title><ns>202</ns><id>2111</id><revision><id>36358</id><timestamp>2014-07-08T14:07:48Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = organ system
-| rdfs:comment@en = the organ system that a anatomical structure belongs to
-| rdfs:domain = AnatomicalStructure
-| rdfs:range = AnatomicalStructure
-| rdfs:subPropertyOf = dul:isPartOf
-}}</text></revision></page><page><title>OntologyProperty:Organisation</title><ns>202</ns><id>7126</id><revision><id>57442</id><timestamp>2022-04-17T21:24:08Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|organisation}}
-	{{label|fr|organisation}}
-	{{label|de|Organisation}}
-| rdfs:range = Organisation
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:OrganisationMember</title><ns>202</ns><id>5040</id><revision><id>36360</id><timestamp>2014-07-08T14:07:57Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = organisation member
-| rdfs:label@de = Organisationsmitglied
-| rdfs:comment@en = Identify the members of an organisation. 
-| rdfs:domain = Organisation
-| rdfs:range = OrganisationMember
-| rdfs:subPropertyOf = dul:hasMember
-}}</text></revision></page><page><title>OntologyProperty:Orientation</title><ns>202</ns><id>7818</id><revision><id>56778</id><timestamp>2022-02-28T18:35:56Z</timestamp><text>{{DatatypeProperty
-| labels =
-    {{label|en|orientation}}
-    {{label|fr|orientation}}
-    {{label|de|Orientierung}}
-| rdfs:domain = Person
-| rdfs:range = xsd:string
-| owl:equivalentProperty = wikidata:P91
-}}</text></revision></page><page><title>OntologyProperty:Origin</title><ns>202</ns><id>1239</id><revision><id>36361</id><timestamp>2014-07-08T14:08:01Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|origin}}
-	{{label|el|προέλευση}}
-	{{label|nl|oorsprong}}
-	{{label|de|Herkunft}}
-	{{label|fr|origine}}
-	{{label|pt|origem}}
-| rdfs:range = PopulatedPlace
-| rdfs:subPropertyOf = dul:hasCommonBoundary
-}}</text></revision></page><page><title>OntologyProperty:OriginalDanseCompetition</title><ns>202</ns><id>8076</id><revision><id>28239</id><timestamp>2013-09-04T09:17:38Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|original danse competititon}}
-| rdfs:domain = Person
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:OriginalDanseScore</title><ns>202</ns><id>8075</id><revision><id>28238</id><timestamp>2013-09-04T09:17:17Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|original danse score}}
-| rdfs:domain = Person
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:OriginalEndPoint</title><ns>202</ns><id>1240</id><revision><id>36362</id><timestamp>2014-07-08T14:08:16Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = original end point
-| rdfs:label@el = πρωταρχικό_σημείο_τέλους
-| rdfs:domain = Canal
-| rdfs:range = Place
-| rdfs:subPropertyOf = dul:hasCommonBoundary
-}}</text></revision></page><page><title>OntologyProperty:OriginalLanguage</title><ns>202</ns><id>3831</id><revision><id>36363</id><timestamp>2014-07-08T14:08:20Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|original language}}
-	{{label|nl|oorspronkelijke taal}}
-	{{label|de|Originalsprache}}
-	{{label|fr|langue originale}}
-	{{label|es|idioma original}}
-| rdfs:domain = Work
-| rdfs:range = Language
-| rdfs:subPropertyOf = language, dul:isExpressedBy
-| rdfs:comment@en = The original language of the work.
-| owl:equivalentProperty = wikidata:P364
-}}</text></revision></page><page><title>OntologyProperty:OriginalMaximumBoatBeam</title><ns>202</ns><id>1241</id><revision><id>8186</id><timestamp>2010-05-28T13:30:14Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = original maximum boat beam
-| rdfs:domain = Canal
-| rdfs:range = Length
-}}</text></revision></page><page><title>OntologyProperty:OriginalMaximumBoatLength</title><ns>202</ns><id>1242</id><revision><id>8187</id><timestamp>2010-05-28T13:30:23Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = original maximum boat length
-| rdfs:domain = Canal
-| rdfs:range = Length
-}}</text></revision></page><page><title>OntologyProperty:OriginalName</title><ns>202</ns><id>5251</id><revision><id>53700</id><timestamp>2020-09-04T15:27:50Z</timestamp><text>{{ DatatypeProperty
-| labels =
-{{label|en|original name}}
-{{label|de|ursprünglicher Namen}}
-{{label|nl|oorspronkelijke naam}}
-| rdfs:comment@en = The original name of the entity, e.g. film, settlement, etc.
-| rdfs:domain = owl:Thing
-| rdfs:range = rdf:langString
-| owl:equivalentProperty = ceo:oorspronkelijkeNaam
-}}</text></revision></page><page><title>OntologyProperty:OriginalNotLatinTitle</title><ns>202</ns><id>13834</id><revision><id>57226</id><timestamp>2022-03-24T20:46:58Z</timestamp><text>{{ DatatypeProperty
-| labels =
-{{label|en|original title not latin}}
-{{label|en|titre original non latin}}
-| comments = 
-    {{comment|en|The original non latin title of the work}}
-    {{comment|fr|Titre original non latin de l'oeuvre}}
-| rdfs:domain = Work
-| rdfs:range = rdf:langString
-}}</text></revision></page><page><title>OntologyProperty:OriginalStartPoint</title><ns>202</ns><id>1243</id><revision><id>36364</id><timestamp>2014-07-08T14:08:25Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = original start point
-| rdfs:label@de = ursprünglicher Ausgangspunkt
-| rdfs:label@el = πρωταρχική_αρχή
-| rdfs:domain = Canal
-| rdfs:range = Place
-| rdfs:subPropertyOf = dul:hasCommonBoundary
-}}</text></revision></page><page><title>OntologyProperty:OriginalTitle</title><ns>202</ns><id>6794</id><revision><id>57227</id><timestamp>2022-03-24T20:51:58Z</timestamp><text>{{ DatatypeProperty
-| labels =
-    {{label|en|original title}}
-    {{label|fr|titre original}}
-    {{label|de|Originaltitel}}
-    {{label|nl|oorspronkelijke titel}}
-| comments = 
-    {{comment|en|The original title of the work, most of the time in the original language as well}}
-    {{comment|fr|Titre original de l'oeuvre, le plus souvent aussi dans la langue d'origine}}
-| rdfs:domain = Work
-| rdfs:range = rdf:langString
-}}</text></revision></page><page><title>OntologyProperty:OriginallyUsedFor</title><ns>202</ns><id>6007</id><revision><id>51229</id><timestamp>2016-06-09T09:54:32Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|originally used for}}
-{{label|de|ursprünglich verwendet für}}
-{{label|nl|oorspronkelijk gebruik}}
-| rdfs:domain = owl:Thing
-| rdfs:range = xsd:string
-| rdfs:comment@en = Original use of ArchitecturalStructure or ConcentrationCamp, if it is currently being used as anything other than its original purpose.
-}}</text></revision></page><page><title>OntologyProperty:Origo</title><ns>202</ns><id>9283</id><revision><id>32597</id><timestamp>2014-03-11T09:26:31Z</timestamp><text>{{ObjectProperty
-| rdfs:label@en = origo
-| rdfs:domain = Muscle
-| rdfs:range = AnatomicalStructure
-}}</text></revision></page><page><title>OntologyProperty:Orogeny</title><ns>202</ns><id>1244</id><revision><id>36365</id><timestamp>2014-07-08T14:08:27Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = orogeny
-| rdfs:label@fr = orogenèse
-| rdfs:subPropertyOf = dul:isClassifiedBy
-}}</text></revision></page><page><title>OntologyProperty:Orpha</title><ns>202</ns><id>11876</id><revision><id>52213</id><timestamp>2017-10-07T15:49:16Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|ORPHA}}
-{{label|nl|ORPHA}}
-{{label|de|ORPHA}}
-{{label|fr|ORPHA}}
-| rdfs:domain = Disease
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:OrthologousGene</title><ns>202</ns><id>5048</id><revision><id>36366</id><timestamp>2014-07-08T14:08:31Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = Orthologous Gene
-| rdfs:label@ja = オーソロガス遺伝子
-| rdfs:domain = Gene
-| rdfs:range = Gene
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:Other</title><ns>202</ns><id>1245</id><revision><id>8188</id><timestamp>2010-05-28T13:30:32Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = other
-| rdfs:domain = University
-| rdfs:range = xsd:integer
-}}</text></revision></page><page><title>OntologyProperty:OtherActivity</title><ns>202</ns><id>7699</id><revision><id>57267</id><timestamp>2022-03-28T21:50:04Z</timestamp><text>{{DatatypeProperty
-| labels =
-  {{label|en|other activity}}
-  {{label|fr|autre activité}}
-  {{label|de|andere Aktivität}}
-| rdfs:domain = Person
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:OtherAppearances</title><ns>202</ns><id>1246</id><revision><id>36367</id><timestamp>2014-07-08T14:08:34Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = other appearances
-| rdfs:domain = OlympicResult
-| rdfs:range = OlympicResult
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:OtherChannel</title><ns>202</ns><id>3184</id><revision><id>11913</id><timestamp>2011-04-05T10:38:02Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = other channel
-| rdfs:domain = Broadcaster
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:OtherFamilyBranch</title><ns>202</ns><id>9293</id><revision><id>32659</id><timestamp>2014-03-13T16:27:55Z</timestamp><text>{{ObjectProperty
-|labels =
-{{label|en|other branch}}
-{{label|nl|zijtak}}
-| rdfs:domain = NobleFamily
-| rdfs:range = Family
-}}</text></revision></page><page><title>OntologyProperty:OtherFuelType</title><ns>202</ns><id>9590</id><revision><id>35516</id><timestamp>2014-06-28T22:03:15Z</timestamp><text>{{ObjectProperty
-|rdfs:label@en = secondary/other fuel type
-|rdfs:domain = PowerStation
-}}</text></revision></page><page><title>OntologyProperty:OtherFunction</title><ns>202</ns><id>7558</id><revision><id>57268</id><timestamp>2022-03-28T21:51:05Z</timestamp><text>{{ObjectProperty
-| labels =
-  {{label|en|other function}}
-  {{label|fr|autre fonction}}
-  {{label|de|andere Funktion}}
-| rdfs:domain = Person
-}}</text></revision></page><page><title>OntologyProperty:OtherInformation</title><ns>202</ns><id>6904</id><revision><id>34048</id><timestamp>2014-04-04T15:34:44Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|other information of a settlement}}
-{{label|de|andere Informationen einer Siedlung}}
-| rdfs:domain = Settlement
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:OtherLanguage</title><ns>202</ns><id>6895</id><revision><id>57269</id><timestamp>2022-03-28T21:53:23Z</timestamp><text>{{DatatypeProperty
-| labels =
-  {{label|en|other language of a settlement}}
-  {{label|fr|autre langue de la colonie}}
-  {{label|de|anderen Sprache einer Siedlung}}
-| rdfs:domain = Settlement
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:OtherMedia</title><ns>202</ns><id>7880</id><revision><id>34050</id><timestamp>2014-04-04T15:34:55Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|other media}}
-{{label|de|andere Medien}}
-| rdfs:domain = Person
-| rdfs:range = PeriodicalLiterature
-}}</text></revision></page><page><title>OntologyProperty:OtherName</title><ns>202</ns><id>6894</id><revision><id>34845</id><timestamp>2014-05-15T05:19:13Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|other name}}
-{{label|de|anderer Name}}
-| rdfs:domain = PopulatedPlace
-| rdfs:range = rdf:langString
-}}</text></revision></page><page><title>OntologyProperty:OtherOccupation</title><ns>202</ns><id>7882</id><revision><id>27364</id><timestamp>2013-07-10T14:08:48Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|other occupation}}
-| rdfs:domain = Person
-| rdfs:range = PersonFunction
-}}</text></revision></page><page><title>OntologyProperty:OtherParty</title><ns>202</ns><id>1248</id><revision><id>36368</id><timestamp>2014-07-08T14:08:37Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = other party
-| rdfs:label@de = andere Partei
-| rdfs:domain = OfficeHolder
-| rdfs:range = PoliticalParty
-| rdfs:subPropertyOf = dul:isMemberOf
-}}</text></revision></page><page><title>OntologyProperty:OtherServingLines</title><ns>202</ns><id>3228</id><revision><id>22274</id><timestamp>2013-01-11T00:22:36Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|other serving lines}}
-{{label|nl|andere verbindingen}}
-{{label|de|andere Verbindungen}}
-| rdfs:domain = Station
-| rdfs:range = xsd:string
-| rdfs:comment@en = Connecting services that serve the station such as bus, etc.
-}}</text></revision></page><page><title>OntologyProperty:OtherSportsExperience</title><ns>202</ns><id>7976</id><revision><id>28024</id><timestamp>2013-08-11T04:34:43Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|otherSportsExperience}}
-{{label|ja|スポーツ歴}}
-| rdfs:domain = Athlete
-| rdfs:range = Athletics
-}}</text></revision></page><page><title>OntologyProperty:OtherWins</title><ns>202</ns><id>3541</id><revision><id>12675</id><timestamp>2011-05-07T14:10:02Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = other wins
-| rdfs:label@de = Sonstige Siege
-| rdfs:domain = SnookerPlayer
-| rdfs:range = xsd:nonNegativeInteger
-| rdfs:subPropertyOf = Wins
-}}</text></revision></page><page><title>OntologyProperty:OtherWorks</title><ns>202</ns><id>13833</id><revision><id>57216</id><timestamp>2022-03-18T19:13:12Z</timestamp><text>{{ObjectProperty
-| labels =
-  {{label|en|other works}}
-  {{label|fr|autres oeuvres}}
-| rdfs:domain = Work
-| rdfs:range = WorkSequence
-| comments =
-  {{comment|en|Tells about existence of other works.}}
-  {{comment|fr|Indique l'existence d'autres oeuvres antérieures/postérieures. }}
-}}</text></revision></page><page><title>OntologyProperty:Outflow</title><ns>202</ns><id>1249</id><revision><id>50326</id><timestamp>2016-02-05T08:21:54Z</timestamp><text>{{ObjectProperty
-| rdfs:label@en = outflow
-| rdfs:label@de = Abfluss
-| rdfs:label@el = εκροή
-| rdfs:domain = BodyOfWater
-| rdfs:range = River
-| rdfs:subPropertyOf = dul:hasCommonBoundary
-}}</text></revision></page><page><title>OntologyProperty:Output</title><ns>202</ns><id>7191</id><revision><id>25741</id><timestamp>2013-06-01T13:20:18Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|output}}
-| rdfs:domain = Place
-| rdfs:range = xsd:float
-}}</text></revision></page><page><title>OntologyProperty:OutputHistory</title><ns>202</ns><id>13824</id><revision><id>57123</id><timestamp>2022-03-13T19:52:41Z</timestamp><text>{{DatatypeProperty
-| labels =
-  {{label|en|output history}}
-  {{label|fr|historique de sortie}}
-| comments =
-  {{comment|en|Existence of multiple output dates.}}
-  {{comment|fr|Indique qu'il existe plusieurs dates de sortie. Valeur oui / non. 
-}}
-| rdfs:domain = MusicalWork
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Outskirts</title><ns>202</ns><id>7238</id><revision><id>25894</id><timestamp>2013-06-12T14:03:14Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|outskirts}}
-| rdfs:domain = PopulatedPlace
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:OverallRecord</title><ns>202</ns><id>1250</id><revision><id>34054</id><timestamp>2014-04-04T15:35:13Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = overall record
-| rdfs:label@de = Gesamtbilanz
-| rdfs:domain = CollegeCoach
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Oversight</title><ns>202</ns><id>1251</id><revision><id>8191</id><timestamp>2010-05-28T13:30:58Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = oversight
-| rdfs:domain = School
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Owl:differentFrom</title><ns>202</ns><id>10468</id><revision><id>39747</id><timestamp>2015-02-03T08:58:41Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|An owl:differentFrom statement indicates that two URI references refer to different individuals}}
-}}</text></revision></page><page><title>OntologyProperty:Owl:sameAs</title><ns>202</ns><id>4030</id><revision><id>13830</id><timestamp>2011-06-22T10:09:51Z</timestamp><text>{{ObjectProperty
-| rdfs:label@en = same as
-}}</text></revision></page><page><title>OntologyProperty:Owner</title><ns>202</ns><id>1252</id><revision><id>47820</id><timestamp>2015-04-28T15:20:20Z</timestamp><text>{{Merge|OntologyProperty:owningOrganisation}}
-
-
-{{ObjectProperty
-| labels =
-	{{label|en|owner}}
-	{{label|nl|eigenaar}}
-	{{label|de|Eigentümer}}
-	{{label|el|ιδιοκτήτης}}
-	{{label|fr|propriétaire}}
-	{{label|es|dueño}}
-	{{label|ga|úinéir}}
-	{{label|pl|właściciel}}
-| rdfs:comment@en = Used as if meaning: owned by, has as its owner
-| rdfs:domain = 
-| rdfs:range = Agent
-| rdfs:subPropertyOf = dul:sameSettingAs
-| owl:equivalentProperty = wikidata:P127
-}}</text></revision></page><page><title>OntologyProperty:OwningCompany</title><ns>202</ns><id>1253</id><revision><id>36371</id><timestamp>2014-07-08T14:08:47Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = owning company
-| rdfs:label@de = Besitzerfirma
-| rdfs:range = Company
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:OwningOrganisation</title><ns>202</ns><id>1254</id><revision><id>58784</id><timestamp>2022-05-31T14:34:20Z</timestamp><text>{{Merge|OntologyProperty:owner}}
-
-
-{{ObjectProperty
-| rdfs:label@en = owning organisation
-| rdfs:label@el = οργανισμός
-| rdfs:range = Organisation
-| rdfs:subPropertyOf = owner
-| owl:equivalentProperty = wikidata:P1830
-}}</text></revision></page><page><title>OntologyProperty:Owns</title><ns>202</ns><id>10202</id><revision><id>53666</id><timestamp>2020-07-30T21:19:33Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|owns}}
-	{{label|nl|in bezit van}}
-| rdfs:comment@en = Used as if meaning: has property rights over
-| rdfs:domain= Agent
-| rdfs:range = Thing
-| rdfs:subPropertyOf = dul:sameSettingAs
-| owl:equivalentProperty = schema:owns
-}}</text></revision></page><page><title>OntologyProperty:Painter</title><ns>202</ns><id>5621</id><revision><id>57250</id><timestamp>2022-03-28T21:07:22Z</timestamp><text>
-{{ObjectProperty
-| labels = 
-  {{label|en|painter}}
-  {{label|fr|peintre}}
-  {{label|de|Maler}}
-  {{label|el|ζωγράφος}}
-| rdfs:domain = Artwork
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:Pandemic</title><ns>202</ns><id>13104</id><revision><id>56981</id><timestamp>2022-03-09T10:41:43Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|Pandemic}}
-	{{label|fr|Pandémie}}
-	{{label|zh|瘟疫}}
-| comments =
-	{{comment|en|Global epidemic of infectious disease}}
-	{{comment|fr|Epidémie globale de maladie infectieuse}}
-	{{comment|zh|也称大流行，是指某种流行病的大范围疾病爆发，其规模涉及多个大陆甚至全球（即全球大流行），并有大量人口患病}}
-| rdfs:domain = owl:Thing
-| rdfs:range = Disease
-}}</text></revision></page><page><title>OntologyProperty:PandemicDeaths</title><ns>202</ns><id>13106</id><revision><id>54876</id><timestamp>2021-07-22T02:54:09Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|Deaths}}
-| rdfs:comment@en = Number of deaths caused by pandemic
-| rdfs:domain = Outbreak
-| rdfs:range = xsd:integer
-}}</text></revision></page><page><title>OntologyProperty:Parent</title><ns>202</ns><id>1256</id><revision><id>53596</id><timestamp>2020-02-04T05:26:28Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|parent}}
-	{{label|de|Elternteil}}
-	{{label|nl|ouder}}
-	{{label|fr|parent}}
-	{{label|ja|親}}
-| rdfs:domain = Person
-| rdfs:range = Person
-| owl:propertyDisjointWith = child
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:ParentCompany</title><ns>202</ns><id>1257</id><revision><id>36375</id><timestamp>2014-07-08T14:09:00Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = parent company
-| rdfs:label@de = Muttergesellschaft
-| rdfs:range = Company
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:ParentMountainPeak</title><ns>202</ns><id>2416</id><revision><id>36376</id><timestamp>2014-07-08T14:09:04Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = parent mountain peak
-| rdfs:domain = Mountain
-| rdfs:range = Mountain
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:ParentOrganisation</title><ns>202</ns><id>1258</id><revision><id>36377</id><timestamp>2014-07-08T14:09:07Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|parent organisation}}
-	{{label|nl|moederorganisatie}}
-| rdfs:domain = Organisation
-| rdfs:range = Organisation
-| owl:equivalentProperty = schema:branchOf
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:Parentheses</title><ns>202</ns><id>11993</id><revision><id>57443</id><timestamp>2022-04-17T21:25:20Z</timestamp><text>{{ObjectProperty
-| labels = 
-  {{label|en|parentheses}}
-  {{label|fr|parenthèses}}
-  {{label|nl|haakjes}}
-| rdfs:domain = Species
-
-}}</text></revision></page><page><title>OntologyProperty:Parish</title><ns>202</ns><id>2139</id><revision><id>36378</id><timestamp>2014-07-08T14:09:10Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = parish
-| rdfs:label@de = Gemeinde
-| rdfs:domain = PopulatedPlace
-| rdfs:range = PopulatedPlace
-| rdfs:subPropertyOf = dul:isPartOf
-}}</text></revision></page><page><title>OntologyProperty:ParkingInformation</title><ns>202</ns><id>3235</id><revision><id>12058</id><timestamp>2011-04-07T15:59:55Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = parking information
-| rdfs:label@de = Parkplatzinformationen
-| rdfs:domain = Station
-| rdfs:range = xsd:string
-| rdfs:comment@en = Information on station's parking facilities.
-}}</text></revision></page><page><title>OntologyProperty:ParkingLotsCars</title><ns>202</ns><id>11143</id><revision><id>46185</id><timestamp>2015-03-18T08:57:41Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = number of parking lots for cars
-| rdfs:label@nl = aantal parkeerplaatsen personenauto's
-| rdfs:domain = RestArea
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:ParkingLotsTrucks</title><ns>202</ns><id>11144</id><revision><id>46186</id><timestamp>2015-03-18T08:58:40Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = number of parking lots for trucks
-| rdfs:label@nl = aantal parkeerplaatsen vrachtwagens
-| rdfs:domain = RestArea
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:Parliament</title><ns>202</ns><id>7179</id><revision><id>52485</id><timestamp>2017-10-16T08:01:24Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|parliament}}
-{{label|de|Parlament}}
-| rdfs:domain = owl:Thing
-| rdfs:range = Parliament
-}}</text></revision></page><page><title>OntologyProperty:ParliamentType</title><ns>202</ns><id>7180</id><revision><id>25729</id><timestamp>2013-06-01T10:21:10Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|parliament type}}
-| rdfs:domain = Place
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:ParliamentaryGroup</title><ns>202</ns><id>7813</id><revision><id>34061</id><timestamp>2014-04-04T15:35:50Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|parliamentary group}}
-{{label|de|Fraktion}}
-| rdfs:domain = Person
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Part</title><ns>202</ns><id>1259</id><revision><id>52307</id><timestamp>2017-10-09T12:48:28Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = part
-| rdfs:label@de = Teil
-| rdfs:subPropertyOf = dul:hasPart
-}}</text></revision></page><page><title>OntologyProperty:PartialFailedLaunches</title><ns>202</ns><id>1260</id><revision><id>10411</id><timestamp>2010-11-10T14:45:25Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = partial failed launches
-| rdfs:range = xsd:nonNegativeInteger
-| rdfs:comment@en = total number of launches resulting in partial failure
-}}</text></revision></page><page><title>OntologyProperty:Participant</title><ns>202</ns><id>5280</id><revision><id>57444</id><timestamp>2022-04-17T21:26:17Z</timestamp><text>{{ DatatypeProperty
-| labels =
-  {{label|en|participant}}
-  {{label|fr|participant}}
-  {{label|nl|deelnemer}}
-  {{label|de|Teilnehmer}}
-| rdfs:domain = Event
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:ParticipatingIn</title><ns>202</ns><id>10243</id><revision><id>38526</id><timestamp>2014-10-03T14:49:21Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|participates/participated in}}
-	{{label|de|nimmt Teil an}}
-	{{label|nl|neemt deel aan}}
-| rdfs:domain = MemberResistanceMovement
-| rdfs:range = SocietalEvent
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:ParticularSign</title><ns>202</ns><id>7819</id><revision><id>27128</id><timestamp>2013-07-05T14:44:17Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|particular sign}}
-| rdfs:domain = Person
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:PartitionCoefficient</title><ns>202</ns><id>12042</id><revision><id>52798</id><timestamp>2018-02-07T19:02:56Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|Partition coefficient}}
-{{label|de|Verteilungskoeffizient}}
-{{label|nl|Verdelingscoëfficiënt}}
-| rdfs:domain = ChemicalSubstance
-| rdfs:range = xsd:float
-}}</text></revision></page><page><title>OntologyProperty:Partner</title><ns>202</ns><id>1261</id><revision><id>57270</id><timestamp>2022-03-28T21:55:05Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|partner}}
-	{{label|fr|partenaire}}
-	{{label|nl|partner}}
-	{{label|el|συνέταιρος}}
-	{{label|de|Partner}}
-| rdfs:domain = Person
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:Party</title><ns>202</ns><id>1264</id><revision><id>36381</id><timestamp>2014-07-08T14:09:31Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|party}}
-	{{label|el|πάρτυ}}
-	{{label|nl|partij}}
-	{{label|de|Partei}}
-	{{label|ja|政党}}
-| rdfs:domain = owl:Thing
-| rdfs:range = PoliticalParty
-| owl:equivalentProperty = wikidata:P102
-| rdfs:subPropertyOf = dul:isMemberOf
-}}</text></revision></page><page><title>OntologyProperty:PartyNumber</title><ns>202</ns><id>3261</id><revision><id>12113</id><timestamp>2011-04-13T10:11:35Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = party number
-| rdfs:label@pt = número do partido
-| rdfs:range = xsd:integer
-}}</text></revision></page><page><title>OntologyProperty:PassengersPerDay</title><ns>202</ns><id>3574</id><revision><id>56868</id><timestamp>2022-03-01T20:45:22Z</timestamp><text>{{DatatypeProperty
-| labels = 
-    {{label|en|passengers per day}}
-    {{label|fr|passagers par jour}}
-    {{label|de|Passagiere pro Tag}}
-| rdfs:domain = Infrastructure
-| rdfs:range = xsd:nonNegativeInteger
-| comments =
-    {{comment|en|Number of passengers per day.}}
-    {{comment|fr|Nombre de passagers par jour.}}
-}}</text></revision></page><page><title>OntologyProperty:PassengersPerYear</title><ns>202</ns><id>3575</id><revision><id>57271</id><timestamp>2022-03-28T21:57:30Z</timestamp><text>{{DatatypeProperty
-| labels =
-    {{label|en|passengers per year}}
-    {{label|fr|passagers par an}}
-    {{label|nl|passagiers per jaar}}
-    {{label|de|Passagiere pro Jahr}}
-| rdfs:domain = Infrastructure
-| rdfs:range = xsd:nonNegativeInteger
-| comments =
-    {{comment|en|Number of passengers per year.}}
-    {{comment|fr|Nombre de passagers par an.}}
-}}</text></revision></page><page><title>OntologyProperty:PassengersUsedSystem</title><ns>202</ns><id>3251</id><revision><id>12077</id><timestamp>2011-04-08T12:30:21Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = passengers used system
-| rdfs:label@de = benutztes System der Passagiere
-| rdfs:domain = Station
-| rdfs:range = xsd:string
-| rdfs:comment@en = System the passengers are using (from which the passenger statistics are).
-}}</text></revision></page><page><title>OntologyProperty:PastMember</title><ns>202</ns><id>1265</id><revision><id>36382</id><timestamp>2014-07-08T14:09:33Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = past member
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:hasMember
-}}</text></revision></page><page><title>OntologyProperty:Pastor</title><ns>202</ns><id>2783</id><revision><id>36383</id><timestamp>2014-07-08T14:09:35Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = pastor
-| rdfs:domain = HistoricBuilding
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:Patent</title><ns>202</ns><id>3352</id><revision><id>36384</id><timestamp>2014-07-08T14:09:38Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = patent
-| rdfs:label@de = Patent
-| rdfs:label@pt = patente
-| rdfs:domain = Person
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:Patron</title><ns>202</ns><id>1267</id><revision><id>36385</id><timestamp>2014-07-08T14:09:42Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = patron
-| rdfs:label@de = Patron
-| rdfs:label@pt = patrono
-| rdfs:domain = MilitaryUnit
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:PatronSaint</title><ns>202</ns><id>6852</id><revision><id>52590</id><timestamp>2017-10-31T08:59:33Z</timestamp><text>
-{{ObjectProperty
-| labels = {{label|en|patron saint}}
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:PccSecretary</title><ns>202</ns><id>7229</id><revision><id>25877</id><timestamp>2013-06-11T12:57:31Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|pcc secretary}}
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Pdb</title><ns>202</ns><id>1269</id><revision><id>51568</id><timestamp>2016-11-01T15:07:13Z</timestamp><text>{{DatatypeProperty
-| labels =
-  {{label|en|PDB ID}}
-  {{label|ja|PDB ID}}
-| comments =
-  {{comment|en|gene entry for 3D structural data as per the PDB (Protein Data Bank) database}}
-| rdfs:domain = Protein
-| rdfs:range = xsd:string
-| owl:equivalentProperty = wikidata:P638
-}}</text></revision></page><page><title>OntologyProperty:PeabodyAward</title><ns>202</ns><id>1270</id><revision><id>36387</id><timestamp>2014-07-08T14:09:49Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = Peabody Award
-| rdfs:domain = Comedian
-| rdfs:range = Award
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:PenaltiesTeamA</title><ns>202</ns><id>6196</id><revision><id>25152</id><timestamp>2013-05-05T22:18:26Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = Penalties Team A 
-| rdfs:domain = PenaltyShootOut
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:PenaltiesTeamB</title><ns>202</ns><id>6197</id><revision><id>25153</id><timestamp>2013-05-05T22:18:41Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = Penalties Team B 
-| rdfs:domain = PenaltyShootOut
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:PenaltyScore</title><ns>202</ns><id>6122</id><revision><id>25150</id><timestamp>2013-05-05T22:16:08Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = penalty score
-| rdfs:domain = PenaltyShootOut
-| rdfs:range = xsd:integer
-}}</text></revision></page><page><title>OntologyProperty:PendamicDeaths</title><ns>202</ns><id>12301</id><revision><id>53614</id><timestamp>2020-04-10T06:28:51Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|Deaths}}
-| rdfs:comment@en = Number of deaths caused by pandemic
-| rdfs:domain = Outbreak
-| rdfs:range = xsd:integer
-}}</text></revision></page><page><title>OntologyProperty:PenisLength</title><ns>202</ns><id>7816</id><revision><id>56777</id><timestamp>2022-02-28T18:34:42Z</timestamp><text>{{DatatypeProperty
-| labels =
-  {{label|en|penis length}}
-  {{label|fr|longeur du pénis}}
-| rdfs:domain = Person
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:PeopleFullyVaccinated</title><ns>202</ns><id>13115</id><revision><id>54889</id><timestamp>2021-07-26T03:53:53Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|People Fully Vaccinated}}
-| comments =
-	{{comment|en|VaccinationStatistics: Number of people fully vaccinated.}}
-| rdfs:domain = owl:Thing
-| rdfs:range = VaccinationStatistics
-}}</text></revision></page><page><title>OntologyProperty:PeopleName</title><ns>202</ns><id>6897</id><revision><id>39675</id><timestamp>2015-01-22T07:55:59Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|peopleName}}
-|comments=
-{{comment|en|Name for the people inhabiting a place, eg Ankara-&gt;Ankariotes, Bulgaria-&gt;Bulgarians}}
-| rdfs:domain = PopulatedPlace
-| rdfs:range = rdf:langString
-}}</text></revision></page><page><title>OntologyProperty:PeopleVaccinated</title><ns>202</ns><id>13114</id><revision><id>54888</id><timestamp>2021-07-26T03:52:37Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|People Vaccinated}}
-| comments =
-	{{comment|en|VaccinationStatistics: Number of people vaccinated.}}
-| rdfs:domain = owl:Thing
-| rdfs:range = VaccinationStatistics
-}}</text></revision></page><page><title>OntologyProperty:PeopleVaccinatedPerHundred</title><ns>202</ns><id>13118</id><revision><id>54892</id><timestamp>2021-07-26T03:59:19Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|People Vaccinated Per Hundred}}
-| comments =
-	{{comment|en|VaccinationStatistics: total vaccination percent.}}
-| rdfs:domain = owl:Thing
-| rdfs:range = VaccinationStatistics
-}}</text></revision></page><page><title>OntologyProperty:PerCapitaIncome</title><ns>202</ns><id>3268</id><revision><id>34070</id><timestamp>2014-04-04T16:26:31Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = per capita income
-| rdfs:label@de = Pro-Kopf-Einkommen
-| rdfs:label@pt = renda per capita
-| rdfs:domain = PopulatedPlace
-| rdfs:range = Currency
-}}</text></revision></page><page><title>OntologyProperty:PerCapitaIncomeAsOf</title><ns>202</ns><id>3269</id><revision><id>12124</id><timestamp>2011-04-13T13:33:27Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = per capita income as of
-| rdfs:label@pt = renda per capita em
-| rdfs:domain = PopulatedPlace
-| rdfs:range = xsd:date
-}}</text></revision></page><page><title>OntologyProperty:PerCapitaIncomeRank</title><ns>202</ns><id>7124</id><revision><id>49917</id><timestamp>2015-12-29T10:54:21Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|per capital income rank}}
-| rdfs:domain = PopulatedPlace
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Percentage</title><ns>202</ns><id>9186</id><revision><id>31918</id><timestamp>2014-02-14T18:44:37Z</timestamp><text>{{ObjectProperty
-| rdfs:label@en = percentage
-| rdfs:label@de = Prozent
-| rdfs:label@nl = percentage
-}}</text></revision></page><page><title>OntologyProperty:PercentageAlcohol</title><ns>202</ns><id>6718</id><revision><id>34071</id><timestamp>2014-04-04T16:26:35Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = percentage of alcohol
-| rdfs:label@de = Anteil von Alkohol
-| rdfs:label@nl = alcoholpercentage
-| rdfs:comment@en = percentage of alcohol present in a beverage
-| rdfs:domain = Beverage
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:PercentageFat</title><ns>202</ns><id>6738</id><revision><id>48758</id><timestamp>2015-08-13T10:08:38Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = percentage of fat
-| rdfs:label@de = Fettgehalt
-| rdfs:label@nl = vetgehalte
-| rdfs:comment@en = how much fat (as a percentage) does this food contain. Mostly applies to Cheese
-| rdfs:domain = Food
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:PercentageLiteracyMen</title><ns>202</ns><id>11428</id><revision><id>56907</id><timestamp>2022-03-02T19:16:41Z</timestamp><text>{{DatatypeProperty
-| labels =
-    {{label|en|percentage of a place's male population that is literate, degree of analphabetism}}
-    {{label|fr|pourcentage de la population masculine alphabétisée d'un lieu, degré d'analphabétisme}}
-    {{label|nl|percentage van de mannelijke bevolking dat geletterd is}}
-| rdfs:domain = PopulatedPlace
-| rdfs:range = xsd:float
-| rdfs:subPropertyOf = percentageLiterate
-}}</text></revision></page><page><title>OntologyProperty:PercentageLiteracyWomen</title><ns>202</ns><id>11429</id><revision><id>56908</id><timestamp>2022-03-02T19:19:59Z</timestamp><text>{{DatatypeProperty
-| labels =
-    {{label|en|percentage of a place's female population that is literate, degree of analphabetism}}
-    {{label|fr|pourcentage de la population féminine alphabétisée d'un lieu, degré d'analphabétisme}}
-    {{label|nl|percentage van de vrouwelijke bevolking dat geletterd is}}
-| rdfs:domain = PopulatedPlace
-| rdfs:range = xsd:float
-| rdfs:subProperty = percentageLiterate
-}}</text></revision></page><page><title>OntologyProperty:PercentageLiterate</title><ns>202</ns><id>11427</id><revision><id>49439</id><timestamp>2015-11-03T09:46:13Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|percentage of a place's population that is literate, degree of analphabetism}}
-{{label|nl|percentage van de bevolking dat geletterd is}}
-| rdfs:domain = PopulatedPlace
-| rdfs:range = xsd:float
-}}</text></revision></page><page><title>OntologyProperty:PercentageOfAreaWater</title><ns>202</ns><id>1271</id><revision><id>59642</id><timestamp>2024-06-04T20:16:26Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = percentage of area water
-| rdfs:label@el = ποσοστό_υδάτων
-| rdfs:label@nl = percentage wateroppervlak
-| rdfs:label@am = የውሃ አካል መቶኛ
-| rdfs:range = xsd:float
-}}</text></revision></page><page><title>OntologyProperty:Performer</title><ns>202</ns><id>6824</id><revision><id>36388</id><timestamp>2014-07-08T14:09:53Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|performer}}
-	{{label|de|Künstler}}
-| rdfs:domain = FictionalCharacter
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:Periapsis</title><ns>202</ns><id>1273</id><revision><id>35336</id><timestamp>2014-06-17T12:50:40Z</timestamp><text>{{DatatypeProperty
-| labels = 
-{{label|en|periapsis}}
-{{label|de|Periapsisdistanz}}
-| rdfs:domain = CelestialBody
-| rdfs:range = Length
-}}</text></revision></page><page><title>OntologyProperty:Perifocus</title><ns>202</ns><id>11493</id><revision><id>49919</id><timestamp>2015-12-29T11:03:50Z</timestamp><text>{{DatatypeProperty
-| labels = 
-{{label|en|perifocus}}
-{{label|nl|perifocus}}
-| rdfs:domain = CelestialBody
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Perimeter</title><ns>202</ns><id>11556</id><revision><id>50448</id><timestamp>2016-03-07T20:51:31Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|perimeter}}
-{{label|nl|omtrek}}
-| rdfs:domain = Place
-| rdfs:range = Length
-}}</text></revision></page><page><title>OntologyProperty:Period</title><ns>202</ns><id>5281</id><revision><id>53746</id><timestamp>2020-09-30T11:41:23Z</timestamp><text>{{ ObjectProperty
-| labels =
-{{label|en|event period}}
-{{label|de|Veranstaltungsdauer}}
-{{label|nl|periode}}
-{{label|fr|période}}
-| owl:equivalentProperty = ceo:heeftPeriode
-}}</text></revision></page><page><title>OntologyProperty:Perpetrator</title><ns>202</ns><id>12048</id><revision><id>52864</id><timestamp>2018-02-13T10:17:27Z</timestamp><text>{{ ObjectProperty
-| labels =
-{{label|en|perpetrator}}
-{{label|nl|dader}}
-{{label|de|Täter}}
-{{label|fr|auteur}}
-| rdfs:domain = Attack
-| rdfs:range = Agent
-}}</text></revision></page><page><title>OntologyProperty:Person</title><ns>202</ns><id>1275</id><revision><id>36389</id><timestamp>2014-07-08T14:09:57Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = person
-| rdfs:label@de = Person
-| rdfs:label@el = άτομο
-| rdfs:domain = PersonFunction
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:isRoleOf
-}}</text></revision></page><page><title>OntologyProperty:PersonFunction</title><ns>202</ns><id>922</id><revision><id>48518</id><timestamp>2015-08-05T14:38:11Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|person function}}
-	{{label|de|Amt}}
-	{{label|nl|persoon functie}}
-| rdfs:range = PersonFunction
-| rdfs:domain = Person
-| rdfs:subPropertyOf = dul:hasRole
-}}</text></revision></page><page><title>OntologyProperty:PersonName</title><ns>202</ns><id>1276</id><revision><id>56816</id><timestamp>2022-02-28T22:34:41Z</timestamp><text>{{DatatypeProperty
-| labels = 
-    {{label|en|personName}}
-    {{label|fr|nom de personne}}
-| rdfs:domain = PersonFunction
-| rdfs:range = xsd:string
-| owl:equivalentProperty=wikidata:P1448
-}}</text></revision></page><page><title>OntologyProperty:PersonsFirstDosesCumul</title><ns>202</ns><id>13130</id><revision><id>54916</id><timestamp>2021-08-12T06:36:52Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|PersonsFirstDosesCumul}}
-| comments =
-	{{comment|en|Number of persons received first vaccine doses}}
-| rdfs:range = xsd:integer
-| owl:equivalentProperty = vaccine
-| rdfs:domain = owl:Thing
-}}</text></revision></page><page><title>OntologyProperty:PersonsFullDosesCumul</title><ns>202</ns><id>13131</id><revision><id>54917</id><timestamp>2021-08-12T06:38:27Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|PersonsFullDosesCumul}}
-| comments =
-	{{comment|en|Number of persons received full vaccine doses}}
-| rdfs:range = xsd:integer
-| owl:equivalentProperty = vaccine
-| rdfs:domain = owl:Thing
-}}</text></revision></page><page><title>OntologyProperty:Pfizer</title><ns>202</ns><id>13111</id><revision><id>56979</id><timestamp>2022-03-09T10:39:48Z</timestamp><text>{{DatatypeProperty
-| labels =
-    {{label|en|Pfizer}}
-    {{label|fr|Pfizer}}
-    {{label|zh|辉瑞}}
-| comments =
-	{{comment|en|American multinational pharmaceutical corporation the COVID-19 vaccine Pfizer–BioNTech COVID-19 vaccine}}
-	{{comment|fr|Corporation pharmaceutique multinationale américaine, vaccin contre le COVID-19, vaccin Pfizer–BioNTech COVID-19}}
-	{{comment|zh|辉瑞是源自美国的跨国制药、生物技术公司，营运总部位于纽约，研发总部位于康涅狄格州的格罗顿市}}
-| rdfs:range = xsd:string
-| owl:equivalentProperty = vaccine
-| rdfs:domain = owl:Thing
-}}</text></revision></page><page><title>OntologyProperty:PfizerCumul</title><ns>202</ns><id>13125</id><revision><id>54910</id><timestamp>2021-08-12T06:12:49Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|PfizerCumulativeDoses}}
-| comments =
-	{{comment|en|American multinational pharmaceutical corporation the COVID-19 vaccine Pfizer–BioNTech COVID-19 vaccine}}
-	{{comment|en|辉瑞是源自美国的跨国制药、生物技术公司，营运总部位于纽约，研发总部位于康涅狄格州的格罗顿市}}
-
-| rdfs:range = xsd:integer
-| owl:equivalentProperty = pfizer
-| rdfs:domain = owl:Thing
-}}</text></revision></page><page><title>OntologyProperty:PgaWins</title><ns>202</ns><id>7649</id><revision><id>27318</id><timestamp>2013-07-10T11:27:55Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|pga wins}}
-| rdfs:domain = Person
-| rdfs:range = skos:Concept
-}}</text></revision></page><page><title>OntologyProperty:PhilosophicalSchool</title><ns>202</ns><id>2311</id><revision><id>36391</id><timestamp>2014-07-08T14:10:03Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = philosophicalSchool
-| rdfs:domain = Person
-| rdfs:subPropertyOf = dul:isMemberOf
-}}</text></revision></page><page><title>OntologyProperty:PhonePrefix</title><ns>202</ns><id>6849</id><revision><id>45160</id><timestamp>2015-02-11T08:52:45Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|phone prefix}}
-{{label|de|Telefonvorwahl}}
-| rdfs:comment@en = Don't use this, use areaCode
-| rdfs:domain = PopulatedPlace
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:PhonePrefixLabel</title><ns>202</ns><id>6927</id><revision><id>34850</id><timestamp>2014-05-15T05:19:54Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|phone prefix label of a settlement}}
-| rdfs:domain = Settlement
-| rdfs:range = rdf:langString
-}}</text></revision></page><page><title>OntologyProperty:Photographer</title><ns>202</ns><id>1277</id><revision><id>57273</id><timestamp>2022-03-28T22:01:08Z</timestamp><text>
-{{ObjectProperty
-| labels = 
-    {{label|en|photographer}}
-    {{label|fr|photographe}}
-    {{label|de|Fotograf}}
-| rdfs:domain = TelevisionEpisode
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:coparticipatesWith
-| owl:equivalentProperty = gnd:photographer
-}}</text></revision></page><page><title>OntologyProperty:Phylum</title><ns>202</ns><id>1278</id><revision><id>36393</id><timestamp>2014-07-08T14:10:09Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|phylum}}
-	{{label|es|filo}}
-	{{label|fr|Embranchement phylogénétique}}
-	{{label|ja|門_(分類学)}}
-| comments =
-	{{comment|en|A rank in the classification of organisms, below kingdom and above class; also called a division, especially in describing plants; a taxon at that rank.&lt;ref&gt;https://en.wiktionary.org/wiki/phylum&lt;/ref&gt;}}
-	{{comment|fr|En systématique, l'embranchement (ou phylum) est le deuxième niveau de classification classique des espèces vivantes.&lt;ref&gt;https://fr.wikipedia.org/wiki/Embranchement_%28biologie%29&lt;/ref&gt;}}
-| rdfs:domain = Species
-| rdfs:subPropertyOf = dul:isSpecializedBy
-}}
-== references ==
-&lt;references/&gt;</text></revision></page><page><title>OntologyProperty:Picture</title><ns>202</ns><id>3217</id><revision><id>57091</id><timestamp>2022-03-12T11:33:45Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|picture}}
-	{{label|el|εικόνα}}
-	{{label|nl|afbeelding}}
-	{{label|pt|figura}}
-	{{label|de|bild}}
-        {{label|ru|рисунок}}
-	{{label|fr|image}}
-| rdfs:domain = owl:Thing
-| rdfs:range = owl:Thing
-| comments =
-  {{comment|en|A picture of something or someone.}}
-  {{comment|fr|Image de quelque chose ou quelqu'un.}}
-| owl:equivalentProperty = schema:image
-| rdfs:subPropertyOf = dul:concretelyExpresses
-}}</text></revision></page><page><title>OntologyProperty:PictureDescription</title><ns>202</ns><id>5272</id><revision><id>34078</id><timestamp>2014-04-04T16:27:09Z</timestamp><text>{{ ObjectProperty
-
-	| rdfs:label@en = picture description
-| rdfs:label@de = Bildbeschreibung
-	| rdfs:domain = owl:Thing
-	| rdfs:range = owl:Thing
-
-}}</text></revision></page><page><title>OntologyProperty:PictureFormat</title><ns>202</ns><id>3055</id><revision><id>57272</id><timestamp>2022-03-28T21:59:26Z</timestamp><text>
-{{ObjectProperty
-| labels =
-    {{label|en|picture format}}
-    {{label|fr|format d'image}}
-    {{label|de|Bildformat}}
-| rdfs:domain = Broadcaster
-| rdfs:range = owl:Thing
-| rdfs:subPropertyOf = dul:hasQuality
-}}</text></revision></page><page><title>OntologyProperty:PicturesCommonsCategory</title><ns>202</ns><id>9300</id><revision><id>43332</id><timestamp>2015-02-06T15:01:18Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|pictures Commons category}}
-| rdfs:comment@en=Wikimedia CommonsCategory for pictures of this resource
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Piercing</title><ns>202</ns><id>3287</id><revision><id>34079</id><timestamp>2014-04-04T16:27:15Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = piercing   
-| rdfs:label@de = Piercing
-| rdfs:label@pt = piercing
-| rdfs:domain = Person
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:PisciculturalPopulation</title><ns>202</ns><id>7101</id><revision><id>25625</id><timestamp>2013-05-26T13:38:14Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|piscicultural population}}
-| rdfs:domain = Place
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:PistonStroke</title><ns>202</ns><id>1279</id><revision><id>8200</id><timestamp>2010-05-28T13:32:15Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = piston stroke
-| rdfs:domain = AutomobileEngine
-| rdfs:range = Length
-}}</text></revision></page><page><title>OntologyProperty:Place</title><ns>202</ns><id>1280</id><revision><id>53764</id><timestamp>2020-10-08T23:09:12Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = Relates an entity to the populated place in which it is located.
-| rdfs:domain = owl:Thing
-| rdfs:range = PopulatedPlace
-| rdfs:subPropertyOf = dul:hasLocation
-| owl:equivalentProperty = event:place
-}}</text></revision></page><page><title>OntologyProperty:PlaceOfBurial</title><ns>202</ns><id>1281</id><revision><id>47449</id><timestamp>2015-04-01T16:11:10Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|place of burial}}
-	{{label|ca|lloc d'enterrament}}
-	{{label|de|Ort der Bestattung}}
-	{{label|el|τόπος θαψίματος}}
-	{{label|nl|begraafplaats}}
-	{{label|pl|miejsce pochówku}}
-| rdfs:domain = Person
-| rdfs:range = Place
-| comments =
-	{{comment|en|The place where the person has been buried.}}
-	{{comment|el|Ο τόπος όπου το πρόσωπο έχει θαφτεί.}}
-	{{comment|nl|De plaats waar een persoon is begraven.}}
-| rdfs:subPropertyOf = dul:hasLocation
-| owl:equivalentProperty = wikidata:P119
-}}</text></revision></page><page><title>OntologyProperty:PlaceOfWorship</title><ns>202</ns><id>6479</id><revision><id>57446</id><timestamp>2022-04-17T21:30:06Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|place of worship}}
-	{{label|fr|lieu de culte}}
-	{{label|de|Kultstätte}}
-	{{label|nl|gebedsplaats}}
-| comments =
-	{{comment|en|A religious administrative body needs to know which places of worship it }}
-	{{comment|fr|Une structure administrative religieuse doit connaître ses lieux de culte }}
-	{{comment|nl|Een kerkelijke organisatie houdt bij welke gebedshuizen ze heeft}}
-| rdfs:domain = ClericalAdministrativeRegion
-| rdfs:range = ReligiousBuilding
-| rdf:type = | rdfs:subPropertyOf     = 
-| owl:equivalentProperty = 
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:Plant</title><ns>202</ns><id>1283</id><revision><id>36399</id><timestamp>2014-07-08T14:10:31Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = plant
-| rdfs:label@de = Pflanze
-| rdfs:label@el = φυτό
-| rdfs:label@ja = 植物
-| rdfs:domain = Place
-| rdfs:range = Plant
-| rdfs:subPropertyOf = dul:isLocationOf
-}}</text></revision></page><page><title>OntologyProperty:PlayRole</title><ns>202</ns><id>6803</id><revision><id>36400</id><timestamp>2014-07-08T14:10:35Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = play role
-| rdfs:domain = owl:Thing
-| rdfs:range = owl:Thing
-| rdfs:subPropertyOf = uses, dul:hasRole
-}}</text></revision></page><page><title>OntologyProperty:PlayerInTeam</title><ns>202</ns><id>4317</id><revision><id>48511</id><timestamp>2015-08-05T14:19:45Z</timestamp><text>{{ObjectProperty
-| labels =
- {{label|en|player in team}}
- {{label|de|Spieler im Team}}
- {{label|el|παίχτης σε ομάδα}}
-| rdfs:domain = SportsTeam
-| rdfs:range = Person
-| comments =
- {{comment|en|A person playing for a sports team. inverseOf team}}
- {{comment|el|Άτομο που παίζει για αθλητική ομάδα.}}
-| rdfs:subPropertyOf = dul:hasMember
-| owl:inverseOf = team
-}}</text></revision></page><page><title>OntologyProperty:PlayerSeason</title><ns>202</ns><id>7874</id><revision><id>27335</id><timestamp>2013-07-10T12:46:14Z</timestamp><text>{{ObjectProperty
-| rdfs:label@en = player season
-| rdfs:domain = Agent
-}}</text></revision></page><page><title>OntologyProperty:PlayerStatus</title><ns>202</ns><id>7790</id><revision><id>34084</id><timestamp>2014-04-04T16:27:50Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|player status}}
-{{label|de|Spielerstatus}}
-| rdfs:domain = Person
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:PlayingTime</title><ns>202</ns><id>2301</id><revision><id>34085</id><timestamp>2014-04-04T16:27:54Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|playing time}}
-{{label|de|Spielzeit}}
-{{label|nl|speeltijd}}
-| rdfs:range = Time
-}}</text></revision></page><page><title>OntologyProperty:Plays</title><ns>202</ns><id>1285</id><revision><id>22455</id><timestamp>2013-01-12T22:51:48Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|plays}}
-{{label|nl|slaghand}}
-| rdfs:domain = TennisPlayer
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Pleochroism</title><ns>202</ns><id>14432</id><revision><id>59600</id><timestamp>2024-05-21T13:55:53Z</timestamp><text>{{ObjectProperty
-| rdfs:label@en = pleochroism
-| rdfs:label@lv = pleohroisms
-| rdfs:label@de = pleochroismus
-| rdfs:label@el = πλεοχρωισμός
-| rdfs:label@fr = pléochroïsme
-| rdfs:label@ja = 色
-| rdfs:label@nl = 多色性
-| rdfs:domain = owl:Thing
-| rdfs:comment@en = Pleochroism is an optical phenomenon in which a substance has different colors when observed at different angles, especially with polarized light
-}}</text></revision></page><page><title>OntologyProperty:Pluviometry</title><ns>202</ns><id>7230</id><revision><id>34086</id><timestamp>2014-04-04T16:27:58Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|pluviometry}}
-{{label|de|Regenmessung}}
-| rdfs:domain = PopulatedPlace
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Podium</title><ns>202</ns><id>7808</id><revision><id>34087</id><timestamp>2014-04-04T16:28:03Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|podium}}
-{{label|de|Podest}}
-| rdfs:range = xsd:nonNegativeInteger
-| rdfs:domain = Person
-}}</text></revision></page><page><title>OntologyProperty:Podiums</title><ns>202</ns><id>1286</id><revision><id>34088</id><timestamp>2014-04-04T16:28:07Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = podiums
-| rdfs:label@de = Podestplätze
-| rdfs:domain = FormulaOneRacer
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:Pole</title><ns>202</ns><id>7653</id><revision><id>34089</id><timestamp>2014-04-04T16:28:12Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|pole}}
-{{label|de|Pol}}
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:PoleDriver</title><ns>202</ns><id>1287</id><revision><id>36402</id><timestamp>2014-07-08T14:10:53Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = pole driver
-| rdfs:domain = GrandPrix
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:hasParticipant
-}}</text></revision></page><page><title>OntologyProperty:PoleDriverCountry</title><ns>202</ns><id>1288</id><revision><id>36403</id><timestamp>2014-07-08T14:10:55Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = pole driver country
-| rdfs:domain = GrandPrix
-| rdfs:range = Country
-| rdfs:subPropertyOf = dul:hasParticipant
-}}</text></revision></page><page><title>OntologyProperty:PoleDriverTeam</title><ns>202</ns><id>1289</id><revision><id>36404</id><timestamp>2014-07-08T14:10:59Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = pole driver team
-| rdfs:domain = GrandPrix
-| rdfs:range = SportsTeam
-| rdfs:subPropertyOf = dul:hasParticipant
-}}</text></revision></page><page><title>OntologyProperty:PolePosition</title><ns>202</ns><id>7806</id><revision><id>34115</id><timestamp>2014-04-04T16:30:17Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|pole position}}
-| rdfs:range = xsd:nonNegativeInteger
-| rdfs:domain = Person
-}}</text></revision></page><page><title>OntologyProperty:Poles</title><ns>202</ns><id>1290</id><revision><id>34091</id><timestamp>2014-04-04T16:28:20Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = poles
-| rdfs:label@de = Pole
-| rdfs:label@fr = pôle
-| rdfs:domain = FormulaOneRacer
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:PoliceName</title><ns>202</ns><id>7298</id><revision><id>39183</id><timestamp>2015-01-11T19:04:44Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|police name}}
-| comments =
-{{comment|en|The police detachment serving a UK place, eg Wakefield -&gt; "West Yorkshire Police"}}
-| rdfs:domain = PopulatedPlace
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:PolishFilmAward</title><ns>202</ns><id>2468</id><revision><id>36405</id><timestamp>2014-07-08T14:11:02Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = Polish Film Award
-| rdfs:label@de = Polnischer Filmpreis
-| rdfs:label@pl = Polska Nagroda Filmowa (Orzeł)
-| rdfs:domain = Artist
-| rdfs:range = Award
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:PoliticGovernmentDepartment</title><ns>202</ns><id>3349</id><revision><id>36406</id><timestamp>2014-07-08T14:11:05Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = politic government department
-| rdfs:label@pt = ministerio do politico
-| rdfs:domain = PopulatedPlace
-| rdfs:subPropertyOf = Department, dul:hasPart
-}}</text></revision></page><page><title>OntologyProperty:PoliticalFunction</title><ns>202</ns><id>7887</id><revision><id>34093</id><timestamp>2014-04-04T16:28:30Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|political function}}
-{{label|de|politische Funktion}}
-| rdfs:domain = Person
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:PoliticalLeader</title><ns>202</ns><id>7896</id><revision><id>34094</id><timestamp>2014-04-04T16:28:34Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|political leader}}
-{{label|de|politischer Führer}}
-| rdfs:domain = Place
-| rdfs:range = PersonFunction
-}}</text></revision></page><page><title>OntologyProperty:PoliticalMajority</title><ns>202</ns><id>7898</id><revision><id>34095</id><timestamp>2014-04-04T16:28:50Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|political majority}}
-{{label|de|politische Mehrheit}}
-| rdfs:domain = Settlement
-| rdfs:range = PoliticalParty
-}}</text></revision></page><page><title>OntologyProperty:PoliticalPartyInLegislature</title><ns>202</ns><id>3530</id><revision><id>36407</id><timestamp>2014-07-08T14:11:08Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = political party in legislature
-| rdfs:label@de = politische Partei in der Legislative
-| rdfs:domain = Legislature
-| rdfs:range = PoliticalParty
-| rdfs:comment@en = Political party in the legislature (eg.: European People's Party in the European Parliament).
-| rdfs:subPropertyOf = dul:hasPart
-}}</text></revision></page><page><title>OntologyProperty:PoliticalPartyOfLeader</title><ns>202</ns><id>3532</id><revision><id>36408</id><timestamp>2014-07-08T14:11:11Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = political party of leader
-| rdfs:label@de = politische Partei des Vorsitzenden
-| rdfs:domain = Legislature
-| rdfs:range = PoliticalParty
-| rdfs:comment@en = The Political party of leader.
-| rdfs:subPropertyOf = dul:hasPart
-}}</text></revision></page><page><title>OntologyProperty:PoliticalSeats</title><ns>202</ns><id>7899</id><revision><id>27424</id><timestamp>2013-07-12T10:14:39Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|political seats}}
-| rdfs:domain = Settlement
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:Politician</title><ns>202</ns><id>11911</id><revision><id>52312</id><timestamp>2017-10-09T13:53:04Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|politician}}
-	{{label|de|Politiker}}
-| comments =
-	{{comment|en|The politician exercising this function.}}
-	{{comment|de|Der Politiker welcher dieses Amt hält (hielt).}}
-| rdfs:domain = PoliticalFunction
-| rdfs:range = Politician
-}}</text></revision></page><page><title>OntologyProperty:PopularVote</title><ns>202</ns><id>2507</id><revision><id>34097</id><timestamp>2014-04-04T16:28:59Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = Number of votes given to candidate
-| rdfs:label@de = Anzahl der Stimmen für Kandidaten
-| rdfs:domain = Election
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:Population</title><ns>202</ns><id>7908</id><revision><id>57115</id><timestamp>2022-03-12T21:03:18Z</timestamp><text>{{ObjectProperty 
-| labels = 
-  {{label|en|population}}
-  {{label|fr|population}}
-| comments =
-  {{comment|en|all the inhabitants of a particular place; ex: 14200}} 
-  {{comment|fr|nombre total d'habitants du lieu; ex: 14200}} 
-| rdfs:domain = PopulatedPlace 
-| rdfs:range = Population 
-| owl:equivalentProperty = gn:population
-}}</text></revision></page><page><title>OntologyProperty:PopulationAsOf</title><ns>202</ns><id>1291</id><revision><id>19893</id><timestamp>2012-11-21T17:44:12Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|population as of}}
-{{label|nl|bevolking vanaf}}
-{{label|fr|population en date de}}
-{{label|el|χρονιά_απογραφής}}
-| rdfs:domain = PopulatedPlace
-| rdfs:range = xsd:date
-}}</text></revision></page><page><title>OntologyProperty:PopulationDensity</title><ns>202</ns><id>1292</id><revision><id>51777</id><timestamp>2016-12-20T13:03:13Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|population density}}
-{{label|nl|bevolkingsdichtheid}}
-{{label|de|Bevölkerungsdichte}}
-{{label|el|πυκνότητα_πληθυσμού}}
-{{label|hi|घनत्व}}
-| rdfs:domain = PopulatedPlace
-| rdfs:range = PopulationDensity
-}}</text></revision></page><page><title>OntologyProperty:PopulationMetro</title><ns>202</ns><id>1293</id><revision><id>10415</id><timestamp>2010-11-10T14:48:10Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = population metro
-| rdfs:domain = PopulatedPlace
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:PopulationMetroDensity</title><ns>202</ns><id>1294</id><revision><id>22400</id><timestamp>2013-01-11T21:51:11Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|population metro density}}
-{{label|nl|bevolkingsdichtheid}}
-| rdfs:domain = PopulatedPlace
-| rdfs:range = PopulationDensity
-}}</text></revision></page><page><title>OntologyProperty:PopulationPctChildren</title><ns>202</ns><id>8921</id><revision><id>30740</id><timestamp>2014-01-22T11:22:17Z</timestamp><text>{{DatatypeProperty
- |rdfs:label@en=population percentage under 12 years
- |rdfs:domain = PopulatedPlace
- |rdfs:range=xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:PopulationPctMen</title><ns>202</ns><id>8919</id><revision><id>30738</id><timestamp>2014-01-22T11:20:57Z</timestamp><text>{{DatatypeProperty
- |rdfs:label@en=population percentage male
- |rdfs:domain = PopulatedPlace
- |rdfs:range=xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:PopulationPctWomen</title><ns>202</ns><id>8920</id><revision><id>30739</id><timestamp>2014-01-22T11:21:32Z</timestamp><text>{{DatatypeProperty
- |rdfs:label@en=population percentage female
- |rdfs:domain = PopulatedPlace
- |rdfs:range=xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:PopulationPlace</title><ns>202</ns><id>1295</id><revision><id>36410</id><timestamp>2014-07-08T14:11:18Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = population place
-| rdfs:domain = EthnicGroup
-| rdfs:range = PopulatedPlace
-| rdfs:comment@en = a place were members of an ethnic group are living
-| rdfs:subPropertyOf = dul:hasLocation
-}}</text></revision></page><page><title>OntologyProperty:PopulationQuote</title><ns>202</ns><id>7133</id><revision><id>25667</id><timestamp>2013-05-26T15:26:24Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|population quote}}
-| rdfs:domain = Place
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:PopulationRural</title><ns>202</ns><id>4349</id><revision><id>14615</id><timestamp>2011-07-28T12:52:10Z</timestamp><text>{{DatatypeProperty
- |rdfs:label@en=population rural
- |rdfs:domain = PopulatedPlace
- |rdfs:range=xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:PopulationRuralDensity</title><ns>202</ns><id>4350</id><revision><id>14616</id><timestamp>2011-07-28T12:52:55Z</timestamp><text>{{DatatypeProperty
- |rdfs:label@en=population density rural
- |rdfs:domain = PopulatedPlace
- |rdfs:range=PopulationDensity
-}}</text></revision></page><page><title>OntologyProperty:PopulationTotal</title><ns>202</ns><id>1296</id><revision><id>49559</id><timestamp>2015-11-22T15:02:14Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|de|Einwohnerzahl}}
-{{label|pt|população total}}
-{{label|en|population total}}
-{{label|nl|inwonersaantal}}
-{{label|fr|population totale}}
-{{label|el|συνολικός_πληθυσμός}}
-| rdfs:range = xsd:nonNegativeInteger
-| rdf:type = owl:FunctionalProperty
-| owl:equivalentProperty = wikidata:P1082
-
-}}</text></revision></page><page><title>OntologyProperty:PopulationTotalRanking</title><ns>202</ns><id>3363</id><revision><id>59643</id><timestamp>2024-06-04T20:20:15Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = total population ranking
-| rdfs:label@pt = posição no ranking do total da populacao
-| rdfs:label@am = የህዝብ ብዛት ደረጃ
-| rdfs:domain = PopulatedPlace
-| rdfs:range = xsd:positiveInteger
-}}</text></revision></page><page><title>OntologyProperty:PopulationTotalReference</title><ns>202</ns><id>3362</id><revision><id>12249</id><timestamp>2011-04-15T14:09:25Z</timestamp><text>{{ObjectProperty
-| rdfs:label@en = total population reference
-| rdfs:label@pt = referencia do total da populacao
-| rdfs:domain = Settlement
-}}</text></revision></page><page><title>OntologyProperty:PopulationUrban</title><ns>202</ns><id>1297</id><revision><id>34098</id><timestamp>2014-04-04T16:29:05Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = population urban
-| rdfs:label@de = Stadtbevölkerung
-| rdfs:domain = PopulatedPlace
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:PopulationUrbanDensity</title><ns>202</ns><id>1298</id><revision><id>8210</id><timestamp>2010-05-28T13:33:32Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = population urban density
-| rdfs:domain = PopulatedPlace
-| rdfs:range = PopulationDensity
-}}</text></revision></page><page><title>OntologyProperty:PopulationYear</title><ns>202</ns><id>6782</id><revision><id>25961</id><timestamp>2013-06-13T15:19:46Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|population year}}
-| rdfs:domain = PopulatedPlace
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Portfolio</title><ns>202</ns><id>2353</id><revision><id>34099</id><timestamp>2014-04-04T16:29:09Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = portfolio
-| rdfs:label@de = Portfolio
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Portrayer</title><ns>202</ns><id>3096</id><revision><id>36413</id><timestamp>2014-07-08T14:11:28Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = portrayer
-| rdfs:domain = FictionalCharacter
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:Position</title><ns>202</ns><id>1307</id><revision><id>53811</id><timestamp>2020-12-01T18:07:02Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|position}}
-{{label|de|Position}}
-{{label|el|Θέση}}
-{{label|nl|positie}}
-{{label|ja|ポジション}}
-| owl:equivalentProperty = schema:position, wikidata:P413
-}}</text></revision></page><page><title>OntologyProperty:PostalCode</title><ns>202</ns><id>1308</id><revision><id>53799</id><timestamp>2020-12-01T17:53:25Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|postal code}}
-{{label|nl|postcode}}
-{{label|de|Postleitzahl}}
-{{label|pt|código postal}}
-{{label|el|ταχυδρομικός κώδικας}}
-{{label|fr|code postal}}
-| rdfs:comment@en = A postal code (known in various countries as a post code, postcode, or ZIP code) is a series of letters and/or digits appended to a postal address for the purpose of sorting mail.
-| rdfs:range = xsd:string
-| rdfs:subPropertyOf = code
-| owl:equivalentProperty = ceo:postcode, bag:postcode, gn:postalCode, wikidata:P281
-}}</text></revision></page><page><title>OntologyProperty:Power</title><ns>202</ns><id>6818</id><revision><id>34101</id><timestamp>2014-04-04T16:29:16Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|power}}
-{{label|de|Macht}}
-| rdfs:domain = FictionalCharacter
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:PowerOutput</title><ns>202</ns><id>1310</id><revision><id>56829</id><timestamp>2022-03-01T00:32:45Z</timestamp><text>{{DatatypeProperty
-| labels =
-    {{label|en|power output}}
-    {{label|fr|puissance de sortie}}
-    {{label|de|Ausgangsleistung}}
-| rdfs:domain = Engine
-| rdfs:range = Power
-| rdf:type = owl:FunctionalProperty
-}}</text></revision></page><page><title>OntologyProperty:PowerType</title><ns>202</ns><id>2535</id><revision><id>36414</id><timestamp>2014-07-08T14:11:31Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = power type
-| rdfs:domain = MeanOfTransportation
-| rdfs:subPropertyOf = dul:isClassifiedBy
-}}</text></revision></page><page><title>OntologyProperty:Precursor</title><ns>202</ns><id>1311</id><revision><id>36415</id><timestamp>2014-07-08T14:11:34Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = precursor
-| rdfs:label@de = Vorläufer
-| rdfs:domain = AnatomicalStructure
-| rdfs:range = Embryology
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:Predecessor</title><ns>202</ns><id>1312</id><revision><id>36416</id><timestamp>2014-07-08T14:11:37Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|predecessor}}
-	{{label|nl|voorganger}}
-	{{label|de|Vorgänger}}
-	{{label|ja|前任者}}
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:PrefaceBy</title><ns>202</ns><id>9321</id><revision><id>34104</id><timestamp>2014-04-04T16:29:30Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|author of preface}}
-{{label|de|Autor des Vorworts}}
-{{label|nl|schrijver voorwoord}}
-| rdfs:domain = WrittenWork
-| rdfs:range = Person
-}}</text></revision></page><page><title>OntologyProperty:Prefect</title><ns>202</ns><id>6922</id><revision><id>36417</id><timestamp>2014-07-08T14:11:40Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|prefect}}
-	{{label|de|Präfekt}}
-| rdfs:domain = Politician
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:PrefectMandate</title><ns>202</ns><id>6923</id><revision><id>25388</id><timestamp>2013-05-25T10:49:26Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|mandate of a prefect of a romanian settlement}}
-| rdfs:domain = RomaniaSettlement
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Prefecture</title><ns>202</ns><id>7016</id><revision><id>36418</id><timestamp>2014-07-08T14:11:43Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|prefecture}}
-	{{label|de|Präfektur}}
-| rdfs:domain = Department
-| rdfs:range = PopulatedPlace
-| rdfs:subPropertyOf = dul:isPartOf
-}}</text></revision></page><page><title>OntologyProperty:Prefix</title><ns>202</ns><id>7227</id><revision><id>34107</id><timestamp>2014-04-04T16:29:43Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|prefix}}
-{{label|de|Präfix}}
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:PremiereDate</title><ns>202</ns><id>3822</id><revision><id>13342</id><timestamp>2011-06-06T10:12:08Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = premiere date
-| rdfs:domain = Play
-| rdfs:range = xsd:date
-| rdfs:subPropertyOf = releaseDate
-| rdfs:comment@en = Date the play was first performed.
-}}</text></revision></page><page><title>OntologyProperty:PremierePlace</title><ns>202</ns><id>3824</id><revision><id>36419</id><timestamp>2014-07-08T14:11:46Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = premiere place
-| rdfs:domain = Play
-| rdfs:range = owl:Thing
-| rdfs:comment@en = The theatre and/or city the play was first performed in.
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:PremiereYear</title><ns>202</ns><id>3823</id><revision><id>13343</id><timestamp>2011-06-06T10:13:39Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = premiere year
-| rdfs:domain = Play
-| rdfs:range = xsd:gYear
-| rdfs:subPropertyOf = releaseYear
-| rdfs:comment@en = Year the play was first performed.
-}}</text></revision></page><page><title>OntologyProperty:PresentMunicipality</title><ns>202</ns><id>9125</id><revision><id>34108</id><timestamp>2014-04-04T16:29:47Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|present municipality}}
-{{label|de|aktuelle Gemeinde}}
-{{label|nl|ligt nu in gemeente}}
-| rdfs:domain = FormerMunicipality
-| rdfs:range = Municipality
-}}</text></revision></page><page><title>OntologyProperty:PresentName</title><ns>202</ns><id>9124</id><revision><id>34109</id><timestamp>2014-04-04T16:29:52Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|a municipality's present name}}
-{{label|de|heutiger Name einer Gemeinde}}
-{{label|nl|huidige gemeentenaam}}
-| rdfs:domain = FormerMunicipality
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Presenter</title><ns>202</ns><id>1313</id><revision><id>36420</id><timestamp>2014-07-08T14:11:49Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|presenter}}
-	{{label|de|Moderator}}
-	{{label|el|παρουσιαστής}}
-| rdfs:domain = TelevisionShow
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:hasParticipant
-}}</text></revision></page><page><title>OntologyProperty:President</title><ns>202</ns><id>1314</id><revision><id>52483</id><timestamp>2017-10-16T07:28:45Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|president}}
-	{{label|de|Präsident}}
-        {{label|fr|président}}
-	{{label|nl|president}}
-	{{label|el|πρόεδρος}}
-	{{label|pt|presidente}}
-| rdfs:domain = owl:Thing
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:PresidentGeneralCouncil</title><ns>202</ns><id>7025</id><revision><id>36422</id><timestamp>2014-07-08T14:11:56Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|president general council}}
-| rdfs:domain = TermOfOffice
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:PresidentGeneralCouncilMandate</title><ns>202</ns><id>7026</id><revision><id>25519</id><timestamp>2013-05-25T20:22:11Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|mandate of the president of the general council}}
-| rdfs:domain = Place
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:PresidentRegionalCouncil</title><ns>202</ns><id>7022</id><revision><id>36423</id><timestamp>2014-07-08T14:11:59Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|president regional council}}
-| rdfs:domain = TermOfOffice
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:PresidentRegionalCouncilMandate</title><ns>202</ns><id>7023</id><revision><id>25516</id><timestamp>2013-05-25T20:20:28Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|mandate of the president council of the regional council}}
-| rdfs:domain = Place
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:PreviousDemographics</title><ns>202</ns><id>7916</id><revision><id>34190</id><timestamp>2014-04-04T16:36:02Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|previous demographics}}
-{{label|de|frühere Demografie}}
-| rdfs:domain = PopulatedPlace
-| rdfs:range = Demographics
-}}</text></revision></page><page><title>OntologyProperty:PreviousEditor</title><ns>202</ns><id>1315</id><revision><id>36424</id><timestamp>2014-07-08T14:12:01Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = previous editor
-| rdfs:label@el = πρώην συντάκτης
-| rdfs:domain = Magazine
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:PreviousEntity</title><ns>202</ns><id>7181</id><revision><id>36425</id><timestamp>2014-07-08T14:12:04Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|previous entity}}
-| rdfs:domain = Place
-| rdfs:range = Place
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:PreviousEvent</title><ns>202</ns><id>1316</id><revision><id>56899</id><timestamp>2022-03-02T18:23:54Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|previous event}}
-	{{label|de|Vorveranstaltung}}
-	{{label|nl|vorige evenement}}
-	{{label|pt|evento anterior}}
-        {{label|fr|événement précédent}}
-| rdfs:domain = Event
-| rdfs:range = Event
-| rdfs:subPropertyOf = dul:follows
-}}</text></revision></page><page><title>OntologyProperty:PreviousInfrastructure</title><ns>202</ns><id>1317</id><revision><id>36427</id><timestamp>2014-07-08T14:12:11Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|previous infrastructure}}
-	{{label|de|vorherige Infrastruktur}}
-	{{label|nl|vorige infrastructuur}}
-| rdfs:domain = Infrastructure
-| rdfs:range = Infrastructure
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:PreviousMission</title><ns>202</ns><id>1318</id><revision><id>36428</id><timestamp>2014-07-08T14:12:14Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = previous mission
-| rdfs:label@de = frührere Mission
-| rdfs:domain = SpaceMission
-| rdfs:range = SpaceMission
-| rdfs:subPropertyOf = dul:follows
-}}</text></revision></page><page><title>OntologyProperty:PreviousName</title><ns>202</ns><id>8147</id><revision><id>34116</id><timestamp>2014-04-04T16:30:17Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|previous name}}
-{{label|de|früheren Namen}}
-{{label|nl|vorige naam}}
-| rdfs:domain = PopulatedPlace
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:PreviousPopulation</title><ns>202</ns><id>7911</id><revision><id>27569</id><timestamp>2013-07-15T10:51:17Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|previous population}}
-| rdfs:domain = PopulatedPlace
-| rdfs:range = Population
-}}</text></revision></page><page><title>OntologyProperty:PreviousPopulationTotal</title><ns>202</ns><id>6972</id><revision><id>25448</id><timestamp>2013-05-25T14:45:37Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|previous population total}}
-| rdfs:domain = PopulatedPlace
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:PreviousTrackNumber</title><ns>202</ns><id>13814</id><revision><id>57064</id><timestamp>2022-03-09T19:01:41Z</timestamp><text>{{DatatypeProperty
-| labels = 
-  {{label|en|number of the previous track}}
-  {{label|fr|numéro de la piste précédente}}
-| rdfs:domain = Work
-| rdfs:range = xsd:nonNegativeInteger
-| comments = 
-  {{comment|en|number of the previous track of the recorded work.}}
-  {{comment|fr|numéro de la piste précédente du support.}}
-}}</text></revision></page><page><title>OntologyProperty:PreviousWork</title><ns>202</ns><id>1319</id><revision><id>57047</id><timestamp>2022-03-09T16:00:36Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|previous work}}
-	{{label|fr|oeuvre précédente}}
-	{{label|de|früheren Arbeiten}}
-	{{label|nl|vorig werk}}
-	{{label|el|προηγούμενη δημιουργία}}
-| rdfs:domain = Work
-| rdfs:range = Work
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:PreviousWorkDate</title><ns>202</ns><id>13812</id><revision><id>57058</id><timestamp>2022-03-09T17:14:29Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|previous work date}}
-	{{label|fr|année de sortie oeuvre précédente}}
-| rdfs:domain = Work
-| rdfs:range = year
-| comments =
- {{comment|en|Year when previous work was released}}
- {{comment|fr|Année de sortie de l'oeuvre précédente}}
-}}</text></revision></page><page><title>OntologyProperty:Price</title><ns>202</ns><id>3537</id><revision><id>48385</id><timestamp>2015-06-16T14:00:12Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = price 
-| rdfs:comment@en = The price of something, eg a journal. For "total money earned by an Athlete" use gross
-| rdfs:label@de = Preis
-| rdfs:domain = owl:Thing
-| rdfs:range = Currency
-}}</text></revision></page><page><title>OntologyProperty:PrimaryFuelType</title><ns>202</ns><id>9589</id><revision><id>35515</id><timestamp>2014-06-28T22:02:39Z</timestamp><text>{{ObjectProperty
-|rdfs:label@en = primary fuel type
-|rdfs:domain = PowerStation
-}}</text></revision></page><page><title>OntologyProperty:Primate</title><ns>202</ns><id>6163</id><revision><id>20734</id><timestamp>2012-12-23T13:00:09Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = Primite
-| rdfs:domain = ChristianDoctrine
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:PrimeMinister</title><ns>202</ns><id>2342</id><revision><id>47444</id><timestamp>2015-04-01T14:59:42Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|prime minister}}
-	{{label|nl|minister-president}}
-	{{label|de|Premierminister}}
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:sameSettingAs
-| owl:equivalentProperty = wikidata:P6
-}}</text></revision></page><page><title>OntologyProperty:Primogenitor</title><ns>202</ns><id>9290</id><revision><id>32656</id><timestamp>2014-03-13T16:20:03Z</timestamp><text>{{ObjectProperty
-|labels =
-{{label|en|primogenitor, first forebear}}
-{{label|nl|stamvader}}
-| rdfs:domain = Family
-| rdfs:range = Person
-}}</text></revision></page><page><title>OntologyProperty:Principal</title><ns>202</ns><id>1320</id><revision><id>43322</id><timestamp>2015-02-06T13:31:19Z</timestamp><text>{{ObjectProperty
-| rdfs:label@en = principal
-| rdfs:label@bg = директор (на училище)
-| rdfs:domain = EducationalInstitution
-| rdfs:range = Person
-| rdfs:comment@en = Principal of an educational institution (school)
-| rdfs:comment@bg = Директор на училище
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:PrincipalArea</title><ns>202</ns><id>2134</id><revision><id>36432</id><timestamp>2014-07-08T14:12:26Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = principal area
-| rdfs:label@de = Hauptbereich
-| rdfs:domain = PopulatedPlace
-| rdfs:range = PopulatedPlace
-| rdfs:subPropertyOf = dul:isLocationOf
-}}</text></revision></page><page><title>OntologyProperty:PrincipalEngineer</title><ns>202</ns><id>1321</id><revision><id>36433</id><timestamp>2014-07-08T14:12:29Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = principal engineer
-| rdfs:label@el = πρώτος_μηχανικός
-| rdfs:domain = Canal
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:ProTeam</title><ns>202</ns><id>7624</id><revision><id>26867</id><timestamp>2013-07-03T07:59:37Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|pro team}}
-| rdfs:range = SportsTeam
-| rdfs:domain = Athlete, CareerStation
-}}</text></revision></page><page><title>OntologyProperty:ProbowlPick</title><ns>202</ns><id>7687</id><revision><id>26959</id><timestamp>2013-07-04T09:29:31Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|pro bowl pick}}
-| rdfs:domain = Athlete
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Procedure</title><ns>202</ns><id>6600</id><revision><id>34119</id><timestamp>2014-04-04T16:30:30Z</timestamp><text>{{DatatypeProperty
-| labels                 =
-{{label|en|procedure}}
-{{label|de|Verfahren}}
-{{label|nl|procedure}}
-| comments               =
-{{comment|en|The name designating a formal collection of steps to be taken to complete the case }}
-{{comment|nl|De naam die verwijst naar de formele definitie van een verzameling stappen die in de juiste volgorde leiden tot de afronding van de zaak}}
-| rdfs:domain            = Case
-| rdfs:range             = xsd:string
-| rdf:type               =
-| rdfs:subPropertyOf     = 
-| owl:equivalentProperty = 
-}}</text></revision></page><page><title>OntologyProperty:ProducedBy</title><ns>202</ns><id>7866</id><revision><id>34120</id><timestamp>2014-04-04T16:30:33Z</timestamp><text>{{ObjectProperty
-| rdfs:label@en = produced by
-| rdfs:label@de = hergestellt durch
-| rdfs:domain = Film
-| rdfs:range = Company
-}}</text></revision></page><page><title>OntologyProperty:Producer</title><ns>202</ns><id>1322</id><revision><id>59614</id><timestamp>2024-05-31T18:13:48Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|producer}}
-	{{label|fr|producteur}}
-	{{label|nl|producent}}
-	{{label|de|Produzent}}
-	{{label|el|παραγωγός}}
-	{{label|pl|producent}}
-	{{label|ru|продюсер}}
-    {{label|am|አዘጋጅ}}
-| comments = 
-  {{comment|en|The producer of the creative work.}}
-  {{comment|fr|Producteur de l'oeuvre créative.}}
-| rdfs:domain = Work
-| rdfs:range = Agent
-| owl:equivalentProperty = schema:producer
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:Produces</title><ns>202</ns><id>6763</id><revision><id>36435</id><timestamp>2014-07-08T14:12:37Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = produces
-| rdfs:label@de = produziert
-| rdfs:domain = owl:Thing
-| rdfs:range = owl:Thing
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:Product</title><ns>202</ns><id>1323</id><revision><id>57034</id><timestamp>2022-03-09T13:56:25Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|product}}
-	{{label|fr|produit}}
-        {{label|nl|product}}
-	{{label|de|Produkt}}
-	{{label|el|προϊόν}}
-| rdfs:domain = Organisation
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:ProductShape</title><ns>202</ns><id>11448</id><revision><id>49536</id><timestamp>2015-11-15T10:38:02Z</timestamp><text>{{DatatypeProperty
-| labels =
-	{{label|en|product shape}}
-| rdfs:domain = Food
-| rdfs:range = xsd:string
-| rdfs:subPropertyOf = dul:hasQuality
-}}</text></revision></page><page><title>OntologyProperty:Production</title><ns>202</ns><id>1324</id><revision><id>34122</id><timestamp>2014-04-04T16:30:41Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = production
-| rdfs:label@de = Produktion
-| rdfs:domain = Company
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:ProductionCompany</title><ns>202</ns><id>5146</id><revision><id>59610</id><timestamp>2024-05-31T17:47:09Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|production company}}
-	{{label|de|Produktionsfirma}}
-	{{label|nl|productiebedrijf}}
-    {{label|am|አዘጋጅ ድርጅት}}
-| rdfs:domain = Work
-| rdfs:range = Company
-| rdfs:comment@en = the company that produced the work e.g. Film, MusicalWork, Software
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:ProductionEndDate</title><ns>202</ns><id>1325</id><revision><id>8222</id><timestamp>2010-05-28T13:35:11Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = production end date
-| rdfs:range = xsd:date
-}}</text></revision></page><page><title>OntologyProperty:ProductionEndYear</title><ns>202</ns><id>1326</id><revision><id>56897</id><timestamp>2022-03-02T18:20:39Z</timestamp><text>{{DatatypeProperty
-| labels =
-    {{label|en|production end year}}
-    {{label|nl|productie eindjaar}}
-    {{label|fr|dernière année de production}}
-| rdfs:range = xsd:gYear
-}}</text></revision></page><page><title>OntologyProperty:ProductionStartDate</title><ns>202</ns><id>1327</id><revision><id>34124</id><timestamp>2014-04-04T16:30:49Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = production start date
-| rdfs:label@de = Produktionsbeginn
-| rdfs:range = xsd:date
-}}</text></revision></page><page><title>OntologyProperty:ProductionStartYear</title><ns>202</ns><id>1328</id><revision><id>22181</id><timestamp>2013-01-10T21:01:12Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|production start year}}
-{{label|nl|productie beginjaar}}
-| rdfs:range = xsd:gYear
-}}</text></revision></page><page><title>OntologyProperty:ProductionYears</title><ns>202</ns><id>1329</id><revision><id>56898</id><timestamp>2022-03-02T18:22:24Z</timestamp><text>{{DatatypeProperty
-| labels = 
-    {{label|en|production years}}
-    {{label|de|Produktionsjahre}}
-    {{label|fr|années de production}}
-| rdfs:domain = Aircraft
-| rdfs:range = xsd:date
-}}</text></revision></page><page><title>OntologyProperty:Profession</title><ns>202</ns><id>1330</id><revision><id>56895</id><timestamp>2022-03-02T18:18:24Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|profession}}
-	{{label|de|Beruf}}
-        {{label|fr|profession}}
-	{{label|el|επάγγελμα}}
-	{{label|nl|beroep}}
-| rdfs:domain = Person
-| rdfs:subPropertyOf = dul:hasRole
-| owl:equivalentProperty = gnd:academicDegree
-}}</text></revision></page><page><title>OntologyProperty:ProgramCost</title><ns>202</ns><id>1331</id><revision><id>8227</id><timestamp>2010-05-28T13:35:55Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = program cost
-| rdfs:domain = Aircraft
-| rdfs:range = Currency
-}}</text></revision></page><page><title>OntologyProperty:ProgrammeFormat</title><ns>202</ns><id>3084</id><revision><id>36439</id><timestamp>2014-07-08T14:12:51Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = programme format
-| rdfs:domain = Broadcaster
-| rdfs:range = owl:Thing
-| rdfs:comment@en = The programming format describes the overall content broadcast on a radio or television station.
-| rdfs:subPropertyOf = dul:isClassifiedBy
-}}</text></revision></page><page><title>OntologyProperty:ProgrammingLanguage</title><ns>202</ns><id>1332</id><revision><id>52106</id><timestamp>2017-06-19T10:56:37Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = programming language
-| rdfs:label@da = programmeringssprog
-| rdfs:label@de = Programmiersprache
-| rdfs:label@fr = langage de programmation
-| rdfs:domain = Software
-| rdfs:subPropertyOf = dul:isExpressedBy
-}}</text></revision></page><page><title>OntologyProperty:Project</title><ns>202</ns><id>7543</id><revision><id>59223</id><timestamp>2023-02-09T10:41:56Z</timestamp><text>{{ObjectProperty
-| labels =
-    {{label|en|project}}
-    {{label|de|Projekt}}
-    {{label|fr|projet}}
-| rdfs:domain = Person
-| rdfs:range = Project
-| owl:equivalentProperty = foaf:currentProject
-}}</text></revision></page><page><title>OntologyProperty:ProjectBudgetFunding</title><ns>202</ns><id>3049</id><revision><id>11412</id><timestamp>2011-03-31T12:11:42Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = project budget funding
-| rdfs:domain = ResearchProject
-| rdfs:range = Currency
-| rdfs:comment@en = The part of the project budget that is funded by the Organistaions given in the "FundedBy" property.
-}}</text></revision></page><page><title>OntologyProperty:ProjectBudgetTotal</title><ns>202</ns><id>3048</id><revision><id>34129</id><timestamp>2014-04-04T16:31:10Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = project budget total
-| rdfs:label@de = Gesamtprojektbudget
-| rdfs:domain = ResearchProject
-| rdfs:range = Currency
-| rdfs:comment@en = The total budget of the research project.
-}}</text></revision></page><page><title>OntologyProperty:ProjectCoordinator</title><ns>202</ns><id>3046</id><revision><id>56805</id><timestamp>2022-02-28T22:07:23Z</timestamp><text>
-{{ObjectProperty
-| labels = 
-    {{label|en|project coordinator}}
-    {{label|de|Projektkoordinator}}
-    {{label|fr|régisseur}}
-| rdfs:domain = ResearchProject
-| rdfs:range = Organisation
-| comments =
-    {{comment|en|The coordinating organisation of the project.}}
-    {{comment|fr|Organisation coordinatrice du project.}}
-| rdfs:subPropertyOf = dul:isSettingFor
-}}</text></revision></page><page><title>OntologyProperty:ProjectEndDate</title><ns>202</ns><id>3037</id><revision><id>34131</id><timestamp>2014-04-04T16:31:18Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = project end date
-| rdfs:label@de = Projektende
-| rdfs:domain = Project
-| rdfs:range = xsd:date
-| rdfs:comment@en = The end date of the project.
-}}</text></revision></page><page><title>OntologyProperty:ProjectKeyword</title><ns>202</ns><id>3041</id><revision><id>11383</id><timestamp>2011-03-31T10:41:47Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = project keyword
-| rdfs:domain = Project
-| rdfs:range = xsd:string
-| rdfs:comment@en = A key word of the project.
-}}</text></revision></page><page><title>OntologyProperty:ProjectObjective</title><ns>202</ns><id>3039</id><revision><id>11380</id><timestamp>2011-03-31T10:34:32Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = project objective
-| rdfs:label@de = Projektziel
-| rdfs:domain = Project
-| rdfs:range = xsd:string
-| rdfs:comment@en = A defined objective of the project.
-}}</text></revision></page><page><title>OntologyProperty:ProjectParticipant</title><ns>202</ns><id>3047</id><revision><id>36442</id><timestamp>2014-07-08T14:13:03Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = project participant
-| rdfs:label@de = Projektteilnehmer
-| rdfs:domain = ResearchProject
-| rdfs:range = Organisation
-| rdfs:comment@en = A participating organisation of the project.
-| rdfs:subPropertyOf = dul:isSettingFor
-}}</text></revision></page><page><title>OntologyProperty:ProjectReferenceID</title><ns>202</ns><id>3044</id><revision><id>11391</id><timestamp>2011-03-31T10:53:31Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = project reference ID
-| rdfs:domain = ResearchProject
-| rdfs:range = xsd:string
-| rdfs:comment@en = The reference identification of the project.
-}}</text></revision></page><page><title>OntologyProperty:ProjectStartDate</title><ns>202</ns><id>3038</id><revision><id>34133</id><timestamp>2014-04-04T16:31:28Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = project start date
-| rdfs:label@de = Projektstart
-| rdfs:domain = Project
-| rdfs:range = xsd:date
-| rdfs:comment@en = The start date of the project.
-}}</text></revision></page><page><title>OntologyProperty:ProjectType</title><ns>202</ns><id>3043</id><revision><id>34134</id><timestamp>2014-04-04T16:31:33Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = project type
-| rdfs:label@de = Projekttyp
-| rdfs:domain = ResearchProject
-| rdfs:range = xsd:string
-| rdfs:comment@en = The type of the research project. Mostly used for the funding schemes of the European Union, for instance: Specific Targeted Research Projects (STREP), Network of Excellence (NoE) or Integrated Project.
-}}</text></revision></page><page><title>OntologyProperty:Prominence</title><ns>202</ns><id>1333</id><revision><id>34271</id><timestamp>2014-04-04T16:52:11Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = prominence
-| rdfs:range = Length
-}}</text></revision></page><page><title>OntologyProperty:Promotion</title><ns>202</ns><id>1334</id><revision><id>36443</id><timestamp>2014-07-08T14:13:07Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = promotion
-| rdfs:label@de = Förderung
-| rdfs:domain = WrestlingEvent
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:Pronunciation</title><ns>202</ns><id>7112</id><revision><id>58797</id><timestamp>2022-05-31T15:32:13Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|pronunciation}}
-{{label|de|Aussprache}}
-| rdfs:range = xsd:string
-| owl:equivalentProperty = wikidata:P443
-}}</text></revision></page><page><title>OntologyProperty:ProspectLeague</title><ns>202</ns><id>1335</id><revision><id>27081</id><timestamp>2013-07-05T13:06:02Z</timestamp><text>{{ObjectProperty
-| rdfs:label@en = prospect league
-| rdfs:domain = IceHockeyPlayer
-| rdfs:range = SportsLeague
-}}</text></revision></page><page><title>OntologyProperty:ProspectTeam</title><ns>202</ns><id>1336</id><revision><id>36444</id><timestamp>2014-07-08T14:13:10Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = prospect team
-| rdfs:domain = IceHockeyPlayer
-| rdfs:range = HockeyTeam
-| rdfs:subPropertyOf = dul:isMemberOf
-}}</text></revision></page><page><title>OntologyProperty:ProtectionStatus</title><ns>202</ns><id>6262</id><revision><id>32506</id><timestamp>2014-03-10T13:11:24Z</timestamp><text>{{DatatypeProperty
-| labels                 =
-{{label|en|monument protection status}}
-{{label|nl|monumentStatus}}
-| comments               =
-{{comment|en|The sort of status that is granted to a protected Building or Monument. This is not about being protected or not, this is about the nature of the protection regime. E.g., in the Netherlands the protection status 'rijksmonument' points to more elaborate protection than other statuses. }}
-{{comment|nl|Aanduiding van het soort beschermingsregime. Bijv. 'rijksmonument' in Nederland of 'Monument Historique' in Belgie of Frankrijk}}
-| rdfs:domain            = Place
-| rdfs:range             = xsd:string
-| rdf:type               =
-| rdfs:subPropertyOf     = Status
-| owl:equivalentProperty = 
-}}</text></revision></page><page><title>OntologyProperty:Protein</title><ns>202</ns><id>11303</id><revision><id>48761</id><timestamp>2015-08-13T10:14:15Z</timestamp><text>{{DatatypeProperty
-| labels = 
-{{label|en|protein}}
-| rdfs:domain = Food
-| rdfs:range = Mass
-| comments =
-{{comment|en|Amount of proteins per servingSize of a Food}}
-}}</text></revision></page><page><title>OntologyProperty:ProtestantPercentage</title><ns>202</ns><id>7312</id><revision><id>26061</id><timestamp>2013-06-14T11:47:52Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|protestant percentage}}
-| rdfs:domain = PopulatedPlace
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Prov:qualifiedRevision</title><ns>202</ns><id>14277</id><revision><id>59111</id><timestamp>2022-12-01T14:42:45Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en| qualified Revision}}
-{{label|fr|est dérivé de}}
-| comments        = 
-{{comment|fr|http://www.w3.org/ns/prov#qualifiedRevision}}
-{{comment|en|http://www.w3.org/ns/prov#qualifiedRevision}}
-| rdfs:domain = Prov:Entity
-| rdfs:range = Prov:Revision
-}}</text></revision></page><page><title>OntologyProperty:Prov:wasRevisionOf</title><ns>202</ns><id>14278</id><revision><id>59116</id><timestamp>2022-12-01T15:28:50Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|was revision of }}
-{{label|en| était la révision de }}
-| comments =
-{{comment|en|http://www.w3.org/ns/prov#wasRevisionOf}}
-| rdfs:domain = prov:Revision
-| rdfs:range = prov:Revision
-}}</text></revision></page><page><title>OntologyProperty:ProvCode</title><ns>202</ns><id>7922</id><revision><id>27665</id><timestamp>2013-07-15T14:48:21Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|prove code}}
-|rdfs:domain=Settlement
-|rdfs:range=xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Provides</title><ns>202</ns><id>6802</id><revision><id>36445</id><timestamp>2014-07-08T14:13:13Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = provides
-| rdfs:label@de = bietet
-| rdfs:domain = owl:Thing
-| rdfs:range = owl:Thing
-| rdfs:subPropertyOf = dul:hasCommonBoundary
-}}</text></revision></page><page><title>OntologyProperty:Province</title><ns>202</ns><id>1337</id><revision><id>53703</id><timestamp>2020-09-04T15:30:46Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|province}}
-	{{label|de|Provinz}}
-	{{label|el|επαρχία}}
-	{{label|nl|provincie}}
-| rdfs:domain = Place
-| rdfs:range = Province
-| owl:equivalentProperty = wikidata:P131, ceo:heeftProvincie
-| rdfs:subPropertyOf = dul:isPartOf
-}}</text></revision></page><page><title>OntologyProperty:ProvinceIsoCode</title><ns>202</ns><id>6882</id><revision><id>53704</id><timestamp>2020-09-04T15:32:36Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|iso code of a province}}
-| rdfs:subPropertyOf = isoCode
-| rdfs:domain = PopulatedPlace
-| rdfs:range = xsd:string
-| owl:equivalentProperty = ceo:provincieCode
-}}</text></revision></page><page><title>OntologyProperty:ProvinceLink</title><ns>202</ns><id>7078</id><revision><id>36447</id><timestamp>2014-07-08T14:13:20Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|province link}}
-| rdfs:domain = Place
-| rdfs:range = Province
-| rdfs:subPropertyOf = dul:isPartOf
-}}</text></revision></page><page><title>OntologyProperty:Provost</title><ns>202</ns><id>1338</id><revision><id>36448</id><timestamp>2014-07-08T14:13:23Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = provost
-| rdfs:domain = University
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:Pseudonym</title><ns>202</ns><id>1339</id><revision><id>58779</id><timestamp>2022-05-31T13:57:07Z</timestamp><text>{{DatatypeProperty
-| labels =
-    {{label|en|pseudonym}}
-    {{label|nl|pseudoniem}}
-    {{label|de|Pseudonym}}
-    {{label|fr|pseudonyme}}
-| rdfs:domain = Person
-| rdfs:range = rdf:langString
-| owl:equivalentProperty = wikidata:P742
-}}</text></revision></page><page><title>OntologyProperty:Pubchem</title><ns>202</ns><id>1340</id><revision><id>38857</id><timestamp>2014-12-08T21:47:57Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = PubChem
-| rdfs:label@fr = PubChem
-| rdfs:label@ja = PubChem
-| rdfs:domain = ChemicalSubstance
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Publication</title><ns>202</ns><id>7956</id><revision><id>56775</id><timestamp>2022-02-28T18:31:41Z</timestamp><text>{{DatatypeProperty
-| labels =
-    {{label|en|publication}}
-    {{label|de|Veröffentlichung}}
-    {{label|fr|publication}}
-| rdfs:domain = Person
-| rdfs:range = xsd:string
-| owl:equivalentProperty = schema:publication, gnd:publication
-}}</text></revision></page><page><title>OntologyProperty:PublicationDate</title><ns>202</ns><id>1342</id><revision><id>53753</id><timestamp>2020-09-30T12:16:16Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|publication date}}
-{{label|de|Veröffentlichungsdatum}}
-{{label|nl|publicatiedatum}}
-| rdfs:range = xsd:date
-| owl:equivalentProperty = dblp2:yearOfPublication
-}}</text></revision></page><page><title>OntologyProperty:PubliclyAccessible</title><ns>202</ns><id>1341</id><revision><id>34143</id><timestamp>2014-04-04T16:32:11Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = publicly accessible
-| rdfs:label@de = öffentlich zugänglich
-| rdfs:comment@en = describes in what way this site is accessible for public
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Publisher</title><ns>202</ns><id>1343</id><revision><id>57050</id><timestamp>2022-03-09T16:09:48Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|publisher}}
-	{{label|fr|éditeur}}
-	{{label|nl|uitgever}}
-	{{label|de|Herausgeber}}
-	{{label|el|εκδότης}}
-| comments =
-  {{comment|en|Publisher of a work. For literal (string) use dc:publisher; for object (URL) use publisher}}
-  {{comment|fr|Editeur d'une oeuvre. Pour le littéral (string) utilisez dc:publisher; pour l'objet (URL) utilisez l'éditeur}}
-| rdfs:domain = Work
-| rdfs:range = Agent
-| owl:equivalentProperty = schema:publisher, dblp2:publishedBy
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:PurchasingPowerParity</title><ns>202</ns><id>7353</id><revision><id>26196</id><timestamp>2013-06-18T11:57:31Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|purchasing power parity}}
-| rdfs:domain = PopulatedPlace
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:PurchasingPowerParityRank</title><ns>202</ns><id>7354</id><revision><id>26198</id><timestamp>2013-06-18T12:02:19Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|purchasing power parity rank}}
-| rdfs:domain = PopulatedPlace
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:PurchasingPowerParityYear</title><ns>202</ns><id>7355</id><revision><id>26199</id><timestamp>2013-06-18T12:03:09Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|purchasing power parity year}}
-| rdfs:domain = PopulatedPlace
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Purpose</title><ns>202</ns><id>1344</id><revision><id>34144</id><timestamp>2014-04-04T16:32:14Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|purpose}}
-{{label|de|Zweck}}
-{{label|nl|doel}}
-{{label|fr|objectif}}
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:QatarClassic</title><ns>202</ns><id>8052</id><revision><id>28207</id><timestamp>2013-09-03T18:50:05Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|qatar classic}}
-| rdfs:domain = Athlete
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:QuebecerTitle</title><ns>202</ns><id>7616</id><revision><id>26853</id><timestamp>2013-07-02T13:37:07Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|quebecer title}}
-| rdfs:domain = Film
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Quotation</title><ns>202</ns><id>6416</id><revision><id>34145</id><timestamp>2014-04-04T16:32:19Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|quotation}}
-{{label|de|Zitat}}
-{{label|fr|citation}}
-{{label|es|cita}}
-| comments = 
-{{comment|en|A quotation is the repetition of one expression as part of another one, particularly when the quoted expression is well-known or explicitly attributed by citation to its original source.&lt;ref&gt;http://en.wikipedia.org/wiki/Quotation&lt;/ref&gt;}}
-{{comment|fr|Une citation est la reproduction d'un court extrait d'un propos ou d'un écrit antérieur dans la rédaction d'un texte ou dans une forme d'expression orale.&lt;ref&gt;http://fr.wikipedia.org/wiki/Citation_%28litt%C3%A9rature%29&lt;/ref&gt;}}
-{{comment|es|En su acepción más amplia, una cita es un recurso retórico que consiste en reproducir un fragmento de una expresión humana respetando su formulación original.&lt;ref&gt;http://es.wikipedia.org/wiki/Cita&lt;/ref&gt;}}
-| rdfs:domain = owl:Thing
-| rdfs:range = xsd:string
-}}
-
-== References ==
-&lt;references/&gt;</text></revision></page><page><title>OntologyProperty:Quote</title><ns>202</ns><id>7207</id><revision><id>34270</id><timestamp>2014-04-04T16:51:36Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|quote}}
-| rdfs:domain = Place
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Ra</title><ns>202</ns><id>6144</id><revision><id>46219</id><timestamp>2015-03-18T11:04:22Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = ra
-| rdfs:domain = Openswarm
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Race</title><ns>202</ns><id>6168</id><revision><id>36450</id><timestamp>2014-07-08T14:13:29Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|race}}
-	{{label|de|Rennen}}
-| rdfs:range = Race
-| rdfs:subPropertyOf = dul:isParticipantIn
-}}</text></revision></page><page><title>OntologyProperty:RaceHorse</title><ns>202</ns><id>6170</id><revision><id>52647</id><timestamp>2017-11-03T16:23:20Z</timestamp><text>{{ObjectProperty
-| labels =
-  {{label|en|race horse}}
-  {{label|de|Rennpferd}}
-| rdfs:range = Horse
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:RaceLength</title><ns>202</ns><id>5335</id><revision><id>34149</id><timestamp>2014-04-04T16:32:36Z</timestamp><text>{{ DatatypeProperty
-
-	| rdfs:label@en = race length
-| rdfs:label@de = Rennlänge
-	| rdfs:domain = FormulaOneRacing
-	| rdfs:range = Length
-&lt;!--	| rdf:type = owl:FunctionalProperty --&gt;
-
-}}</text></revision></page><page><title>OntologyProperty:RaceResult</title><ns>202</ns><id>11626</id><revision><id>50969</id><timestamp>2016-04-26T15:01:38Z</timestamp><text>{{ObjectProperty
-| rdfs:label@en = race result
-| rdfs:domain = Race
-| rdfs:range = SportCompetitionResult
-| rdfs:comment@en = Result of one racer in a sport competition
-}}</text></revision></page><page><title>OntologyProperty:RaceTrack</title><ns>202</ns><id>5952</id><revision><id>36452</id><timestamp>2014-07-08T14:13:35Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|race track}}
-	{{label|de|Rennstrecke}}
-	{{label|fr|circuit}}
-| rdfs:domain = SportsEvent
-| rdfs:range = RaceTrack
-| rdfs:subPropertyOf = dul:hasPart
-}}</text></revision></page><page><title>OntologyProperty:RaceWins</title><ns>202</ns><id>7809</id><revision><id>34151</id><timestamp>2014-04-04T16:32:45Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|race wins}}
-{{label|de|Siege}}
-| rdfs:range = xsd:nonNegativeInteger
-| rdfs:domain = Person
-}}</text></revision></page><page><title>OntologyProperty:Races</title><ns>202</ns><id>1345</id><revision><id>34152</id><timestamp>2014-04-04T16:32:50Z</timestamp><text>{{DatatypeProperty
-| labels = 
-{{label|en|races}}
-{{label|de|Rennen}}
-{{label|el|αγώνας}}
-
-| rdfs:domain = FormulaOneRacer
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:RacketCatching</title><ns>202</ns><id>7708</id><revision><id>50081</id><timestamp>2016-01-04T12:44:17Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|racket catching}}
-| rdfs:domain = TennisPlayer
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Radio</title><ns>202</ns><id>7703</id><revision><id>57275</id><timestamp>2022-03-28T22:03:45Z</timestamp><text>{{ObjectProperty
-| labels =
-   {{label|en|radio}}
-   {{label|fr|radio}}
-   {{label|de|Radio}}
-   {{label|el|ραδιόφωνο}}
-| comments =
-   {{comment|el|To ραδιόφωνο είναι η συσκευή που λειτουργεί ως "ραδιοδέκτης - μετατροπέας" όπου λαμβάνοντας τις ραδιοφωνικές εκπομπές των ραδιοφωνικών σταθμών τις μετατρέπει σε ήχο.}}
-| rdfs:domain = Person
-| rdfs:range = RadioStation
-}}</text></revision></page><page><title>OntologyProperty:RadioStation</title><ns>202</ns><id>11145</id><revision><id>57274</id><timestamp>2022-03-28T22:02:50Z</timestamp><text>{{DatatypeProperty
-| labels =
-    {{label|en|radio station}}
-    {{label|fr|station de radio}}
-    {{label|nl|radiozender}}
-| rdfs:domain = RadioStation
-| rdfs:range =  xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Radius ly</title><ns>202</ns><id>6152</id><revision><id>20716</id><timestamp>2012-12-23T12:32:30Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = Radius_ly
-| rdfs:domain = Globularswarm
-| rdfs:range = xsd:integer
-}}</text></revision></page><page><title>OntologyProperty:RailGauge</title><ns>202</ns><id>3593</id><revision><id>12804</id><timestamp>2011-05-16T15:48:39Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = rail gauge
-| rdfs:label@de = Spurweite Eisenbahn
-| rdfs:domain = RouteOfTransportation
-| rdfs:range = Length
-| rdfs:comment@en = Track gauge or rail gauge is the distance between the inner sides of the heads of the two load bearing rails that make up a single railway line (http://en.wikipedia.org/wiki/Track_gauge).
-}}</text></revision></page><page><title>OntologyProperty:RailwayLineUsingTunnel</title><ns>202</ns><id>3431</id><revision><id>36453</id><timestamp>2014-07-08T14:13:39Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = railway line using tunnel
-| rdfs:label@de = Tunnel benutzende Eisenbahnlinie
-| rdfs:domain = RailwayTunnel
-| rdfs:range = owl:Thing
-| rdfs:comment@en = Railway line that is using the tunnel.
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:RailwayPlatforms</title><ns>202</ns><id>2122</id><revision><id>34154</id><timestamp>2014-04-04T16:32:58Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|railway platforms}}
-{{label|de|Bahnsteige}}
-{{label|nl|perrons}}
-{{label|el|αποβάθρα}}
-| rdfs:domain= Station
-| rdfs:range = xsd:string
-| rdfs:comment@en = Information on the type of platform(s) at the station.
-}}</text></revision></page><page><title>OntologyProperty:RailwayRollingStock</title><ns>202</ns><id>3613</id><revision><id>36454</id><timestamp>2014-07-08T14:13:42Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = railway rolling stock
-| rdfs:label@de = Operierende Schienenfahrzeuge
-| rdfs:domain = RouteOfTransportation
-| rdfs:range = owl:Thing
-| rdfs:comment@en = Types of rolling stock used on the rail line (http://en.wikipedia.org/wiki/Template:Infobox_rail_line). Stock of engins and vehicles that run on the railway (International Union of Railways - www.uic.org/IMG/doc/listealph_en.doc).
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:Range</title><ns>202</ns><id>1346</id><revision><id>52600</id><timestamp>2017-10-31T10:39:10Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|range}}
-{{label|nl|bereik}}
-| rdfs:domain = MeanOfTransportation
-| rdfs:comment@en = Maximum distance without refueling
-| rdfs:range = xsd:positiveInteger
-}}</text></revision></page><page><title>OntologyProperty:Rank</title><ns>202</ns><id>6421</id><revision><id>59632</id><timestamp>2024-06-04T10:11:47Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|rank}}
-{{label|fr|rang}}
-{{label|de|Platzierung}}
-{{label|am|ደረጃ}}
-| comments =
-  {{comment|en|Rank of something among other things of the same kind, eg Constellations by Area; MusicalAlbums by popularity, etc}}
-  {{comment|fr|Rang d'un élément parmi d'autres éléments du même type, par ex. les constellations par zone; les albums de musique par popularité, etc...}}
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:RankAgreement</title><ns>202</ns><id>7043</id><revision><id>25542</id><timestamp>2013-05-25T22:56:05Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|rank of an agreement}}
-| rdfs:domain = Place
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:RankArea</title><ns>202</ns><id>7037</id><revision><id>25535</id><timestamp>2013-05-25T22:50:19Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|rank of an area}}
-| rdfs:domain = PopulatedPlace
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:RankInFinalMedalCount</title><ns>202</ns><id>1347</id><revision><id>10419</id><timestamp>2010-11-10T14:48:50Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = rank in final medal count
-| rdfs:domain = OlympicResult
-| rdfs:range = xsd:positiveInteger
-}}</text></revision></page><page><title>OntologyProperty:RankPopulation</title><ns>202</ns><id>7041</id><revision><id>25540</id><timestamp>2013-05-25T22:54:16Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|rank of a population}}
-| rdfs:domain = PopulatedPlace
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:Ranking</title><ns>202</ns><id>1348</id><revision><id>56817</id><timestamp>2022-02-28T22:38:00Z</timestamp><text>{{DatatypeProperty
-| labels =
-    {{label|en|ranking}}
-    {{label|fr|classement}}
-    {{label|de|Rangliste}}
-| rdfs:domain = Organisation
-| rdfs:range = xsd:positiveInteger
-}}</text></revision></page><page><title>OntologyProperty:RankingWins</title><ns>202</ns><id>3540</id><revision><id>12674</id><timestamp>2011-05-07T13:48:35Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = ranking wins
-| rdfs:label@de = Siege in Ranglistenturnieren
-| rdfs:domain = SnookerPlayer
-| rdfs:range = xsd:nonNegativeInteger
-| rdfs:subPropertyOf = Wins
-}}</text></revision></page><page><title>OntologyProperty:RankingsDoubles</title><ns>202</ns><id>5657</id><revision><id>34156</id><timestamp>2014-04-04T16:33:07Z</timestamp><text>{{ DatatypeProperty
-
-	| rdfs:label@en = doubles rankings
-| rdfs:label@de = Doppelrangliste
-	| rdfs:domain = TennisPlayer
-	| rdfs:range = xsd:nonNegativeInteger
-
-}}</text></revision></page><page><title>OntologyProperty:RankingsSingles</title><ns>202</ns><id>5656</id><revision><id>34157</id><timestamp>2014-04-04T16:33:12Z</timestamp><text>{{ DatatypeProperty
-
-	| rdfs:label@en = single rankings
-| rdfs:label@de = Einzelrangliste
-	| rdfs:domain = TennisPlayer
-	| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:Rating</title><ns>202</ns><id>2527</id><revision><id>34158</id><timestamp>2014-04-04T16:33:15Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|rating}}
-{{label|de|Wertung}}
-{{label|nl|cijfer}}
-| rdfs:domain = owl:Thing
-| rdfs:range = xsd:float
-}}</text></revision></page><page><title>OntologyProperty:Ratio</title><ns>202</ns><id>1349</id><revision><id>34269</id><timestamp>2014-04-04T16:50:05Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = ratio
-| rdfs:domain = School
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Rdfs:seeAlso</title><ns>202</ns><id>10471</id><revision><id>56861</id><timestamp>2022-03-01T20:17:20Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|is used to indicate a resource that might provide additional information about the subject resource}}
-	{{label|fr|utilisé pour indiquer une ressource pouvant fournir des informations supplémentaires concernant la ressource sujet}}
-}}</text></revision></page><page><title>OntologyProperty:Rdfs:subClassOf</title><ns>202</ns><id>11208</id><revision><id>56862</id><timestamp>2022-03-01T20:19:19Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|subclass of}}
-	{{label|fr|sous-classe de}}
-
-}}</text></revision></page><page><title>OntologyProperty:RebuildDate</title><ns>202</ns><id>2549</id><revision><id>22346</id><timestamp>2013-01-11T20:28:04Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|rebuild date}}
-{{label|nl|herbouw datum}}
- |rdfs:range=xsd:date
-}}</text></revision></page><page><title>OntologyProperty:Rebuilder</title><ns>202</ns><id>2550</id><revision><id>36455</id><timestamp>2014-07-08T14:13:44Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = rebuilder
-| rdfs:domain = MeanOfTransportation
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:RebuildingDate</title><ns>202</ns><id>1350</id><revision><id>12339</id><timestamp>2011-04-20T15:56:16Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = rebuilding date
-| rdfs:domain = ArchitecturalStructure
-| rdfs:range = xsd:date
-}}</text></revision></page><page><title>OntologyProperty:RebuildingYear</title><ns>202</ns><id>3385</id><revision><id>19940</id><timestamp>2012-11-22T12:29:27Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|rebuilding year}}
-{{label|nl|herbouw jaar}}
-| rdfs:domain = ArchitecturalStructure
-| rdfs:range = xsd:gYear
-}}</text></revision></page><page><title>OntologyProperty:RecentWinner</title><ns>202</ns><id>1351</id><revision><id>36456</id><timestamp>2014-07-08T14:13:48Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = recent winner
-| rdfs:label@de = letzter Gewinner
-| rdfs:domain = Race
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:hasParticipant
-}}</text></revision></page><page><title>OntologyProperty:RecommissioningDate</title><ns>202</ns><id>3106</id><revision><id>11651</id><timestamp>2011-04-02T10:56:48Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en=recommissioning date
-| rdfs:domain = Ship
-| rdfs:range = xsd:date
-}}</text></revision></page><page><title>OntologyProperty:RecordDate</title><ns>202</ns><id>1352</id><revision><id>57045</id><timestamp>2022-03-09T15:53:50Z</timestamp><text>{{DatatypeProperty
-| labels =
-  {{label|en|record date}}
-  {{label|fr|date d'enregistrement}}
-  {{label|de|Stichtag}}
-  {{label|nl|opname datum}}
-  {{label|el|ηχογράφηση}}
-| rdfs:domain = MusicalWork
-| rdfs:range = xsd:date
-| owl:equivalentProperty = ceo:registratiedatum
-}}</text></revision></page><page><title>OntologyProperty:RecordLabel</title><ns>202</ns><id>1011</id><revision><id>36457</id><timestamp>2014-07-08T14:14:04Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|record label}}
-	{{label|es|compañía discográfica}}
-	{{label|fr|label discographique}}
-	{{label|nl|platenlabel}}
-	{{label|el|δισκογραφική}}
-| rdfs:range = RecordLabel
-| owl:equivalentProperty = wikidata:P264
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:RecordedIn</title><ns>202</ns><id>1353</id><revision><id>36458</id><timestamp>2014-07-08T14:14:07Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|recorded in}}
-	{{label|nl|opgenomen in}}
-	{{label|el|ηχογράφηση}}
-	{{label|fr|enregistré à}}
-| rdfs:domain = MusicalWork
-| rdfs:range = PopulatedPlace
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:RecoveryCases</title><ns>202</ns><id>12300</id><revision><id>53612</id><timestamp>2020-04-10T06:25:30Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|Recovery Cases}}
-| rdfs:comment@en = Number of recovered cases in a pandemic
-| rdfs:domain = Outbreak
-| rdfs:range = xsd:integer
-}}</text></revision></page><page><title>OntologyProperty:Rector</title><ns>202</ns><id>1354</id><revision><id>36459</id><timestamp>2014-07-08T14:14:10Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = rector
-| rdfs:label@de = Rektor
-| rdfs:domain = EducationalInstitution
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:RedListIdNL</title><ns>202</ns><id>10385</id><revision><id>39209</id><timestamp>2015-01-12T20:58:20Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|red list ID NL}}
-{{label|nl|rode lijst ID NL}}
-| rdfs:domain = Species
-| rdfs:range = xsd:integer
-| comments = 
-{{comment|en|red list code for treatened species NL (different from IUCN)}}
-{{comment|nl|rode lijst ID van bedreigde soorten in Nederland}}
-}}</text></revision></page><page><title>OntologyProperty:RedLongDistancePisteNumber</title><ns>202</ns><id>7201</id><revision><id>25751</id><timestamp>2013-06-01T13:24:47Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|red long distance piste number}}
-| rdfs:domain = Place
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:RedSkiPisteNumber</title><ns>202</ns><id>7194</id><revision><id>25744</id><timestamp>2013-06-01T13:21:26Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|red ski piste number}}
-| rdfs:domain = Place
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:Redline</title><ns>202</ns><id>1355</id><revision><id>10429</id><timestamp>2010-11-10T14:54:43Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = redline
-| rdfs:domain = AutomobileEngine
-| rdfs:range = Speed
-| rdf:type = owl:FunctionalProperty
-}}</text></revision></page><page><title>OntologyProperty:Refcul</title><ns>202</ns><id>6986</id><revision><id>25469</id><timestamp>2013-05-25T16:06:35Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|reference for cultural data}}
-| rdfs:range = xsd:string
-| rdfs:domain = Place
-}}</text></revision></page><page><title>OntologyProperty:Reference</title><ns>202</ns><id>7081</id><revision><id>49097</id><timestamp>2015-10-10T16:05:30Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|reference}}
-{{label|de|Referenz}}
-| rdfs:comment@en = Structured reference providing info about the subject
-| rdfs:domain = Reference
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:ReffBourgmestre</title><ns>202</ns><id>7897</id><revision><id>27422</id><timestamp>2013-07-12T10:13:28Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|referent bourgmestre}}
-| rdfs:domain = Settlement
-| rdfs:range = Person
-}}</text></revision></page><page><title>OntologyProperty:Refgen</title><ns>202</ns><id>6985</id><revision><id>34164</id><timestamp>2014-04-04T16:33:42Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|reference for general data}}
-{{label|de|Referenz für allgemeine Daten}}
-| rdfs:range = xsd:string
-| rdfs:domain = Place
-}}</text></revision></page><page><title>OntologyProperty:Refgeo</title><ns>202</ns><id>6987</id><revision><id>47905</id><timestamp>2015-05-13T11:22:06Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|reference for geographic data}}
-{{label|de|Referenz für geographische Daten}}
-{{label|nl|geometrie}}
-| rdfs:range = xsd:string
-| rdfs:domain = Place
-}}</text></revision></page><page><title>OntologyProperty:Refpol</title><ns>202</ns><id>6988</id><revision><id>34166</id><timestamp>2014-04-04T16:33:52Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|reference for politic data}}
-{{label|de|Referenz für politische Daten}}
-| rdfs:range = xsd:string
-| rdfs:domain = Place
-}}</text></revision></page><page><title>OntologyProperty:Refseq</title><ns>202</ns><id>1356</id><revision><id>8243</id><timestamp>2010-05-28T13:37:59Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = RefSeq
-| rdfs:domain = Protein
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Refseqmrna</title><ns>202</ns><id>5031</id><revision><id>19133</id><timestamp>2012-07-31T11:19:25Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = refseq mRNA
-| rdfs:label@ja = refseq mRNA
-| rdfs:domain = Biomolecule
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Refseqprotein</title><ns>202</ns><id>5032</id><revision><id>19134</id><timestamp>2012-07-31T11:19:52Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = refseq protein
-| rdfs:label@ja = refseq protein
-| rdfs:domain = Biomolecule
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Regency</title><ns>202</ns><id>6791</id><revision><id>36460</id><timestamp>2014-07-08T14:14:13Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|regency }}
-	{{label|de|Regentschaft}}
-	{{label|id|kabupaten }}
-| comments =
-	
-| rdfs:domain = Place
-| rdfs:range = PopulatedPlace
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:RegentOf</title><ns>202</ns><id>11286</id><revision><id>48717</id><timestamp>2015-08-10T11:25:44Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|regent of}}
-| rdfs:comment@en = Subject has served as the regent of another monarch	
-| rdfs:domain = Monarch
-| rdfs:range = Monarch
-}}</text></revision></page><page><title>OntologyProperty:Regime</title><ns>202</ns><id>1357</id><revision><id>34268</id><timestamp>2014-04-04T16:49:17Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = regime
-| rdfs:domain = Spacecraft
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Region</title><ns>202</ns><id>1358</id><revision><id>36461</id><timestamp>2014-07-08T14:14:16Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|region}}
-	{{label|de|Region}}
-	{{label|nl|regio}}
-	{{label|el|περιοχή}}
-	{{label|pl|region}}
-| rdfs:comment@en = The regin where the thing is located or is connected to.
-| rdfs:domain = owl:Thing
-| rdfs:range = Place
-| rdfs:subPropertyOf = dul:hasLocation
-}}</text></revision></page><page><title>OntologyProperty:RegionLink</title><ns>202</ns><id>7109</id><revision><id>25639</id><timestamp>2013-05-26T14:16:44Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|region link}}
-| rdfs:domain = Place
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:RegionServed</title><ns>202</ns><id>1361</id><revision><id>36462</id><timestamp>2014-07-08T14:14:18Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|region served}}
-	{{label|nl|werkgebied}}
-| rdfs:domain = Organisation
-| rdfs:range = Place
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:RegionType</title><ns>202</ns><id>1362</id><revision><id>22198</id><timestamp>2013-01-10T21:16:42Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|region type}}
-{{label|nl|regio-type}}
-| rdfs:domain = Place
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:RegionalCouncil</title><ns>202</ns><id>7021</id><revision><id>34171</id><timestamp>2014-04-04T16:34:21Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|regional council}}
-{{label|de|Gemeinderat}}
-| rdfs:domain = Agent
-| rdfs:range = TermOfOffice
-}}</text></revision></page><page><title>OntologyProperty:RegionalLanguage</title><ns>202</ns><id>1360</id><revision><id>36463</id><timestamp>2014-07-08T14:14:22Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = regional language
-| rdfs:label@de = Regionalsprache
-| rdfs:domain = PopulatedPlace
-| rdfs:range = Language
-| rdfs:subPropertyOf = dul:isLocationOf
-}}</text></revision></page><page><title>OntologyProperty:RegionalPrefecture</title><ns>202</ns><id>7137</id><revision><id>34173</id><timestamp>2014-04-04T16:34:31Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|regional prefecture}}
-{{label|de|regionale Präfektur}}
-| rdfs:domain = Place
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Registration</title><ns>202</ns><id>1363</id><revision><id>57276</id><timestamp>2022-03-28T22:05:44Z</timestamp><text>{{DatatypeProperty
-| labels = 
-    {{label|en|registration}}
-    {{label|fr|enregistrement}}
-    {{label|de|Anmeldung}}
-| rdfs:domain = Company
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Registry</title><ns>202</ns><id>6535</id><revision><id>52561</id><timestamp>2017-10-26T13:16:08Z</timestamp><text>{{DatatypeProperty
-| labels                 =
-{{label|en|registry}}
-{{label|de|Register}}
-{{label|fr|registre}}
-| comments               =
-{{comment|en|A registry recording entires with associated codes. }}
-{{comment|de|Ein Register welches Einträge mit Kennungen versieht. }}
-| rdfs:range             = xsd:string
-| owl:equivalentProperty = 
-}}</text></revision></page><page><title>OntologyProperty:RegistryNumber</title><ns>202</ns><id>8410</id><revision><id>53756</id><timestamp>2020-09-30T13:09:26Z</timestamp><text>{{ DatatypeProperty
-	| rdfs:comment@en = Identification of the registry a document is in
-	| rdfs:label@en = registry number
-        | rdfs:label@de = Registrierungsnummer
-	| rdfs:label@nl = registernummer
-        | rdfs:domain = Document
-	| rdfs:range = xsd:string
-|owl:equivalentProperty=ceo:kennisregistratienummer
-}}</text></revision></page><page><title>OntologyProperty:Reign</title><ns>202</ns><id>7638</id><revision><id>26884</id><timestamp>2013-07-03T09:08:22Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|reign}}
-| rdfs:domain = Person
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:ReignName</title><ns>202</ns><id>8086</id><revision><id>28251</id><timestamp>2013-09-04T10:23:47Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|reign name}}
-| rdfs:domain = Person
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:ReigningPope</title><ns>202</ns><id>11362</id><revision><id>49214</id><timestamp>2015-10-14T20:19:16Z</timestamp><text>{{ObjectProperty
-|labels =
-  {{label|en|reigning pope}}
-  {{label|nl|regerende paus}}
-| rdfs:domain = Cleric &lt;!-- Cardinal , Priest--&gt;
-| rdfs:range = Pope
-}}</text></revision></page><page><title>OntologyProperty:Related</title><ns>202</ns><id>1364</id><revision><id>53706</id><timestamp>2020-09-04T15:35:43Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|related}}
-	{{label|de|verbunden}}
-	{{label|nl|gerelateerd}}
-| rdfs:subPropertyOf = dul:associatedWith
-| owl:equivalentProperty = schema:isRelatedTo, ceo:heeftBetrekkingOp
-}}</text></revision></page><page><title>OntologyProperty:RelatedFunctions</title><ns>202</ns><id>6454</id><revision><id>36465</id><timestamp>2014-07-08T14:14:29Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|related functions}}
-	{{label|nl|soortgelijke functies}}
-| comments =
-	{{comment|en|This property is to accommodate the list field that contains a list of related personFunctions a person holds or has held  }}
-	{{comment|nl|Deze property is voor de lijst van persoonfuncties die een persoon (bv. een politicus) bekleedt of heeft bekleed}}
-| rdfs:domain = Person
-| rdfs:range = List
-| rdf:type = | rdfs:subPropertyOf     = 
-| owl:equivalentProperty = 
-| rdfs:subPropertyOf = dul:unifies
-}}</text></revision></page><page><title>OntologyProperty:RelatedMeanOfTransportation</title><ns>202</ns><id>1365</id><revision><id>36466</id><timestamp>2014-07-08T14:14:32Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = related mean of transportation
-| rdfs:domain = MeanOfTransportation
-| rdfs:range = MeanOfTransportation
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:RelatedPlaces</title><ns>202</ns><id>6327</id><revision><id>36467</id><timestamp>2014-07-08T14:14:35Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|related places}}
-	{{label|nl|soortgelijke plaatsen}}
-| comments =
-	{{comment|en|This property is to accommodate the list field that contains a list of, e.g., monuments in the same town  }}
-	{{comment|nl|Deze property is voor de lijst van monumenten die horen bij het monument van de infobox}}
-| rdfs:domain = Place
-| rdfs:range = List
-| rdf:type = | rdfs:subPropertyOf     = 
-| owl:equivalentProperty = 
-| rdfs:subPropertyOf = dul:unifies
-}}</text></revision></page><page><title>OntologyProperty:Relation</title><ns>202</ns><id>1366</id><revision><id>36468</id><timestamp>2014-07-08T14:14:39Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|relation}}
-	{{label|de|Beziehung}}
-	{{label|el|σχέση}}
-	{{label|nl|relatie}}
-| rdfs:domain = Person
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:Relative</title><ns>202</ns><id>1367</id><revision><id>49046</id><timestamp>2015-10-08T15:38:14Z</timestamp><text>{{ObjectProperty
-| rdfs:label@en = relative
-| rdfs:label@el = συγγενής
-| rdfs:label@de = Verwandter
-| rdfs:label@gl = parente
-| rdfs:label@ja = 親戚
-| rdfs:domain = Person
-| rdfs:range = Person
-| owl:equivalentProperty = schema:relatedTo
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:RelativeAtomicMass</title><ns>202</ns><id>11018</id><revision><id>45317</id><timestamp>2015-02-13T17:39:52Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|atomic weight}}
-{{label|ga|Mais adamhach choibhneasta}}
-| comments =
-{{comment|en|the ratio of the average mass of atoms of an element (from a single given sample or source) to 1⁄12 of the mass of an atom of carbon-12&lt;ref&gt;https://en.wikipedia.org/wiki/Relative_atomic_mass&lt;/ref&gt;}}
-{{comment|ga|Maiseanna adamh, a chuirtear síos i dtéarmaí aonaid maise adamhaí u.&lt;ref&gt;https://ga.wikipedia.org/wiki/Mais_adamhach_choibhneasta&lt;/ref&gt;}}
-| rdfs:domain = ChemicalElement
-| rdfs:range = xsd:nonNegativeInteger
-}}
-
-&lt;references/&gt;</text></revision></page><page><title>OntologyProperty:ReleaseDate</title><ns>202</ns><id>1368</id><revision><id>59609</id><timestamp>2024-05-31T17:46:20Z</timestamp><text>{{DatatypeProperty
-| labels =
-  {{label|en|release date}}
-  {{label|fr|date de sortie}}
-  {{label|da|udgivet}}
-  {{label|nl|release datum}}
-  {{label|el|ημερομηνία κυκλοφορίας}}
-  {{label|pl|data wydania}}
-  {{label|am|የተለቀቀበት ዓመት}}
-| comments = 
-  {{comment|en|Release date of a Work or another product (eg Aircraft or other MeansOfTransportation}}
-  {{comment|fr|Date de sortie d'un travail ou d'un autre produit (un avion, d'autres moyens de transport...}}
-| rdfs:range = xsd:date
-| owl:equivalentProperty = wikidata:P577
-}}</text></revision></page><page><title>OntologyProperty:ReleaseLocation</title><ns>202</ns><id>11038</id><revision><id>45393</id><timestamp>2015-02-18T16:26:07Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|release location}}
-| rdfs:domain = Work
-| rdfs:range = Place
-| rdfs:comment@en = Usually used with releaseDate, particularly for Films. Often there can be several pairs so our modeling is not precise here...
-}}</text></revision></page><page><title>OntologyProperty:Relics</title><ns>202</ns><id>11237</id><revision><id>47843</id><timestamp>2015-05-04T16:37:50Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = relics
-| rdfs:label@bg = реликви
-| rdfs:domain = ReligiousBuilding
-| rdfs:range = xsd:string
-| rdfs:comment@en = Physical remains or personal effects of a saint or venerated person, preserved in a religious building
-}}</text></revision></page><page><title>OntologyProperty:Relief</title><ns>202</ns><id>7145</id><revision><id>25684</id><timestamp>2013-05-26T16:09:08Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|relief}}
-| rdfs:domain = Place
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Religion</title><ns>202</ns><id>1369</id><revision><id>36470</id><timestamp>2014-07-08T14:14:45Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|religion}}
-	{{label|de|Religion}}
-	{{label|el|θρησκεία}}
-	{{label|nl|religie}}
-	{{label|fr|religion}}
-	{{label|pt|religião}}
-	{{label|ja|宗教}}
-| owl:equivalentProperty = wikidata:P140
-| rdfs:subPropertyOf = dul:conceptualizes
-}}</text></revision></page><page><title>OntologyProperty:ReligiousHead</title><ns>202</ns><id>3116</id><revision><id>52592</id><timestamp>2017-10-31T09:09:15Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = religious head
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:hasMember
-}}</text></revision></page><page><title>OntologyProperty:ReligiousHeadLabel</title><ns>202</ns><id>3115</id><revision><id>36472</id><timestamp>2014-07-08T14:14:53Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = religious head label
-| rdfs:domain = School
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:ReligiousOrder</title><ns>202</ns><id>6031</id><revision><id>58789</id><timestamp>2022-05-31T15:01:06Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|religious order}}
-	{{label|nl|religieuze orde}}
-| rdfs:domain = Monastry
-| rdfs:range = ClericalOrder
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:Reopened</title><ns>202</ns><id>1370</id><revision><id>52593</id><timestamp>2017-10-31T09:10:25Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = reopened
-| rdfs:label@de = wieder eröffnet
-| rdfs:range = xsd:date
-}}</text></revision></page><page><title>OntologyProperty:ReopeningDate</title><ns>202</ns><id>3836</id><revision><id>34180</id><timestamp>2014-04-04T16:35:12Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = reopening date
-| rdfs:label@de = Wiedereröffnungdatum
-| rdfs:domain = ArchitecturalStructure
-| rdfs:range = xsd:date
-| rdfs:comment@en = Date of reopening the architectural structure.
-}}</text></revision></page><page><title>OntologyProperty:ReopeningYear</title><ns>202</ns><id>3837</id><revision><id>22267</id><timestamp>2013-01-11T00:17:24Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|reopening year}}
-{{label|nl|heropening jaar}}
-| rdfs:domain = ArchitecturalStructure
-| rdfs:range = xsd:gYear
-| rdfs:comment@en = Year of reopening the architectural structure.
-}}</text></revision></page><page><title>OntologyProperty:ReportingMark</title><ns>202</ns><id>3705</id><revision><id>13065</id><timestamp>2011-05-19T13:11:08Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = reporting mark
-| rdfs:domain = PublicTransitSystem
-| rdfs:range = xsd:string
-| rdfs:comment@en = A reporting mark is a two-, three-, or four-letter alphabetic code used to identify owners or lessees of rolling stock and other equipment used on the North American railroad network.
-}}</text></revision></page><page><title>OntologyProperty:Representative</title><ns>202</ns><id>7044</id><revision><id>34181</id><timestamp>2014-04-04T16:35:16Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|number of representatives}}
-{{label|de|Zahl der Vertreter}}
-| rdfs:domain = Place
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:Requirement</title><ns>202</ns><id>2128</id><revision><id>34182</id><timestamp>2014-04-04T16:35:21Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = requirement
-| rdfs:label@de = Anforderung
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Reservations</title><ns>202</ns><id>2529</id><revision><id>34183</id><timestamp>2014-04-04T16:35:25Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = reservations
-| rdfs:label@de = Reservierungen
-| rdfs:comment@en = Are reservations required for the establishment or event?
-| rdfs:domain = Restaurant
-| rdfs:range = xsd:boolean
-}}</text></revision></page><page><title>OntologyProperty:Residence</title><ns>202</ns><id>1371</id><revision><id>58775</id><timestamp>2022-05-31T13:38:17Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|residence}}
-	{{label|de|Residenz}}
-	{{label|nl|verblijfplaats}}
-	{{label|el|κατοικία}}
-	{{label|ja|居住地}}
-	{{label|pl|miejsce zamieszkania}}
-| rdfs:comment@en = Place of residence of a person.
-| rdfs:domain = Person
-| rdfs:range = Place
-| owl:equivalentProperty = wikidata:P551
-| rdfs:subPropertyOf = dul:hasLocation
-}}</text></revision></page><page><title>OntologyProperty:Resolution</title><ns>202</ns><id>2124</id><revision><id>36475</id><timestamp>2014-07-08T14:15:14Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|resolution}}
-	{{label|de|Auflösung}}
-	{{label|el|ανάλυση}}
-	{{label|fr|résolution}}
-| rdfs:domain = Software
-| rdfs:comment@en = Native Resolution
-| rdfs:subPropertyOf = dul:hasQuality
-}}</text></revision></page><page><title>OntologyProperty:Restaurant</title><ns>202</ns><id>14267</id><revision><id>59097</id><timestamp>2022-10-13T09:50:19Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = hotel
-| rdfs:label@fr = hotêl
-| rdfs:domain = Hotel
-| rdfs:range = Building
-}}</text></revision></page><page><title>OntologyProperty:RestingDate</title><ns>202</ns><id>7978</id><revision><id>52837</id><timestamp>2018-02-08T20:23:04Z</timestamp><text>{{DatatypeProperty
-| labels =
-  {{label|en|resting date}}
-  {{label|de|Bestattungsdatum}}
-  {{label|ja|埋葬年月日}}
-| rdfs:domain = Person
-| rdfs:range = xsd:date
-| rdf:type = owl:FunctionalProperty
-| owl:equivalentProperty = 
-}}</text></revision></page><page><title>OntologyProperty:RestingPlace</title><ns>202</ns><id>1373</id><revision><id>36476</id><timestamp>2014-07-08T14:15:18Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = resting place
-| rdfs:label@de = Ruhestätte
-| rdfs:label@ja = 埋葬地
-| rdfs:domain = Person
-| rdfs:range = Place
-| rdfs:subPropertyOf = dul:hasLocation
-}}</text></revision></page><page><title>OntologyProperty:RestingPlacePosition</title><ns>202</ns><id>1374</id><revision><id>36477</id><timestamp>2014-07-08T14:15:20Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = resting place position
-| rdfs:domain = Person
-| rdfs:range = geo:SpatialThing
-| rdfs:subPropertyOf = dul:hasLocation
-}}</text></revision></page><page><title>OntologyProperty:RestoreDate</title><ns>202</ns><id>2551</id><revision><id>11331</id><timestamp>2011-03-30T15:23:30Z</timestamp><text>{{DatatypeProperty
-|rdfs:label@en=restore date
-| rdfs:label@el = ημερομηνία ανακαίνισης
-|rdfs:range=xsd:date
-}}</text></revision></page><page><title>OntologyProperty:Restriction</title><ns>202</ns><id>11972</id><revision><id>52559</id><timestamp>2017-10-26T10:44:38Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = restriction
-| rdfs:label@de = Beschränkung
-| rdfs:comment@en = The use of a thing is restricted in a way.
-| rdfs:comment@de = Die Verwendung von etwas ist beschränkt.
-| rdfs:domain = owl:Thing
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Result</title><ns>202</ns><id>1375</id><revision><id>34273</id><timestamp>2014-04-04T17:08:38Z</timestamp><text>{{DatatypeProperty
-| labels = 
-{{label|en|result}}
-{{label|de|Folge}}
-{{label|el|αποτέλεσμα}}
-
-| rdfs:domain = MilitaryConflict
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:RetentionTime</title><ns>202</ns><id>7098</id><revision><id>25622</id><timestamp>2013-05-26T13:36:52Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|relation time}}
-| rdfs:domain = Place
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Retired</title><ns>202</ns><id>1376</id><revision><id>21749</id><timestamp>2013-01-03T17:33:58Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = retired
-| rdfs:label@el = συνταξιούχος
-| rdfs:range = xsd:date
-}}</text></revision></page><page><title>OntologyProperty:RetiredRocket</title><ns>202</ns><id>1378</id><revision><id>36478</id><timestamp>2014-07-08T14:15:23Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = retired rocket
-| rdfs:domain = YearInSpaceflight
-| rdfs:range = Rocket
-| rdfs:subPropertyOf = dul:isSettingFor
-}}</text></revision></page><page><title>OntologyProperty:RetirementDate</title><ns>202</ns><id>5640</id><revision><id>22412</id><timestamp>2013-01-11T22:28:02Z</timestamp><text>{{ DatatypeProperty
-| labels =
-{{label|en|retirement date}}
-{{label|nl|pensioendatum}}
-| rdfs:domain = Person
-| rdfs:range = xsd:date
-| rdf:type = owl:FunctionalProperty
-}}</text></revision></page><page><title>OntologyProperty:RevPerYear</title><ns>202</ns><id>14282</id><revision><id>59120</id><timestamp>2022-12-01T17:27:38Z</timestamp><text>#REDIRECT [[OntologyProperty:NbRevPerYear]]</text></revision></page><page><title>OntologyProperty:Revenue</title><ns>202</ns><id>1379</id><revision><id>59625</id><timestamp>2024-05-31T22:18:10Z</timestamp><text>{{DatatypeProperty
-| labels = 
-  {{label|en|revenue}}
-{{label|de|Einnahmen}}
-  {{label|el|έσοδα}}
-  {{label|am|ገቢ}}
-  {{label|fr|chiffre d'affaire}}
-| rdfs:domain = Organisation
-| rdfs:range = Currency
-| owl:equivalentProperty = wikidata:P2139
-}}</text></revision></page><page><title>OntologyProperty:RevenueYear</title><ns>202</ns><id>12331</id><revision><id>53654</id><timestamp>2020-07-27T08:48:15Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|year of reported revenue}}
-| rdfs:domain = Organization
-| rdfs:range = xsd:gYear
-}}</text></revision></page><page><title>OntologyProperty:Review</title><ns>202</ns><id>1380</id><revision><id>57042</id><timestamp>2022-03-09T15:48:01Z</timestamp><text>{{DatatypeProperty
-| labels = 
-  {{label|en|review}}
-  {{label|fr|évaluation}}
-  {{label|de|Rezension}}
-| rdfs:domain = Album
-| rdfs:range = xsd:anyURI
-}}</text></revision></page><page><title>OntologyProperty:RgbCoordinateBlue</title><ns>202</ns><id>2371</id><revision><id>10448</id><timestamp>2010-11-10T15:01:49Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = bluecoordinate in the RGB space
-| rdfs:domain = Colour
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:RgbCoordinateGreen</title><ns>202</ns><id>2372</id><revision><id>10449</id><timestamp>2010-11-10T15:01:57Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = green coordinate in the RGB space
-| rdfs:domain = Colour
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:RgbCoordinateRed</title><ns>202</ns><id>2370</id><revision><id>10447</id><timestamp>2010-11-10T15:01:31Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = red coordinate in the RGB space
-| rdfs:domain = Colour
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:RidId</title><ns>202</ns><id>8425</id><revision><id>52884</id><timestamp>2018-02-13T10:56:11Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|RID Id}}
-| comments =
-{{comment|en|An identifying system for scientific authors. The system was introduced in January 2008 by Thomson Reuters. The combined use of the Digital Object Identifier with the ResearcherID allows for a unique association of authors and scientific articles.}}
-| rdfs:range = xsd:string
-| rdfs:subPropertyOf = code
-}}</text></revision></page><page><title>OntologyProperty:RightAscension</title><ns>202</ns><id>5343</id><revision><id>49153</id><timestamp>2015-10-13T11:07:58Z</timestamp><text>{{ DatatypeProperty
-
-	| rdfs:label@en = right ascension
-	| rdfs:domain = CelestialBody
-	| rdfs:range = xsd:nonNegativeInteger
-
-}}</text></revision></page><page><title>OntologyProperty:RightChild</title><ns>202</ns><id>1383</id><revision><id>36479</id><timestamp>2014-07-08T14:15:26Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = right child
-| rdfs:domain = Island
-| rdfs:range = Island
-| rdfs:subPropertyOf = dul:hasCommonBoundary
-}}</text></revision></page><page><title>OntologyProperty:RightTributary</title><ns>202</ns><id>1384</id><revision><id>36480</id><timestamp>2014-07-08T14:15:30Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = right tributary
-| rdfs:label@de = rechter Nebenfluss
-| rdfs:label@el = δεξιοί_παραπόταμοι
-| rdfs:domain = River
-| rdfs:range = River
-| rdfs:subPropertyOf = dul:hasCommonBoundary
-}}</text></revision></page><page><title>OntologyProperty:Rival</title><ns>202</ns><id>11975</id><revision><id>52595</id><timestamp>2017-10-31T09:11:26Z</timestamp><text>#REDIRECT [[OntologyProperty:RivalSchool]]</text></revision></page><page><title>OntologyProperty:RivalSchool</title><ns>202</ns><id>1385</id><revision><id>52594</id><timestamp>2017-10-31T09:11:26Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = rival
-| rdfs:label@de = Rivale
-| rdfs:domain = School
-| rdfs:range = School
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:River</title><ns>202</ns><id>1386</id><revision><id>36482</id><timestamp>2014-07-08T14:15:36Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|river}}
-	{{label|de|Fluss}}
-	{{label|el|ποτάμι}}
-	{{label|fr|rivière}}
-| rdfs:domain = Place
-| rdfs:range = River
-| rdfs:subPropertyOf = dul:nearTo
-}}</text></revision></page><page><title>OntologyProperty:RiverBranch</title><ns>202</ns><id>620</id><revision><id>36483</id><timestamp>2014-07-08T14:15:40Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|branch}}
-	{{label|nl|riviertak}}
-	{{label|el|διακλαδώσεις}}
-| rdfs:domain = River
-| rdfs:range = River
-| rdfs:subPropertyOf = dul:hasCommonBoundary
-}}</text></revision></page><page><title>OntologyProperty:RiverBranchOf</title><ns>202</ns><id>622</id><revision><id>36484</id><timestamp>2014-07-08T14:15:43Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = branch of
-| rdfs:label@el = διακλάδωση_του
-| rdfs:domain = River
-| rdfs:range = River
-| rdfs:subPropertyOf = dul:hasCommonBoundary
-}}</text></revision></page><page><title>OntologyProperty:RiverMouth</title><ns>202</ns><id>1147</id><revision><id>36485</id><timestamp>2014-07-08T14:15:47Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|river mouth}}
-	{{label|de|Flussmündung}}
-	{{label|nl|riviermonding}}
-	{{label|el|εκβολές}}
-| rdfs:domain = River
-| rdfs:range = BodyOfWater
-| rdfs:subPropertyOf = dul:hasCommonBoundary
-}}</text></revision></page><page><title>OntologyProperty:RkdArtistsId</title><ns>202</ns><id>11041</id><revision><id>52885</id><timestamp>2018-02-13T10:57:26Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|RKDartists id}}
-| comments =
-{{comment|en|Rijksbureau voor Kunsthistorische Documentatie (RKD) artists database id.
-http://rkd.nl/explore/artists/$1}}
-| rdfs:domain = owl:Thing
-| rdfs:range = xsd:string
-| owl:equivalentProperty = wikidata:P650
-| rdfs:subPropertyOf = code
-}}</text></revision></page><page><title>OntologyProperty:Road</title><ns>202</ns><id>11138</id><revision><id>46170</id><timestamp>2015-03-18T08:26:22Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|road}}
-	{{label|nl|weg}}
-| rdfs:domain = Infrastructure
-| rdfs:range = Road
-}}</text></revision></page><page><title>OntologyProperty:Rocket</title><ns>202</ns><id>1387</id><revision><id>36486</id><timestamp>2014-07-08T14:15:51Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = rocket
-| rdfs:label@de = Rakete
-| rdfs:label@fr = fusée
-| rdfs:label@el = ρουκέτα
-| rdfs:domain = Spacecraft
-| rdfs:range = Rocket
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:RocketFunction</title><ns>202</ns><id>1684</id><revision><id>36487</id><timestamp>2014-07-08T14:15:54Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = rocket function
-| rdfs:domain = Rocket
-| rdfs:comment@en = purpose of the rocket
-| rdfs:subPropertyOf = dul:isClassifiedBy
-}}</text></revision></page><page><title>OntologyProperty:RocketStages</title><ns>202</ns><id>1462</id><revision><id>34198</id><timestamp>2014-04-04T16:36:37Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = number of rocket stages
-| rdfs:label@de = Anzahl von Raketenstufen
-| rdfs:comment@en = number of stages, not including boosters
-| rdfs:domain = Rocket
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:RolandGarrosDouble</title><ns>202</ns><id>7723</id><revision><id>50070</id><timestamp>2016-01-04T12:32:27Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|roland garros double}}
-| rdfs:domain = TennisPlayer
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:RolandGarrosMixed</title><ns>202</ns><id>7727</id><revision><id>50071</id><timestamp>2016-01-04T12:33:02Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|roland garros mixed}}
-| rdfs:domain = TennisPlayer
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:RolandGarrosSingle</title><ns>202</ns><id>7719</id><revision><id>50072</id><timestamp>2016-01-04T12:33:38Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|roland garros single}}
-| rdfs:domain = TennisPlayer
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Role</title><ns>202</ns><id>1388</id><revision><id>53707</id><timestamp>2020-09-04T15:36:28Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = role
-| rdfs:label@de = Rolle
-| rdfs:label@el = ρόλος
-| rdfs:label@fr = rôle
-| rdfs:range = xsd:string
-| owl:equivalentProperty = schema:role, ceo:rol
-}}</text></revision></page><page><title>OntologyProperty:RoleInEvent</title><ns>202</ns><id>10105</id><revision><id>37585</id><timestamp>2014-08-07T09:29:39Z</timestamp><text>{{ObjectProperty
-| rdfs:label@en = A Person's role in an event
-| rdfs:label@nl = Rol van een persoon in een gebeurtenis
-| rdfs:label@fr = rôle d'une personne dans un événement
-| rdfs:domain = Agent
-| rdfs:range = Event
-}}</text></revision></page><page><title>OntologyProperty:RoofHeight</title><ns>202</ns><id>6431</id><revision><id>23478</id><timestamp>2013-01-22T13:34:31Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|roof height}}
-{{label|de|Höhe Dach}}
-| rdfs:domain = Skyscraper
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:RotationPeriod</title><ns>202</ns><id>4361</id><revision><id>14681</id><timestamp>2011-07-29T15:36:01Z</timestamp><text>{{DatatypeProperty
- |rdfs:label@en=rotation period
- |rdfs:domain=Planet
- |rdfs:range=Time
-}}</text></revision></page><page><title>OntologyProperty:Route</title><ns>202</ns><id>7110</id><revision><id>34200</id><timestamp>2014-04-04T16:36:46Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|route}}
-{{label|de|Route}}
-| rdfs:domain = Place
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:RouteActivity</title><ns>202</ns><id>11079</id><revision><id>45568</id><timestamp>2015-03-08T12:55:34Z</timestamp><text>{{ObjectProperty
-| rdfs:label@en = route activity 
-| rdfs:label@fr = activité de route
-| rdfs:domain = RouteStop
-| rdfs:comment@en = details of the activity for a road.
-| rdfs:comment@fr = détail de l'activité sur une route.
-}}</text></revision></page><page><title>OntologyProperty:RouteDirection</title><ns>202</ns><id>3337</id><revision><id>12220</id><timestamp>2011-04-15T13:26:23Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = route direction
-| rdfs:label@de = Himmelsrichtung des Verkehrsweges
-| rdfs:domain = RouteOfTransportation
-| rdfs:range = xsd:string
-| rdfs:comment@en = The general direction of the route (eg. North-South).
-| rdfs:comment@de = Himmelsrichtung des Verkehrsweges (z.B. North-South).
-}}</text></revision></page><page><title>OntologyProperty:RouteEnd</title><ns>202</ns><id>3334</id><revision><id>52253</id><timestamp>2017-10-08T09:42:42Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = route end 
-| rdfs:label@de = Wegende
-| rdfs:domain = RouteOfTransportation
-| rdfs:range = Station
-| rdfs:comment@en = End of the route. This is where the route ends and, for U.S. roads, is either at the northern terminus or eastern terminus.
-| rdfs:comment@de = Ende des Verkehrswegs.
-| rdfs:subPropertyOf = dul:hasCommonBoundary
-}}</text></revision></page><page><title>OntologyProperty:RouteEndDirection</title><ns>202</ns><id>3335</id><revision><id>12218</id><timestamp>2011-04-15T13:17:42Z</timestamp><text>http://mappings.dbpedia.org/index.php/OntologyProperty:routeEndDirection
-{{DatatypeProperty
-| rdfs:label@en = road end direction
-| rdfs:label@de = Himmelsrichtung des Wegendes
-| rdfs:domain = RouteOfTransportation
-| rdfs:range = xsd:string
-| rdfs:comment@en = End of the route. The opposite of OntologyProperty:routeStartDirection.
-| rdfs:comment@de = Himmelsrichtung des Endes des Verkehrsweges. Der Gegensatz zur OntologyProperty:routeStartDirection.
-}}</text></revision></page><page><title>OntologyProperty:RouteEndLocation</title><ns>202</ns><id>3393</id><revision><id>36489</id><timestamp>2014-07-08T14:16:00Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = route end location
-| rdfs:label@de = Ort des Wegendes
-| rdfs:domain = RouteOfTransportation
-| rdfs:range = Place
-| rdfs:comment@en = The end location of the route.
-| rdfs:comment@de = End-Ort des Verkehrswegs.
-| rdfs:subPropertyOf = dul:hasCommonBoundary
-}}</text></revision></page><page><title>OntologyProperty:RouteJunction</title><ns>202</ns><id>3319</id><revision><id>52254</id><timestamp>2017-10-08T09:43:08Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = route junction
-| rdfs:label@de = Wegabzweigung
-| rdfs:domain = RouteOfTransportation
-| rdfs:range = Station
-| rdfs:comment@en = A junction or cross to another route.
-| rdfs:comment@de = Eine Abzweigung oder Kreuzung zu einem anderen Verkehrsweg.
-| rdfs:subPropertyOf = dul:hasCommonBoundary
-}}</text></revision></page><page><title>OntologyProperty:RouteLine</title><ns>202</ns><id>11078</id><revision><id>45564</id><timestamp>2015-03-08T12:47:18Z</timestamp><text>{{ObjectProperty
-| rdfs:label@en = line 
-| rdfs:label@fr = ligne
-| rdfs:domain = RouteStop
-| rdfs:comment@fr = ligne d'un arrêt sur une route.
-| rdfs:comment@en = line of a stop on a route.
-}}</text></revision></page><page><title>OntologyProperty:RouteNext</title><ns>202</ns><id>11077</id><revision><id>45567</id><timestamp>2015-03-08T12:50:15Z</timestamp><text>{{ObjectProperty
-| rdfs:label@en = route next stop 
-| rdfs:label@fr = arrêt suivant
-| rdfs:domain = RouteStop
-| rdfs:range = RouteStop
-| rdfs:comment@en = next stop on a route.
-| rdfs:comment@fr = arrêt suivant sur une route.
-}}</text></revision></page><page><title>OntologyProperty:RouteNumber</title><ns>202</ns><id>4352</id><revision><id>34201</id><timestamp>2014-04-04T16:36:51Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = route number
-| rdfs:label@de = Routennummer
-| rdfs:domain = RouteOfTransportation
-| rdfs:range = xsd:string
-| rdfs:comment@en = The number of the route.
-}}</text></revision></page><page><title>OntologyProperty:RoutePrevious</title><ns>202</ns><id>11075</id><revision><id>45566</id><timestamp>2015-03-08T12:49:38Z</timestamp><text>{{ObjectProperty
-| rdfs:label@en = route previous stop 
-| rdfs:label@fr = arrêt précédent 
-| rdfs:domain = RouteStop
-| rdfs:range = RouteStop
-| rdfs:comment@en = previous stop on a route.
-| rdfs:comment@fr = arrêt précédent sur une route.
-}}</text></revision></page><page><title>OntologyProperty:RouteStart</title><ns>202</ns><id>3332</id><revision><id>52255</id><timestamp>2017-10-08T09:43:46Z</timestamp><text>{{ObjectProperty
-| rdfs:label@en = route start 
-| rdfs:label@fr = point de départ 
-| rdfs:label@de = Weganfang
-| rdfs:domain = RouteOfTransportation
-| rdfs:range = Station
-| rdfs:comment@en = Start of the route. This is where the route begins and, for U.S. roads, is either at the southern terminus or western terminus.
-| rdfs:comment@fr = point de départ d'une route.
-| rdfs:comment@de = Anfang des Verkehrswegs.
-| rdfs:subPropertyOf = dul:hasCommonBoundary
-}}</text></revision></page><page><title>OntologyProperty:RouteStartDirection</title><ns>202</ns><id>3333</id><revision><id>12216</id><timestamp>2011-04-15T13:16:18Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = road start direction
-| rdfs:label@de = Himmelsrichtung des Wegstarts
-| rdfs:domain = RouteOfTransportation
-| rdfs:range = xsd:string
-| rdfs:comment@en = End of the route. For U.S. roads, this should be either "South" or "West" per the standards set by the U.S. Roads project.
-| rdfs:comment@de = Himmelsrichtung des Anfangs des Verkehrsweges.
-}}</text></revision></page><page><title>OntologyProperty:RouteStartLocation</title><ns>202</ns><id>3394</id><revision><id>36492</id><timestamp>2014-07-08T14:16:10Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = route start location
-| rdfs:label@de = Ort des Weganfangs
-| rdfs:domain = RouteOfTransportation
-| rdfs:range = Place
-| rdfs:comment@en = The start location of the route.
-| rdfs:comment@de = Der Startort des Verkehrswegs.
-| rdfs:subPropertyOf = dul:hasCommonBoundary
-}}</text></revision></page><page><title>OntologyProperty:RouteTypeAbbreviation</title><ns>202</ns><id>4353</id><revision><id>14661</id><timestamp>2011-07-28T15:03:58Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = route type abbreviation
-| rdfs:domain = RouteOfTransportation
-| rdfs:range = xsd:string
-| rdfs:comment@en = The route type abbreviation (eg.: I for Interstate, M for Motorway or NJ for New Jersey Route).
-}}</text></revision></page><page><title>OntologyProperty:RoyalAnthem</title><ns>202</ns><id>1389</id><revision><id>36493</id><timestamp>2014-07-08T14:16:14Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = royal anthem
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:Ruling</title><ns>202</ns><id>6605</id><revision><id>34202</id><timestamp>2014-04-04T16:36:56Z</timestamp><text>{{DatatypeProperty
-| labels                 =
-{{label|en|ruling}}
-{{label|de|Entscheidung}}
-{{label|nl|relevante regelgeving}}
-| comments               =
-{{comment|en| Ruling referred to in this legal case }}
-| rdfs:domain            = LegalCase
-| rdfs:range             = xsd:string
-| rdf:type               =
-| rdfs:subPropertyOf     = 
-| owl:equivalentProperty = 
-}}</text></revision></page><page><title>OntologyProperty:RunningMate</title><ns>202</ns><id>2355</id><revision><id>37606</id><timestamp>2014-08-25T09:23:49Z</timestamp><text>{{ObjectProperty
-| rdfs:label@en = running mate
-| rdfs:label@es = compañero de candidatura
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:Runtime</title><ns>202</ns><id>1390</id><revision><id>52830</id><timestamp>2018-02-08T20:13:51Z</timestamp><text>{{Merge|duration}}
-
-{{DatatypeProperty
-| labels =
-{{label|en|runtime}}
-{{label|de|Laufzeit}}
-{{label|nl|duur}}
-{{label|el|διάρκεια}}
-{{label|fr|durée}}
-| rdfs:domain = Work
-| rdfs:range = Time
-| owl:equivalentProperty = wikidata:P2047
-| rdfs:subPropertyOf = schema:duration
-}}</text></revision></page><page><title>OntologyProperty:RunwayDesignation</title><ns>202</ns><id>4363</id><revision><id>14693</id><timestamp>2011-08-01T13:00:53Z</timestamp><text>{{DatatypeProperty
- |rdfs:label@en=designation of runway
- |rdfs:domain=Airport
- |rdfs:range=xsd:string
-}}</text></revision></page><page><title>OntologyProperty:RunwayLength</title><ns>202</ns><id>4362</id><revision><id>14691</id><timestamp>2011-08-01T12:56:04Z</timestamp><text>{{DatatypeProperty
- |rdfs:label@en=length of runway
- |rdfs:label@de=Start- und Landebahnlänge
- |rdfs:domain=Airport
- |rdfs:range=Length
-}}</text></revision></page><page><title>OntologyProperty:RunwaySurface</title><ns>202</ns><id>4364</id><revision><id>14695</id><timestamp>2011-08-01T13:04:05Z</timestamp><text>{{DatatypeProperty
- |rdfs:label@en=surface of runway
- |rdfs:domain=Airport
- |rdfs:range=xsd:string
-}}</text></revision></page><page><title>OntologyProperty:RunwayWidth</title><ns>202</ns><id>6676</id><revision><id>24606</id><timestamp>2013-03-27T02:30:00Z</timestamp><text>{{DatatypeProperty
- |rdfs:label@en=width of runway
- |rdfs:label@ja=滑走路の全幅
- |rdfs:domain=Airport
- |rdfs:range=Length
-}}</text></revision></page><page><title>OntologyProperty:RuralMunicipality</title><ns>202</ns><id>1391</id><revision><id>36495</id><timestamp>2014-07-08T14:16:21Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = rural municipality
-| rdfs:label@de = Landgemeinde
-| rdfs:domain = Road
-| rdfs:range = PopulatedPlace
-| rdfs:subPropertyOf = dul:hasLocation
-}}</text></revision></page><page><title>OntologyProperty:Saint</title><ns>202</ns><id>1392</id><revision><id>36496</id><timestamp>2014-07-08T14:16:23Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|saint}}
-	{{label|de|Heiliger}}
-	{{label|el|άγιος}}
-	{{label|nl|heilige}}
-	{{label|pt|santo}}
-| rdfs:domain = PopulatedPlace
-| rdfs:range = Saint
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:Salary</title><ns>202</ns><id>1393</id><revision><id>21509</id><timestamp>2012-12-30T12:54:17Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = salary
-| rdfs:label@el = μισθός
-| rdfs:label@de = Gehalt
-| rdfs:label@ja = 給料
-| rdfs:domain = Person
-| rdfs:range = Currency
-}}</text></revision></page><page><title>OntologyProperty:Sales</title><ns>202</ns><id>1394</id><revision><id>36497</id><timestamp>2014-07-08T14:16:27Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = sales
-| rdfs:label@de = Vertrieb
-| rdfs:label@el = πώληση
-| rdfs:label@fr = vente
-| rdfs:range = Sales
-| rdfs:comment@en = This property holds an intermediate node of the type Sales.
-| rdfs:subPropertyOf = dul:hasSetting
-}}</text></revision></page><page><title>OntologyProperty:SameName</title><ns>202</ns><id>6936</id><revision><id>34853</id><timestamp>2014-05-15T05:20:08Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|same name}}
-{{label|de|gleicher Name}}
-| rdfs:domain = Settlement
-| rdfs:range = rdf:langString
-}}</text></revision></page><page><title>OntologyProperty:SatScore</title><ns>202</ns><id>3138</id><revision><id>36498</id><timestamp>2014-07-08T14:16:30Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = SAT score
-| rdfs:comment@en = most recent average SAT scores
-| rdfs:domain = School
-| rdfs:subPropertyOf = dul:isClassifiedBy
-}}</text></revision></page><page><title>OntologyProperty:Satcat</title><ns>202</ns><id>11895</id><revision><id>52267</id><timestamp>2017-10-08T12:53:12Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = SATCAT
-| rdfs:label@sr = SATCAT
-| rdfs:label@de = SATCAT
-| rdfs:label@fr = SATCAT
-| rdfs:domain = SpaceMission
-| rdfs:range = xsd:string
-| comments =
-{{comment|en|satellite catalogue number, omit leading zeroes (e.g. 25544)}}
-}}</text></revision></page><page><title>OntologyProperty:Satellite</title><ns>202</ns><id>5644</id><revision><id>35734</id><timestamp>2014-07-07T08:32:49Z</timestamp><text>{{ DatatypeProperty
-
- 	| rdfs:label@en = satellite
-| rdfs:label@de = Satellit
-| labels =
-        {{label|el|δορυφόρος}}
-	| rdfs:domain = Planet
-	| rdfs:range = xsd:string
-
-}}</text></revision></page><page><title>OntologyProperty:SatellitesDeployed</title><ns>202</ns><id>1395</id><revision><id>10422</id><timestamp>2010-11-10T14:50:30Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = satellites deployed
-| rdfs:domain = SpaceShuttle
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:Scale</title><ns>202</ns><id>7080</id><revision><id>34209</id><timestamp>2014-04-04T16:37:30Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|scale}}
-{{label|de|Maßstab}}
-| rdfs:domain = Place
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:ScaleFactor</title><ns>202</ns><id>13821</id><revision><id>57154</id><timestamp>2022-03-15T11:48:19Z</timestamp><text>{{DatatypeProperty
-| labels =
-  {{label|en|scale factor}}
-  {{label|fr|facteur d'échelle}}
-| comments =
-  {{comment|en|Scale factor (ex: for images) to zoom out (value &gt; 1) or reduce (0 &lt; value &lt; 1) the proportions. Decimal numbers use dot séparator; ex : 0.75 }}
-  {{comment|fr|Facteur d'échelle (par exemple pour des images) pour aggrandir (valeur &gt; 1) ou réduire (0 &lt; valeur &lt; 1 les proportions. Pour les nombres décimaux, utiliser un point comme séparateur; ex : 0.75 }}
-| rdfs:range = xsd:float
-}}</text></revision></page><page><title>OntologyProperty:Scene</title><ns>202</ns><id>7758</id><revision><id>34210</id><timestamp>2014-04-04T16:37:34Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|scene}}
-{{label|de|Szene}}
-| rdfs:domain = Person
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:School</title><ns>202</ns><id>1396</id><revision><id>36499</id><timestamp>2014-07-08T14:16:33Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|school}}
-	{{label|nl|school}}
-	{{label|de|schule}}
-	{{label|it|scuola}}
-	{{label|el|σχολείο}}
-	{{label|fr|école}}
-| rdfs:domain = Person
-| rdfs:range = EducationalInstitution
-| comments =
-	{{comment|en|school a person goes or went to}}
-	{{comment|el|σχολείο στο οποίο πηγαίνει ή πήγε κάποιος}}
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:SchoolBoard</title><ns>202</ns><id>3123</id><revision><id>36500</id><timestamp>2014-07-08T14:16:36Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = school board
-| rdfs:domain = School
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:SchoolCode</title><ns>202</ns><id>1397</id><revision><id>52896</id><timestamp>2018-02-13T12:29:57Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = school code
-| rdfs:domain = School
-| rdfs:range = xsd:string
-| rdfs:subPropertyOf = code
-}}</text></revision></page><page><title>OntologyProperty:SchoolNumber</title><ns>202</ns><id>1398</id><revision><id>8259</id><timestamp>2010-05-28T13:40:18Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = school number
-| rdfs:domain = School
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:SchoolPatron</title><ns>202</ns><id>3122</id><revision><id>52932</id><timestamp>2018-03-01T11:15:33Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = school patron
-| rdfs:domain = School
-| rdfs:range = Agent
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:ScientificName</title><ns>202</ns><id>9285</id><revision><id>34211</id><timestamp>2014-04-04T16:37:50Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = scientific name
-| rdfs:label@de = wissenschaftlicher Name
-| rdfs:label@nl = wetenschappelijke naam
-| rdfs:domain = Species
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Score</title><ns>202</ns><id>10466</id><revision><id>51806</id><timestamp>2017-01-06T13:37:31Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = score
-| rdfs:comment@en = Score or points of something (eg a SportCompetitionResult)
-| rdfs:range = xsd:double
-}}</text></revision></page><page><title>OntologyProperty:ScreenActorsGuildAward</title><ns>202</ns><id>1400</id><revision><id>36502</id><timestamp>2014-07-08T14:16:41Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = Screen Actors Guild Award
-| rdfs:domain = Actor
-| rdfs:range = Award
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:Sea</title><ns>202</ns><id>6982</id><revision><id>56733</id><timestamp>2022-02-28T15:09:03Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|sea}}
-	{{label|de|Meer}}
-	{{label|fr|mer}}
-| rdfs:range = Sea
-| rdfs:domain = Place
-| rdfs:subPropertyOf = dul:nearTo
-}}</text></revision></page><page><title>OntologyProperty:Season</title><ns>202</ns><id>1401</id><revision><id>36504</id><timestamp>2014-07-08T14:16:50Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = season
-| rdfs:label@de = Saison
-| rdfs:label@el = σαιζόν
-| rdfs:domain = Agent
-| rdfs:subPropertyOf = dul:hasSetting
-}}</text></revision></page><page><title>OntologyProperty:SeasonManager</title><ns>202</ns><id>7829</id><revision><id>27142</id><timestamp>2013-07-05T15:25:42Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|season manager}}
-| rdfs:domain = Person
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:SeasonNumber</title><ns>202</ns><id>2105</id><revision><id>13659</id><timestamp>2011-06-14T14:16:34Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = season number
-| rdfs:domain = TelevisionEpisode
-| rdfs:range = xsd:nonNegativeInteger
-| rdfs:comment@en = The season number to which the TelevisionEpisode belongs.
-}}</text></revision></page><page><title>OntologyProperty:SeatNumber</title><ns>202</ns><id>6870</id><revision><id>49223</id><timestamp>2015-10-15T07:20:56Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|number of seats in the land parlement}}
-| rdfs:domain = AdministrativeRegion
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:SeatingCapacity</title><ns>202</ns><id>2528</id><revision><id>34214</id><timestamp>2014-04-04T16:38:09Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|seating capacity}}
-{{label|de|Sitzplatzkapazität}}
-{{label|nl|zitplaatsen}}
-| rdfs:domain = Building
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:Second</title><ns>202</ns><id>7891</id><revision><id>27396</id><timestamp>2013-07-10T15:23:31Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|second}}
-| rdfs:range = xsd:nonNegativeInteger
-| rdfs:domain = Person
-}}</text></revision></page><page><title>OntologyProperty:SecondCommander</title><ns>202</ns><id>1403</id><revision><id>36505</id><timestamp>2014-07-08T14:16:53Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = second commander
-| rdfs:label@de = zweiter Kommandant
-| rdfs:domain = MilitaryUnit
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:SecondDriver</title><ns>202</ns><id>1404</id><revision><id>36506</id><timestamp>2014-07-08T14:16:56Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = second driver
-| rdfs:label@de = zweiter Fahrer
-| rdfs:label@el = δεύτερος οδηγός
-| rdfs:label@it = secondo pilota
-| rdfs:domain = GrandPrix
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:hasParticipant
-}}</text></revision></page><page><title>OntologyProperty:SecondDriverCountry</title><ns>202</ns><id>1405</id><revision><id>36507</id><timestamp>2014-07-08T14:17:00Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = second driver country
-| rdfs:domain = GrandPrix
-| rdfs:range = Country
-| rdfs:subPropertyOf = dul:hasParticipant
-}}</text></revision></page><page><title>OntologyProperty:SecondLeader</title><ns>202</ns><id>3126</id><revision><id>36508</id><timestamp>2014-07-08T14:17:03Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|secondLeader}}
-	{{label|nl|vice-voorzitter}}
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:SecondPlace</title><ns>202</ns><id>8081</id><revision><id>34282</id><timestamp>2014-04-04T17:21:38Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|second place}}
-{{label|de|zweiter Platz}}
-| rdfs:domain = owl:Thing
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:SecondPopularVote</title><ns>202</ns><id>3128</id><revision><id>36509</id><timestamp>2014-07-08T14:17:06Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = secondPopularVote
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:SecondTeam</title><ns>202</ns><id>1406</id><revision><id>36510</id><timestamp>2014-07-08T14:17:10Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = second team
-| rdfs:label@de = zweites Team
-| rdfs:label@el = δεύτερη ομάδα
-| rdfs:domain = GrandPrix
-| rdfs:range = SportsTeam
-| rdfs:subPropertyOf = dul:hasParticipant
-}}</text></revision></page><page><title>OntologyProperty:SecretaryGeneral</title><ns>202</ns><id>3348</id><revision><id>36511</id><timestamp>2014-07-08T14:17:13Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|secretary}}
-	{{label|de|Sekretärin}}
-	{{label|nl|secretaris}}
-	{{label|pt|secretario}}
-| rdfs:domain = Organisation
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:Security</title><ns>202</ns><id>6428</id><revision><id>34954</id><timestamp>2014-05-24T07:26:48Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|security}}
-{{label|de|Sicherheit}}
-{{label|el|ασφάλεια}}
-| comments =
-{{comment|en|Safety precautions that are used in the building.}}
-{{comment|de|Sicherheitsmaßnahmen, die für das Gebäude getroffen wurden.}}
-{{comment|el|Μέτρα ασφαλείας για την προστασία ενός κτιρίου.}}
-| rdfs:domain = Building
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Seiyu</title><ns>202</ns><id>7772</id><revision><id>27063</id><timestamp>2013-07-05T08:03:43Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|seiyu}}
-| rdfs:domain = Person
-| rdfs:range = Person
-}}</text></revision></page><page><title>OntologyProperty:Selection</title><ns>202</ns><id>1407</id><revision><id>36512</id><timestamp>2014-07-08T14:17:27Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = selection
-| rdfs:label@de = Auswahl
-| rdfs:domain = Astronaut
-| rdfs:comment@en = when (or in which project) the person was selected to train as an astronaut
-| rdfs:subPropertyOf = dul:hasSetting
-}}</text></revision></page><page><title>OntologyProperty:SelectionPoint</title><ns>202</ns><id>7673</id><revision><id>26943</id><timestamp>2013-07-04T07:55:11Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|selection point}}
-| rdfs:range = xsd:nonNegativeInteger
-| rdfs:domain = Athlete
-}}</text></revision></page><page><title>OntologyProperty:SelectionYear</title><ns>202</ns><id>7672</id><revision><id>34221</id><timestamp>2014-04-04T16:39:01Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|selection year}}
-{{label|de|Auswahljahr}}
-| rdfs:range = xsd:string
-| rdfs:domain = Athlete
-}}</text></revision></page><page><title>OntologyProperty:SelibrId</title><ns>202</ns><id>8422</id><revision><id>52886</id><timestamp>2018-02-13T10:59:29Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|SELIBR Id}}
-| comments =
-{{comment|en|Authority data from the National Library of Sweden}}
-| rdfs:range = xsd:string
-| owl:equivalentProperty = wikidata:P906
-| rdfs:subPropertyOf = code
-}}</text></revision></page><page><title>OntologyProperty:Senator</title><ns>202</ns><id>3361</id><revision><id>36513</id><timestamp>2014-07-08T14:17:30Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = senator
-| rdfs:label@de = Senator
-| rdfs:label@pt = senador
-| rdfs:range = Person
-| rdfs:subPropertyOf = MemberOfParliament, dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:Senior</title><ns>202</ns><id>7256</id><revision><id>34280</id><timestamp>2014-04-04T17:20:32Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|senior}}
-| rdfs:domain = PopulatedPlace
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Seniority</title><ns>202</ns><id>2359</id><revision><id>8398</id><timestamp>2010-05-28T13:58:58Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = seniority
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Seniunija</title><ns>202</ns><id>7252</id><revision><id>25912</id><timestamp>2013-06-13T08:49:48Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|seniunija}}
-| rdfs:domain = PopulatedPlace
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Sentence</title><ns>202</ns><id>8029</id><revision><id>34224</id><timestamp>2014-04-04T16:39:26Z</timestamp><text>{{DatatypeProperty
-| labels = 
-{{label|en|sentence}}
-{{label|de|Satz}}
-| rdfs:domain = Person
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Series</title><ns>202</ns><id>1408</id><revision><id>52002</id><timestamp>2017-03-22T18:52:31Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|series}}
-	{{label|fr|série}}
-	{{label|de|Serie}}
-	{{label|nl|reeks}}
-	{{label|el|σειρά}}
-| rdfs:subPropertyOf = dul:isParticipantIn
-}}</text></revision></page><page><title>OntologyProperty:Service</title><ns>202</ns><id>1409</id><revision><id>52508</id><timestamp>2017-10-17T23:06:34Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = service
-| rdfs:label@de = Dienst
-| rdfs:domain = Organisation
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:ServiceEndDate</title><ns>202</ns><id>1410</id><revision><id>8263</id><timestamp>2010-05-28T13:40:47Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = service end date
-| rdfs:domain = MilitaryPerson
-| rdfs:range = xsd:date
-}}</text></revision></page><page><title>OntologyProperty:ServiceEndYear</title><ns>202</ns><id>1411</id><revision><id>8264</id><timestamp>2010-05-28T13:40:54Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = service end year
-| rdfs:domain = MilitaryPerson
-| rdfs:range = xsd:gYear
-}}</text></revision></page><page><title>OntologyProperty:ServiceModule</title><ns>202</ns><id>1412</id><revision><id>8265</id><timestamp>2010-05-28T13:41:02Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = service module
-| rdfs:domain = SpaceMission
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:ServiceNumber</title><ns>202</ns><id>1702</id><revision><id>8354</id><timestamp>2010-05-28T13:52:54Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = service number
-| rdfs:domain = MilitaryPerson
-| rdfs:comment@en =  The service number held by the individual during military service.
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:ServiceStartDate</title><ns>202</ns><id>1413</id><revision><id>8266</id><timestamp>2010-05-28T13:41:08Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = service start date
-| rdfs:domain = MilitaryPerson
-| rdfs:range = xsd:date
-}}</text></revision></page><page><title>OntologyProperty:ServiceStartYear</title><ns>202</ns><id>1414</id><revision><id>8267</id><timestamp>2010-05-28T13:41:18Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = service start year
-| rdfs:domain = MilitaryPerson
-| rdfs:range = xsd:gYear
-}}</text></revision></page><page><title>OntologyProperty:ServingRailwayLine</title><ns>202</ns><id>3227</id><revision><id>36516</id><timestamp>2014-07-08T14:17:38Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|serving railway line}}
-	{{label|nl|spoorlijnen}}
-	{{label|de|angebundene Eisenbahnlinie}}
-| rdfs:domain = Station
-| rdfs:range = owl:Thing
-| rdfs:comment@en = Railway services that serve the station.
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:ServingSize</title><ns>202</ns><id>11297</id><revision><id>48771</id><timestamp>2015-08-13T10:23:03Z</timestamp><text>{{DatatypeProperty
-| labels = 
-{{label|en|serving size}}
-| rdfs:domain = Food
-| rdfs:range = Mass
-| comments =
-{{comment|en|Default serving size (eg "100 g" for the standard 100 g serving size). approximateCalories apply to this serving size}}
-}}</text></revision></page><page><title>OntologyProperty:ServingTemperature</title><ns>202</ns><id>3931</id><revision><id>13669</id><timestamp>2011-06-16T14:53:01Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = serving temperature
-| rdfs:domain = Food
-| rdfs:range = xsd:string
-| rdfs:comment@en = Serving temperature for the food (e.g.: hot, cold, warm or room temperature).
-}}</text></revision></page><page><title>OntologyProperty:SessionNumber</title><ns>202</ns><id>3303</id><revision><id>12179</id><timestamp>2011-04-15T10:24:15Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = session number
-| rdfs:label@pt = número da sessão
-| rdfs:range = Event
-| rdfs:range = xsd:integer
-}}</text></revision></page><page><title>OntologyProperty:SetDesigner</title><ns>202</ns><id>5148</id><revision><id>36517</id><timestamp>2014-07-08T14:17:41Z</timestamp><text>
-{{ObjectProperty
-| rdfs:domain = Film
-| rdfs:range = Person
-| rdfs:label@en = set designer
-| rdfs:label@de = Bühnenbildner
-| rdfs:label@it = scenografo
-| rdfs:comment@en = the person who is responsible for the film set design
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:SettingOfPlay</title><ns>202</ns><id>3832</id><revision><id>13364</id><timestamp>2011-06-06T12:55:04Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = setting of play
-| rdfs:domain = Play
-| rdfs:range = xsd:string
-| rdfs:comment@en = The places and time where the play takes place.
-}}</text></revision></page><page><title>OntologyProperty:Settlement</title><ns>202</ns><id>6981</id><revision><id>36518</id><timestamp>2014-07-08T14:17:44Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|settlement}}
-	{{label|de|Siedlung}}
-	{{label|it|luogo abitato (insediamento)}}
-| rdfs:range = PopulatedPlace
-| rdfs:domain = Place
-| owl:equivalentProperty = wikidata:P131
-| rdfs:subPropertyOf = dul:hasLocation
-}}</text></revision></page><page><title>OntologyProperty:SettlementAttached</title><ns>202</ns><id>6846</id><revision><id>49218</id><timestamp>2015-10-15T07:16:19Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|settlement attached}}
-| rdfs:domain = Settlement
-| rdfs:range = Place
-}}</text></revision></page><page><title>OntologyProperty:SetupTime</title><ns>202</ns><id>2300</id><revision><id>8385</id><timestamp>2010-05-28T13:57:09Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = setup time
-| rdfs:range = Time
-}}</text></revision></page><page><title>OntologyProperty:SevereCases</title><ns>202</ns><id>12299</id><revision><id>53611</id><timestamp>2020-04-10T06:23:53Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|Severe Cases}}
-| rdfs:comment@en = Number of severe cases in a pandemic
-| rdfs:domain = Outbreak
-| rdfs:range = xsd:integer
-}}</text></revision></page><page><title>OntologyProperty:Sex</title><ns>202</ns><id>5275</id><revision><id>45543</id><timestamp>2015-03-08T10:48:10Z</timestamp><text>{{ DatatypeProperty
-
-	| rdfs:label@en = sex
-        | rdfs:label@el = φύλο
-        | rdfs:label@de = Geschlecht
-        | rdfs:label@fr = sexe
-	| rdfs:domain = Person
-	| rdfs:range = xsd:string
-        | owl:equivalentProperty = wikidata:P21
-
-}}</text></revision></page><page><title>OntologyProperty:SexualOrientation</title><ns>202</ns><id>3296</id><revision><id>36519</id><timestamp>2014-07-08T14:17:47Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = sexual orientation
-| rdfs:label@de = sexuelle Orientierung
-| rdfs:label@pt = orientação sexual
-| rdfs:domain = Person
-| rdfs:subPropertyOf = dul:hasQuality
-}}</text></revision></page><page><title>OntologyProperty:Shape</title><ns>202</ns><id>7076</id><revision><id>36520</id><timestamp>2014-07-08T14:17:51Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|intercommunality shape}}
-| rdfs:domain = Intercommunality
-| rdfs:range = Community
-| rdfs:subPropertyOf = dul:hasQuality
-}}</text></revision></page><page><title>OntologyProperty:ShareDate</title><ns>202</ns><id>1416</id><revision><id>11602</id><timestamp>2011-04-01T13:37:31Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = share date
-| rdfs:domain = Broadcaster
-| rdfs:range = xsd:gYearMonth
-}}</text></revision></page><page><title>OntologyProperty:ShareOfAudience</title><ns>202</ns><id>1415</id><revision><id>11326</id><timestamp>2011-03-30T14:36:46Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = share of audience
-| rdfs:label@de = Anteil der Zuschauer/Zuhörer
-| rdfs:domain = Broadcaster
-| rdfs:range = xsd:float
-}}</text></revision></page><page><title>OntologyProperty:ShareSource</title><ns>202</ns><id>1417</id><revision><id>11601</id><timestamp>2011-04-01T13:31:07Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = share source
-| rdfs:domain = Broadcaster
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:SharingOutPopulation</title><ns>202</ns><id>7233</id><revision><id>25889</id><timestamp>2013-06-12T13:32:29Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|sharing out population}}
-| rdfs:domain = PopulatedPlace
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:SharingOutPopulationYear</title><ns>202</ns><id>7234</id><revision><id>25890</id><timestamp>2013-06-12T13:33:14Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|sharing out year}}
-| rdfs:domain = PopulatedPlace
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Sheading</title><ns>202</ns><id>2140</id><revision><id>36521</id><timestamp>2014-07-08T14:17:55Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = sheading
-| rdfs:domain = PopulatedPlace
-| rdfs:range = PopulatedPlace
-| rdfs:subPropertyOf = dul:isPartOf
-}}</text></revision></page><page><title>OntologyProperty:ShipBeam</title><ns>202</ns><id>2265</id><revision><id>16601</id><timestamp>2012-01-15T22:32:27Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = ship beam
-| rdfs:comment@en = The beam of a ship is its width at the widest point.
-| rdfs:domain = Ship
-| rdfs:range = Length
-}}</text></revision></page><page><title>OntologyProperty:ShipCrew</title><ns>202</ns><id>4547</id><revision><id>36522</id><timestamp>2014-07-08T14:17:59Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = crew
-| rdfs:label@de = Crew
-| rdfs:range = Person
-| rdfs:domain = Ship
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:ShipDisplacement</title><ns>202</ns><id>2275</id><revision><id>34275</id><timestamp>2014-04-04T17:15:56Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = displacement
-| rdfs:label@de = Deplacement
-| rdfs:domain = Ship
-| rdfs:range = Mass
-| rdfs:comment@en = A ship's displacement is its mass at any given time.
-}}</text></revision></page><page><title>OntologyProperty:ShipDraft</title><ns>202</ns><id>2273</id><revision><id>34233</id><timestamp>2014-04-04T16:40:17Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = ship draft
-| rdfs:label@de = Schiffsentwurf
-| rdfs:domain = Ship
-| rdfs:range = Length
-| rdfs:comment@en = The draft (or draught) of a ship's hull is the vertical distance between the waterline and the bottom of the hull (keel), with the thickness of the hull included; in the case of not being included the draft outline would be obtained.
-}}</text></revision></page><page><title>OntologyProperty:ShipLaunch</title><ns>202</ns><id>3109</id><revision><id>11654</id><timestamp>2011-04-02T11:04:40Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en=ship launched
-| rdfs:domain = Ship
-| rdfs:range = xsd:date
-}}</text></revision></page><page><title>OntologyProperty:ShoeNumber</title><ns>202</ns><id>3291</id><revision><id>57277</id><timestamp>2022-03-28T22:08:09Z</timestamp><text>{{DatatypeProperty
-| labels =
-    {{label|en|shoe number}}
-    {{label|fr|pointure}}
-    {{label|nl|schoenmaat}}
-    {{label|pt|número do sapato}}
-| rdfs:domain = Person
-| rdfs:range = xsd:positiveInteger
-}}</text></revision></page><page><title>OntologyProperty:ShoeSize</title><ns>202</ns><id>7751</id><revision><id>56771</id><timestamp>2022-02-28T18:22:50Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|shoe size}}
-{{label|fr|pointure}}
-{{label|de|Schuhgröße}}
-{{label|nl|schoenmaat}}
-{{label|pt|número do sapato}}
-| rdfs:domain = Person
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Shoot</title><ns>202</ns><id>7780</id><revision><id>34277</id><timestamp>2014-04-04T17:18:01Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|shoot}}
-| rdfs:domain = Person
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Shoots</title><ns>202</ns><id>1418</id><revision><id>8271</id><timestamp>2010-05-28T13:41:48Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = shoots
-| rdfs:domain = IceHockeyPlayer
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:ShoreLength</title><ns>202</ns><id>1419</id><revision><id>50325</id><timestamp>2016-02-05T08:21:40Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = shore length
-| rdfs:label@de = Uferlänge
-| rdfs:label@el = μήκος_όχθης
-| rdfs:domain = BodyOfWater
-| rdfs:range = Length
-}}</text></revision></page><page><title>OntologyProperty:ShortProgCompetition</title><ns>202</ns><id>8068</id><revision><id>28231</id><timestamp>2013-09-04T09:12:13Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|short prog competition}}
-| rdfs:domain = Person
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:ShortProgScore</title><ns>202</ns><id>8067</id><revision><id>28230</id><timestamp>2013-09-04T09:11:35Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|short prog score}}
-| rdfs:domain = Person
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Show</title><ns>202</ns><id>1422</id><revision><id>36523</id><timestamp>2014-07-08T14:18:02Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = show
-| rdfs:label@de = Sendung
-| rdfs:label@fr = spectacle
-| rdfs:range = TelevisionShow
-| rdfs:subPropertyOf = dul:isParticipantIn
-}}</text></revision></page><page><title>OntologyProperty:ShowJudge</title><ns>202</ns><id>2103</id><revision><id>36524</id><timestamp>2014-07-08T14:18:05Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = showJudge
-| rdfs:domain = TelevisionShow
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:hasParticipant
-}}</text></revision></page><page><title>OntologyProperty:Shuttle</title><ns>202</ns><id>1423</id><revision><id>36525</id><timestamp>2014-07-08T14:18:08Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = shuttle
-| rdfs:domain = SpaceMission
-| rdfs:range = SpaceShuttle
-| rdfs:subPropertyOf = dul:hasParticipant
-}}</text></revision></page><page><title>OntologyProperty:Sibling</title><ns>202</ns><id>6692</id><revision><id>58794</id><timestamp>2022-05-31T15:18:40Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|sibling}}
-	{{label|nl|broer of zus}}
-	{{label|fr|frère ou soeur}}
-	{{label|de|Geschwister}}
-	{{label|ja|兄弟}}
-| rdfs:domain = Person
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:sameSettingAs
-| owl:equivalentProperty = wikidata:P3373
-}}</text></revision></page><page><title>OntologyProperty:SignName</title><ns>202</ns><id>6905</id><revision><id>34846</id><timestamp>2014-05-15T05:19:26Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|sign name of a hungarian settlement}}
-| rdfs:domain = HungarySettlement
-| rdfs:range = rdf:langString
-}}</text></revision></page><page><title>OntologyProperty:Signature</title><ns>202</ns><id>7560</id><revision><id>34239</id><timestamp>2014-04-04T16:40:42Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|signature}}
-{{label|de|Unterschrift}}
-| rdfs:domain = Person
-| rdfs:range = xsd:string
-| owl:equivalentProperty = wikidata:P109
-}}</text></revision></page><page><title>OntologyProperty:SignificantBuilding</title><ns>202</ns><id>1424</id><revision><id>36527</id><timestamp>2014-07-08T14:18:14Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = significant building
-| rdfs:label@de = bedeutendes Gebäude
-| rdfs:domain = Architect
-| rdfs:range = Building
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:SignificantDesign</title><ns>202</ns><id>1425</id><revision><id>36528</id><timestamp>2014-07-08T14:18:17Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = significant design
-| rdfs:label@de = bedeutendes Design
-| rdfs:domain = Architect
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:SignificantProject</title><ns>202</ns><id>1426</id><revision><id>36529</id><timestamp>2014-07-08T14:18:20Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = significant project
-| rdfs:label@de = bedeutendes Projekt
-| rdfs:label@pl = istotne osiągnięcie
-| rdfs:comment@en = A siginificant artifact constructed by the person.
-| rdfs:domain = Person
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:SilCode</title><ns>202</ns><id>3702</id><revision><id>36530</id><timestamp>2014-07-08T14:18:23Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|SIL code}}
-	{{label|nl|SIL-code}}
-	{{label|pl|kod SIL}}
-| rdfs:domain = Language
-| rdfs:subPropertyOf = LanguageCode, dul:isClassifiedBy
-}}</text></revision></page><page><title>OntologyProperty:SilverMedalDouble</title><ns>202</ns><id>7734</id><revision><id>50075</id><timestamp>2016-01-04T12:37:08Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|silver medal double}}
-{{label|de|Silbermedaille Doppel}}
-| rdfs:domain = TennisPlayer
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:SilverMedalMixed</title><ns>202</ns><id>7737</id><revision><id>50076</id><timestamp>2016-01-04T12:37:51Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|silver medal mixed}}
-{{label|de|Silbermedaille gemischt}}
-| rdfs:domain = TennisPlayer
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:SilverMedalSingle</title><ns>202</ns><id>7731</id><revision><id>50077</id><timestamp>2016-01-04T12:38:32Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|silver medal single}}
-{{label|de|Silbermedaille Einzel}}
-| rdfs:domain = TennisPlayer
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:SilverMedalist</title><ns>202</ns><id>5667</id><revision><id>36531</id><timestamp>2014-07-08T14:18:25Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = siler medalist
-| rdfs:label@de = Silbermedaillengewinner
-| rdfs:label@pt = medalha de prata
-| rdfs:label@nl = zilveren medaille drager
-| rdfs:domain = SportsEvent
-| rdfs:range = Person
-| rdfs:subPropertyOf = Medalist, dul:hasParticipant
-}}</text></revision></page><page><title>OntologyProperty:SimcCode</title><ns>202</ns><id>3403</id><revision><id>52928</id><timestamp>2018-02-28T08:38:07Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = SIMC code
-| rdfs:domain = PopulatedPlace
-| rdfs:comment@en = indexing code used by the Polish National Official Register of the Territorial Division of the Country (TERYT) to identify various entities
-| rdfs:subPropertyOf = code
-| owl:equivalentProperty = dul:isClassifiedBy 
-| rdfs:comment@en = Should be a datatype property
-}}</text></revision></page><page><title>OntologyProperty:Similar</title><ns>202</ns><id>1427</id><revision><id>36533</id><timestamp>2014-07-08T14:18:34Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = similar
-| rdfs:label@de = ähnlich
-| rdfs:label@el = παρόμοιος
-| rdfs:label@pl = podobny
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:SingleList</title><ns>202</ns><id>13818</id><revision><id>57131</id><timestamp>2022-03-14T17:38:10Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|list of singles}}
-	{{label|fr|liste de singles}}
-| comments =
-	{{comment|en|set of singles}}
-	{{comment|fr|suite de disques 45tours}}
-| rdfs:domain = Album
-| rdfs:range = SingleList
-}}</text></revision></page><page><title>OntologyProperty:SingleOf</title><ns>202</ns><id>13817</id><revision><id>57194</id><timestamp>2022-03-18T13:56:18Z</timestamp><text>{{ObjectProperty
-| labels= 
-  {{label|en|singleOf}}
-  {{label|fr|single extrait}}
-| rdfs:domain = SingleList
-| rdfs:range = Work
-| comments =
-  {{comment|en|single produced from an album}}
-  {{comment|fr|single extrait d'un album}}
-}}</text></revision></page><page><title>OntologyProperty:Sire</title><ns>202</ns><id>6171</id><revision><id>36534</id><timestamp>2014-07-08T14:18:37Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|sire}}
-| rdfs:domain = Animal
-| rdfs:range = Animal
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:Siren</title><ns>202</ns><id>7073</id><revision><id>25593</id><timestamp>2013-05-26T12:15:44Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|siren number}}
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:Sister</title><ns>202</ns><id>12289</id><revision><id>53583</id><timestamp>2020-01-30T10:19:55Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|sister}}
-	{{label|nl|zus}}
-	{{label|de|Schwester}}
-	{{label|el|αδελφή}}
-	{{label|ja|シスター}}
-	{{label|ar|أخت}}
-| rdfs:domain = Woman
-| rdfs:range = Person 
-| owl:propertyDisjointWith = parent
-}}</text></revision></page><page><title>OntologyProperty:SisterCollege</title><ns>202</ns><id>1428</id><revision><id>36535</id><timestamp>2014-07-08T14:18:40Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = sister college
-| rdfs:domain = College
-| rdfs:range = College
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:SisterNewspaper</title><ns>202</ns><id>1429</id><revision><id>36536</id><timestamp>2014-07-08T14:18:43Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = sister newspaper
-| rdfs:domain = Newspaper
-| rdfs:range = Newspaper
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:SisterStation</title><ns>202</ns><id>1430</id><revision><id>36537</id><timestamp>2014-07-08T14:18:47Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = sister station
-| rdfs:domain = Broadcaster
-| rdfs:range = Broadcaster
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:SixthFormStudents</title><ns>202</ns><id>1431</id><revision><id>34248</id><timestamp>2014-04-04T16:41:18Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = sixth form students
-| rdfs:label@de = Schüler der Oberstufe
-| rdfs:domain = School
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:SizeBlazon</title><ns>202</ns><id>7563</id><revision><id>26777</id><timestamp>2013-07-01T14:46:40Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|size blazon}}
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:SizeLogo</title><ns>202</ns><id>7070</id><revision><id>25588</id><timestamp>2013-05-26T12:01:16Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|size logo}}
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:SizeMap</title><ns>202</ns><id>6993</id><revision><id>34249</id><timestamp>2014-04-04T16:41:23Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|size map}}
-{{label|de|Größe der Karte}}
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:SizeThumbnail</title><ns>202</ns><id>6901</id><revision><id>26897</id><timestamp>2013-07-03T10:17:41Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|size thumbnail}}
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Size v</title><ns>202</ns><id>6139</id><revision><id>46215</id><timestamp>2015-03-18T11:03:58Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = size_v
-| rdfs:label@el = μέγεθος
-| rdfs:domain = Openswarm
-| rdfs:range = xsd:integer
-}}</text></revision></page><page><title>OntologyProperty:SkiLift</title><ns>202</ns><id>7189</id><revision><id>34250</id><timestamp>2014-04-04T16:41:27Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|ski lift}}
-{{label|de|Skilift}}
-| rdfs:domain = Place
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:SkiPisteKilometre</title><ns>202</ns><id>7197</id><revision><id>34251</id><timestamp>2014-04-04T16:41:30Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|ski piste kilometre}}
-{{label|de|Skipiste km}}
-| rdfs:domain = Place
-| rdfs:range = Length
-}}</text></revision></page><page><title>OntologyProperty:SkiPisteNumber</title><ns>202</ns><id>7192</id><revision><id>34252</id><timestamp>2014-04-04T16:41:34Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|ski piste number}}
-{{label|de|Skipistennummer}}
-| rdfs:domain = Place
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:SkiTow</title><ns>202</ns><id>7190</id><revision><id>25740</id><timestamp>2013-06-01T13:19:41Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|ski tow}}
-| rdfs:domain = Place
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:Skills</title><ns>202</ns><id>6557</id><revision><id>36538</id><timestamp>2014-07-08T14:18:51Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|skills}}
-	{{label|de|Fähigkeiten}}
-	{{label|fr|compétences}}
-	{{label|nl|bekwaamheden}}
-| rdfs:subPropertyOf = dul:isDescribedBy
-}}</text></revision></page><page><title>OntologyProperty:SkinColor</title><ns>202</ns><id>10478</id><revision><id>56772</id><timestamp>2022-02-28T18:24:32Z</timestamp><text>{{DatatypeProperty
-| labels =
-    {{label|en|skin color}}
-    {{label|fr|couleur de peau}}
-| rdfs:domain = Person
-| rdfs:range = xsd:string
-&lt;!-- | rdfs:subPropertyOf = dul:hasQuality commented, dul:hasQuality defined as object property, see https://github.com/dbpedia/ontology-tracker/issues/9 --&gt;
-}}</text></revision></page><page><title>OntologyProperty:Skos:broader</title><ns>202</ns><id>1625</id><revision><id>24758</id><timestamp>2013-04-05T08:00:06Z</timestamp><text>{{ObjectProperty
-|rdfs:label@en		= broader
-|rdfs:label@de		= weiter
-|rdfs:label@it		= più ampio
-}}</text></revision></page><page><title>OntologyProperty:Skos:notation</title><ns>202</ns><id>11069</id><revision><id>49121</id><timestamp>2015-10-10T20:51:09Z</timestamp><text>{{DatatypeProperty
-|rdfs:label@en		= notation
-|rdfs:label@fr		= notation
-|rdfs:domain		= Work
-|rdfs:range		= xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Skos:prefLabel</title><ns>202</ns><id>1627</id><revision><id>34812</id><timestamp>2014-05-14T11:25:32Z</timestamp><text>{{DatatypeProperty
-|rdfs:label@en		= prefLabel
-|rdfs:label@de		= bevorzugtes Label
-|rdfs:label@it		= Label preferito
-|rdfs:range		= rdf:langString
-}}</text></revision></page><page><title>OntologyProperty:Skos:related</title><ns>202</ns><id>2906</id><revision><id>34254</id><timestamp>2014-04-04T16:41:42Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|related}}
-{{label|de|verbunden}}
-{{label|nl|gerelateerd}}
-}}</text></revision></page><page><title>OntologyProperty:Skos:subject</title><ns>202</ns><id>1628</id><revision><id>50332</id><timestamp>2016-02-12T14:07:12Z</timestamp><text>Wrong property!!!, use dct:subject
-&lt;!--
-{{ObjectProperty
-|rdfs:label@en = subject
-|rdfs:label@de = subjekt
-|rdfs:label@it = soggetto
-|rdfs:comment@en = DEPRECATED
-}}--&gt;</text></revision></page><page><title>OntologyProperty:Slogan</title><ns>202</ns><id>1434</id><revision><id>43333</id><timestamp>2015-02-06T15:06:44Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|slogan}}
-{{label|nl|slogan}}
-{{label|de|Slogan}}
-{{label|bg|Девиз}}
-
-| rdfs:range = rdf:langString
-}}</text></revision></page><page><title>OntologyProperty:Smiles</title><ns>202</ns><id>8170</id><revision><id>28750</id><timestamp>2013-11-20T11:16:18Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = SMILES
-| rdfs:domain = ChemicalCompound
-| rdfs:range = xsd:string
-| rdfs:comment@en = The Simplified Molecular-Input Line-Entry System or SMILES is a specification in form of a line notation for describing the structure of chemical molecules using short ASCII strings.
-}}</text></revision></page><page><title>OntologyProperty:SnowParkNumber</title><ns>202</ns><id>7198</id><revision><id>25748</id><timestamp>2013-06-01T13:23:16Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|snow park number}}
-| rdfs:domain = Place
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:SoccerLeaguePromoted</title><ns>202</ns><id>4573</id><revision><id>36540</id><timestamp>2014-07-08T14:18:57Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = promoted
-| rdfs:label@tr = yükselenler
-| rdfs:domain = SoccerLeagueSeason
-| rdfs:range = SportsTeam
-| rdfs:subPropertyOf = dul:isSettingFor
-}}</text></revision></page><page><title>OntologyProperty:SoccerLeagueRelegated</title><ns>202</ns><id>4574</id><revision><id>36541</id><timestamp>2014-07-08T14:19:00Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = relegated teams
-| rdfs:label@de = Absteiger
-| rdfs:label@tr = düşenler
-| rdfs:domain = SoccerLeagueSeason
-| rdfs:range = SportsTeam
-| rdfs:subPropertyOf = dul:isSettingFor
-}}</text></revision></page><page><title>OntologyProperty:SoccerLeagueSeason</title><ns>202</ns><id>4575</id><revision><id>36542</id><timestamp>2014-07-08T14:19:04Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = season
-| rdfs:label@de = Saison
-| rdfs:label@tr = sezon
-| rdfs:domain = SoccerLeagueSeason
-| rdfs:range = SoccerLeagueSeason
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:SoccerLeagueWinner</title><ns>202</ns><id>4572</id><revision><id>36543</id><timestamp>2014-07-08T14:19:07Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = league champion
-| rdfs:label@de = Liga-Meister
-| rdfs:label@tr = şampiyon
-| rdfs:domain = SoccerLeagueSeason
-| rdfs:range = SportsTeam
-| rdfs:subPropertyOf = dul:isSettingFor
-}}</text></revision></page><page><title>OntologyProperty:SoccerTournamentClosingSeason</title><ns>202</ns><id>4579</id><revision><id>36544</id><timestamp>2014-07-08T14:19:11Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = closing season
-| rdfs:label@tr = kapanış sezonu
-| rdfs:domain = SoccerTournament
-| rdfs:range = SoccerTournament
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:SoccerTournamentLastChampion</title><ns>202</ns><id>4581</id><revision><id>36545</id><timestamp>2014-07-08T14:19:15Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = last champion
-| rdfs:label@de = letzter Sieger
-| rdfs:label@tr = son şampiyon
-| rdfs:domain = SoccerTournament
-| rdfs:range = SoccerClub
-| rdfs:subPropertyOf = dul:isSettingFor
-}}</text></revision></page><page><title>OntologyProperty:SoccerTournamentMostSteady</title><ns>202</ns><id>4583</id><revision><id>36546</id><timestamp>2014-07-08T14:19:19Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = most steady
-| rdfs:label@tr = en istikrarlı
-| rdfs:domain = SoccerTournament
-| rdfs:range = SoccerClub
-| rdfs:subPropertyOf = dul:isSettingFor
-}}</text></revision></page><page><title>OntologyProperty:SoccerTournamentMostSuccesfull</title><ns>202</ns><id>4582</id><revision><id>36547</id><timestamp>2014-07-08T14:19:22Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = most successfull
-| rdfs:label@de = am erfolgreichsten
-| rdfs:label@tr = en başarılı
-| rdfs:domain = SoccerTournament
-| rdfs:range = SoccerClub
-| rdfs:subPropertyOf = dul:isSettingFor
-}}</text></revision></page><page><title>OntologyProperty:SoccerTournamentOpeningSeason</title><ns>202</ns><id>4578</id><revision><id>36548</id><timestamp>2014-07-08T14:19:36Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = opening season
-| rdfs:label@tr = açılış sezonu
-| rdfs:domain = SoccerTournament
-| rdfs:range = SoccerTournament
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:SoccerTournamentThisSeason</title><ns>202</ns><id>4580</id><revision><id>36549</id><timestamp>2014-07-08T14:19:39Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = this season
-| rdfs:label@tr = bu sezon
-| rdfs:domain = SoccerTournament
-| rdfs:range = SoccerTournament
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:SoccerTournamentTopScorer</title><ns>202</ns><id>4584</id><revision><id>36550</id><timestamp>2014-07-08T14:19:41Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = top scorer
-| rdfs:label@de = Torschützenkönig
-| rdfs:label@tr = en golcü
-| rdfs:domain = SoccerTournament
-| rdfs:range = SoccerPlayer
-| rdfs:subPropertyOf = dul:hasParticipant
-}}</text></revision></page><page><title>OntologyProperty:SolicitorGeneral</title><ns>202</ns><id>6602</id><revision><id>36551</id><timestamp>2014-07-08T14:19:44Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|solicitor general}}
-	{{label|de|Generalstaatsanwalt}}
-	{{label|nl|advocaat-generaal}}
-| comments =
-	{{comment|en|high-ranking solicitor }}
-	{{comment|nl|de advocaat-generaal}}
-| rdfs:domain = LegalCase
-| rdfs:range = Person
-| rdf:type = | rdfs:subPropertyOf     = personFunction
-| owl:equivalentProperty = 
-| rdfs:subPropertyOf = dul:isSettingFor
-}}</text></revision></page><page><title>OntologyProperty:Solubility</title><ns>202</ns><id>8927</id><revision><id>34264</id><timestamp>2014-04-04T16:42:33Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = solubility
-| rdfs:label@de = Löslichkeit
-| rdfs:label@nl = oplosbaarheid
-| rdfs:domain = ChemicalSubstance
-| rdfs:range = xsd:integer
-}}</text></revision></page><page><title>OntologyProperty:Solvent</title><ns>202</ns><id>12045</id><revision><id>52801</id><timestamp>2018-02-07T19:13:49Z</timestamp><text>{{ObjectProperty
-| rdfs:label@en = solvent
-| rdfs:label@de = Lösungsmittel
-| rdfs:domain = ChemicalSubstance
-| rdfs:range = ChemicalSubstance
-}}</text></revision></page><page><title>OntologyProperty:SolventWithBadSolubility</title><ns>202</ns><id>8930</id><revision><id>34265</id><timestamp>2014-04-04T16:42:37Z</timestamp><text>{{ObjectProperty
-| rdfs:label@en = solvent with bad solubility
-| rdfs:label@de = Lösungsmittel mit schlechter Löslichkeit
-| rdfs:label@nl = slecht oplosbaar in
-| rdfs:domain = ChemicalSubstance
-| rdfs:range = ChemicalSubstance
-}}</text></revision></page><page><title>OntologyProperty:SolventWithGoodSolubility</title><ns>202</ns><id>8928</id><revision><id>34266</id><timestamp>2014-04-04T16:42:41Z</timestamp><text>{{ObjectProperty
-| rdfs:label@en = solvent with good solubility
-| rdfs:label@de = Lösungsmittel mit guter Löslichkeit
-| rdfs:label@nl = goed oplosbaar in
-| rdfs:domain = ChemicalSubstance
-| rdfs:range = ChemicalSubstance
-}}</text></revision></page><page><title>OntologyProperty:SolventWithMediocreSolubility</title><ns>202</ns><id>8931</id><revision><id>34267</id><timestamp>2014-04-04T16:42:45Z</timestamp><text>{{ObjectProperty
-| rdfs:label@en = solvent with mediocre solubility
-| rdfs:label@de = Lösungsmittel mit mittelmäßiger Löslichkeit
-| rdfs:label@nl = matig oplosbaar in
-| rdfs:domain = ChemicalSubstance
-| rdfs:range = ChemicalSubstance
-}}</text></revision></page><page><title>OntologyProperty:Son</title><ns>202</ns><id>12290</id><revision><id>53586</id><timestamp>2020-01-30T18:19:07Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|son}}
-	{{label|nl|zoon}}
-	{{label|de|Sohn}}
-	{{label|el|υιός}}
-	{{label|ja|息子}}
-	{{label|ar|ابن}}
-| rdfs:domain = Man
-| rdfs:range = Person
-| owl:propertyDisjointWith = parent
-}}</text></revision></page><page><title>OntologyProperty:SoundRecording</title><ns>202</ns><id>11030</id><revision><id>45356</id><timestamp>2015-02-16T09:14:28Z</timestamp><text>{{ObjectProperty
-| labels =
-  {{label|en|sound recording}}
-| rdfs:range = Sound
-| rdfs:comment@en = Sound recording somehow related to the subject
-}}</text></revision></page><page><title>OntologyProperty:Source</title><ns>202</ns><id>1704</id><revision><id>53708</id><timestamp>2020-09-04T15:38:08Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = source
-| rdfs:label@de = Quelle
-| rdfs:label@el = πηγή
-| rdfs:subPropertyOf = dul:hasCommonBoundary
-| owl:equivalentProperty = ceo:bronidentificatie
-}}</text></revision></page><page><title>OntologyProperty:SourceConfluence</title><ns>202</ns><id>1437</id><revision><id>36553</id><timestamp>2014-07-08T14:19:51Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = source confluence
-| rdfs:label@es = lugar de nacimiento
-| rdfs:label@el = πηγές
-| rdfs:domain = River
-| rdfs:subPropertyOf = dul:hasCommonBoundary
-}}</text></revision></page><page><title>OntologyProperty:SourceConfluenceCountry</title><ns>202</ns><id>1438</id><revision><id>36554</id><timestamp>2014-07-08T14:19:54Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = source confluence country
-| rdfs:domain = River
-| rdfs:range = Country
-| rdfs:subPropertyOf = dul:hasLocation
-}}</text></revision></page><page><title>OntologyProperty:SourceConfluenceElevation</title><ns>202</ns><id>1439</id><revision><id>8276</id><timestamp>2010-05-28T13:42:27Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = source confluence elevation
-| rdfs:range = Length
-}}</text></revision></page><page><title>OntologyProperty:SourceConfluenceMountain</title><ns>202</ns><id>1440</id><revision><id>36555</id><timestamp>2014-07-08T14:19:57Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = source confluence mountain
-| rdfs:domain = River
-| rdfs:range = Mountain
-| rdfs:subPropertyOf = dul:nearTo
-}}</text></revision></page><page><title>OntologyProperty:SourceConfluencePlace</title><ns>202</ns><id>1441</id><revision><id>36556</id><timestamp>2014-07-08T14:20:00Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = source confluence place
-| rdfs:domain = River
-| rdfs:range = Place
-| rdfs:subPropertyOf = dul:hasLocation
-}}</text></revision></page><page><title>OntologyProperty:SourceConfluencePosition</title><ns>202</ns><id>1442</id><revision><id>36557</id><timestamp>2014-07-08T14:20:03Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = source confluence position
-| rdfs:domain = River
-| rdfs:range = geo:SpatialThing
-| rdfs:subPropertyOf = dul:hasLocation
-}}</text></revision></page><page><title>OntologyProperty:SourceConfluenceRegion</title><ns>202</ns><id>1443</id><revision><id>36558</id><timestamp>2014-07-08T14:20:06Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = source confluence region
-| rdfs:domain = River
-| rdfs:range = Place
-| rdfs:subPropertyOf = dul:hasLocation
-}}</text></revision></page><page><title>OntologyProperty:SourceConfluenceState</title><ns>202</ns><id>1444</id><revision><id>36559</id><timestamp>2014-07-08T14:20:09Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = source confluence state
-| rdfs:domain = River
-| rdfs:range = PopulatedPlace
-| rdfs:subPropertyOf = dul:hasLocation
-}}</text></revision></page><page><title>OntologyProperty:SourceCountry</title><ns>202</ns><id>1445</id><revision><id>52930</id><timestamp>2018-02-28T09:04:07Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = source country
-| rdfs:domain = Stream
-| rdfs:range = Country
-| owl:equivalentProperty = dul:hasLocation
-}}</text></revision></page><page><title>OntologyProperty:SourceDistrict</title><ns>202</ns><id>1446</id><revision><id>36561</id><timestamp>2014-07-08T14:20:15Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = source district
-| rdfs:range = PopulatedPlace
-| rdfs:subPropertyOf = dul:hasLocation
-}}</text></revision></page><page><title>OntologyProperty:SourceElevation</title><ns>202</ns><id>1447</id><revision><id>8277</id><timestamp>2010-05-28T13:42:36Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = source elevation
-| rdfs:range = Length
-}}</text></revision></page><page><title>OntologyProperty:SourceMountain</title><ns>202</ns><id>1448</id><revision><id>36562</id><timestamp>2014-07-08T14:20:18Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = source mountain
-| rdfs:range = Mountain
-| rdfs:subPropertyOf = dul:hasLocation
-}}</text></revision></page><page><title>OntologyProperty:SourceName</title><ns>202</ns><id>13120</id><revision><id>54894</id><timestamp>2021-07-26T04:03:09Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|Source Name}}
-| comments =
-	{{comment|en|VaccinationStatistics: Source Authority name.}}
-| rdfs:domain = owl:Thing
-| rdfs:range = VaccinationStatistics
-}}</text></revision></page><page><title>OntologyProperty:SourcePlace</title><ns>202</ns><id>1449</id><revision><id>36563</id><timestamp>2014-07-08T14:20:21Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = source place
-| rdfs:range = PopulatedPlace
-| rdfs:subPropertyOf = dul:hasLocation
-}}</text></revision></page><page><title>OntologyProperty:SourcePosition</title><ns>202</ns><id>1450</id><revision><id>36564</id><timestamp>2014-07-08T14:20:25Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = source position
-| rdfs:range = geo:SpatialThing
-| rdfs:subPropertyOf = dul:hasLocation
-}}</text></revision></page><page><title>OntologyProperty:SourceRegion</title><ns>202</ns><id>1451</id><revision><id>36565</id><timestamp>2014-07-08T14:20:28Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = source region
-| rdfs:range = PopulatedPlace
-| rdfs:subPropertyOf = dul:hasLocation
-}}</text></revision></page><page><title>OntologyProperty:SourceState</title><ns>202</ns><id>1452</id><revision><id>36566</id><timestamp>2014-07-08T14:20:32Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = source state
-| rdfs:range = PopulatedPlace
-| rdfs:subPropertyOf = dul:hasLocation
-}}</text></revision></page><page><title>OntologyProperty:SourceText</title><ns>202</ns><id>10419</id><revision><id>39423</id><timestamp>2015-01-19T17:02:05Z</timestamp><text>{{DatatypeProperty
-| labels=
-{{label|en|sourceText}}
-| comments=
-{{comment|en|Source of something (eg an image) as text. Use dct:source if the source is described using a resource}}
-| rdfs:domain = owl:Thing
-| rdfs:range = rdf:langString
-}}</text></revision></page><page><title>OntologyProperty:SourceWebsite</title><ns>202</ns><id>13121</id><revision><id>54895</id><timestamp>2021-07-26T04:05:37Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|Source Website}}
-| comments =
-	{{comment|en|VaccinationStatistics: source website.}}
-| rdfs:domain = owl:Thing
-| rdfs:range = VaccinationStatistics
-}}</text></revision></page><page><title>OntologyProperty:SouthEastPlace</title><ns>202</ns><id>11088</id><revision><id>45596</id><timestamp>2015-03-08T14:10:40Z</timestamp><text>{{ObjectProperty
-| rdfs:label@en = south-east place
-| rdfs:label@fr = lieu au sud-est
-| rdfs:comment@fr = indique un autre lieu situé au sud-est.
-| rdfs:comment@en = indicates another place situated south-east.
-| rdfs:domain = Place
-| rdfs:range = Place
-| owl:inverseOf = northWestPlace
-| rdfs:subPropertyOf = closeTo
-
-}}</text></revision></page><page><title>OntologyProperty:SouthPlace</title><ns>202</ns><id>11083</id><revision><id>45594</id><timestamp>2015-03-08T14:08:55Z</timestamp><text>{{ObjectProperty
-| rdfs:label@en = south place
-| rdfs:label@fr = lieu au sud
-| rdfs:comment@fr = indique un autre lieu situé au sud.
-| rdfs:comment@en = indicates another place situated south.
-| rdfs:domain = Place
-| rdfs:range = Place
-| owl:inverseOf = northPlace
-| rdfs:subPropertyOf = closeTo
-}}</text></revision></page><page><title>OntologyProperty:SouthWestPlace</title><ns>202</ns><id>11090</id><revision><id>45595</id><timestamp>2015-03-08T14:09:48Z</timestamp><text>{{ObjectProperty
-| rdfs:label@en = south-west place
-| rdfs:label@fr = lieu au sud-ouest
-| rdfs:comment@fr = indique un autre lieu situé au sud-ouest.
-| rdfs:comment@en = indicates another place situated south-west.
-| rdfs:domain = Place
-| rdfs:range = Place
-| owl:inverseOf = northEastPlace
-| rdfs:subPropertyOf = closeTo
-
-}}</text></revision></page><page><title>OntologyProperty:SovereignCountry</title><ns>202</ns><id>7054</id><revision><id>36567</id><timestamp>2014-07-08T14:20:35Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|sovereign country}}
-	{{label|de|souveräner Staat}}
-| rdfs:domain = Place
-| rdfs:range = PopulatedPlace
-| rdfs:subPropertyOf = dul:isPartOf
-}}</text></revision></page><page><title>OntologyProperty:Space</title><ns>202</ns><id>6427</id><revision><id>23469</id><timestamp>2013-01-22T13:09:07Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|space}}
-{{label|de|Raum}}
-| rdfs:domain = Building
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:Spacecraft</title><ns>202</ns><id>1453</id><revision><id>36568</id><timestamp>2014-07-08T14:20:38Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = spacecraft
-| rdfs:label@de = Raumfahrzeug
-| rdfs:label@el = διαστημόπλοιο
-| rdfs:label@fr = véhicule spatial
-| rdfs:domain = SpaceMission
-| rdfs:range = Spacecraft
-| rdfs:subPropertyOf = dul:hasParticipant
-}}</text></revision></page><page><title>OntologyProperty:Spacestation</title><ns>202</ns><id>10461</id><revision><id>39724</id><timestamp>2015-01-27T16:48:28Z</timestamp><text>{{ObjectProperty
-| labels =
-  {{label|en|spacestation}}
-  {{label|de|raumstation}}
-| comments =
-  {{comment|en|space station that has been visited during a space mission}}
-  {{comment|de|Raumstation, die während einer Raummission besucht wurde}}
-| rdfs:domain = SpaceMission
-| rdfs:range = SpaceStation
-}}</text></revision></page><page><title>OntologyProperty:SpacewalkBegin</title><ns>202</ns><id>1454</id><revision><id>34308</id><timestamp>2014-04-08T13:36:12Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = spacewalk begin
-| rdfs:label@de = Beginn Weltraumspaziergang
-| rdfs:domain = SpaceMission
-| rdfs:range = xsd:date
-}}</text></revision></page><page><title>OntologyProperty:SpacewalkEnd</title><ns>202</ns><id>1455</id><revision><id>34309</id><timestamp>2014-04-08T13:36:15Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = spacewalk end
-| rdfs:label@de = Ende Weltraumspaziergang
-| rdfs:domain = SpaceMission
-| rdfs:range = xsd:date
-}}</text></revision></page><page><title>OntologyProperty:Speaker</title><ns>202</ns><id>2358</id><revision><id>34460</id><timestamp>2014-04-08T14:49:29Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = speaker
-| rdfs:comment@en = number of office holder
-| rdfs:range = xsd:integer
-}}</text></revision></page><page><title>OntologyProperty:SpecialEffects</title><ns>202</ns><id>5147</id><revision><id>36569</id><timestamp>2014-07-08T14:20:41Z</timestamp><text>
-{{ObjectProperty
-| rdfs:domain = Film
-| rdfs:range = Person
-| rdfs:label@en = special effects
-| rdfs:label@de = Spezialeffekte
-| rdfs:comment@en = the person who is responsible for the film special effects
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:SpecialTrial</title><ns>202</ns><id>7889</id><revision><id>27394</id><timestamp>2013-07-10T15:23:18Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|special trial}}
-| rdfs:range = xsd:nonNegativeInteger
-| rdfs:domain = Person
-}}</text></revision></page><page><title>OntologyProperty:Specialist</title><ns>202</ns><id>1456</id><revision><id>52296</id><timestamp>2017-10-08T19:37:56Z</timestamp><text>{{ObjectProperty
-| rdfs:label@en = specialist
-| rdfs:label@de = Spezialist
-| rdfs:domain = owl:Thing
-| rdfs:range = PersonFunction
-}}</text></revision></page><page><title>OntologyProperty:Speciality</title><ns>202</ns><id>7700</id><revision><id>34313</id><timestamp>2014-04-08T13:36:34Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|speciality}}
-{{label|de|Spezialität}}
-| rdfs:domain = Person
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Specialization</title><ns>202</ns><id>11904</id><revision><id>52290</id><timestamp>2017-10-08T19:15:30Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|specialization}}
-	{{label|de|Spezialisierung}}
-| comments =
-	{{comment|en|Points out the subject or thing someone or something is specialized in (for).}}
-	{{comment|de|Verweist of den Gegenstand (auch fig.) auf welchen jemand oder etwas spezialisiert ist.}}
-| rdfs:domain = owl:Thing
-| rdfs:range = owl:Thing
-}}</text></revision></page><page><title>OntologyProperty:Species</title><ns>202</ns><id>1457</id><revision><id>52016</id><timestamp>2017-04-07T09:29:00Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|species}}
-	{{label|de|Spezies}}
-	{{label|nl|soort}}
-	{{label|ja|種_(分類学) }}
-	{{label|fr|espèce}}
-| rdfs:domain = Species
-| rdfs:range = Species
-| rdfs:subPropertyOf = dul:specializes
-}}</text></revision></page><page><title>OntologyProperty:SpeedLimit</title><ns>202</ns><id>3427</id><revision><id>12427</id><timestamp>2011-04-26T13:14:35Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = speed limit
-| rdfs:label@de = Tempolimit
-| rdfs:domain= RouteOfTransportation
-| rdfs:range = Speed
-}}</text></revision></page><page><title>OntologyProperty:Spike</title><ns>202</ns><id>4438</id><revision><id>34459</id><timestamp>2014-04-08T14:48:09Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = spike
-| rdfs:label@de = schmettern
-| rdfs:label@el = καρφί
-| rdfs:label@tr = smaç
-| rdfs:domain = VolleyballPlayer
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:SplitFromParty</title><ns>202</ns><id>3724</id><revision><id>36571</id><timestamp>2014-07-08T14:20:48Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = split from party
-| rdfs:label@de = Abspaltung von Partei
-| rdfs:domain = PoliticalParty
-| rdfs:range = PoliticalParty
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:SpokenIn</title><ns>202</ns><id>1470</id><revision><id>36572</id><timestamp>2014-07-08T14:20:52Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|spoken in}}
-	{{label|de|gesprochen in}}
-	{{label|nl|gesproken in}}
-| rdfs:domain = Language
-| rdfs:range = PopulatedPlace
-| rdfs:subPropertyOf = dul:hasLocation
-}}</text></revision></page><page><title>OntologyProperty:Spokesperson</title><ns>202</ns><id>3347</id><revision><id>36573</id><timestamp>2014-07-08T14:20:56Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = spokesperson
-| rdfs:label@de = Sprecher
-| rdfs:label@pt = porta-voz
-| rdfs:domain = PoliticalParty
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:Sport</title><ns>202</ns><id>1458</id><revision><id>36574</id><timestamp>2014-07-08T14:21:00Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|sport}}
-	{{label|de|Sport}}
-	{{label|el|άθλημα}}
-	{{label|fr|sport}}
-| rdfs:range = Sport
-| rdfs:subPropertyOf = dul:isParticipantIn
-}}</text></revision></page><page><title>OntologyProperty:SportCountry</title><ns>202</ns><id>3534</id><revision><id>36575</id><timestamp>2014-07-08T14:21:05Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = sport country
-| rdfs:label@de = Sportnation
-| rdfs:comment@en = The country, for which the athlete is participating in championships
-| rdfs:comment@de = Das Land, für das der Sportler an Wettkämpfen teilnimmt
-| rdfs:domain = Athlete
-| rdfs:range = Country
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:SportDiscipline</title><ns>202</ns><id>5136</id><revision><id>36576</id><timestamp>2014-07-08T14:21:21Z</timestamp><text>
-{{ObjectProperty
-| rdfs:domain = Person
-| rdfs:range = Sport
-| labels =
-	{{label|en|sport discipline}}
-	{{label|de|Sportdisziplin}}
-	{{label|fr|discipline sportive}}
-	{{label|nl|tak van sport}}
-| comments =
-	{{comment|en|the sport discipline the athlete practices, e.g. Diving, or that a board member of a sporting club is focussing at}}
-| rdfs:subPropertyOf = dul:isParticipantIn
-}}</text></revision></page><page><title>OntologyProperty:SportGoverningBody</title><ns>202</ns><id>2306</id><revision><id>36577</id><timestamp>2014-07-08T14:21:24Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = sport governing body
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:SportSpecialty</title><ns>202</ns><id>5137</id><revision><id>36578</id><timestamp>2014-07-08T14:21:26Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|sport specialty}}
-	{{label|nl|sport specialiteit}}
-| rdfs:domain = Athlete
-| rdfs:range = Sport
-| rdfs:comment@en = the sport specialty the athlete practices, e.g. 'Ring' for a men's artistic gymnastics athlete
-| rdfs:subPropertyOf = dul:isParticipantIn
-}}</text></revision></page><page><title>OntologyProperty:SportsFunction</title><ns>202</ns><id>7888</id><revision><id>27388</id><timestamp>2013-07-10T15:02:06Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|sports function}}
-| rdfs:domain = Person
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Spouse</title><ns>202</ns><id>1459</id><revision><id>53597</id><timestamp>2020-02-17T07:43:22Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|spouse}}
-	{{label|de|Ehepartner}}
-	{{label|nl|echtgenoot}}
-	{{label|ja|配偶者}}
-	{{label|el|σύζυγος}}
-| rdfs:domain = Person
-| rdfs:range = Person
-| owl:equivalentProperty = schema:spouse, wikidata:P26
-| owl:propertyDisjointWith = child
-| rdfs:comment@en = the person they are married to
-| comments =
-	{{comment|el|Το άτομο με το οποίο κάποιος είναι παντρεμένος}}
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:SpouseName</title><ns>202</ns><id>7704</id><revision><id>34321</id><timestamp>2014-04-08T13:37:25Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|spouse name}}
-{{label|de|Name des Ehepartners}}
-{{label|el|όνομα συζύγου}}
-| rdfs:domain = Person
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:SpurOf</title><ns>202</ns><id>2762</id><revision><id>36580</id><timestamp>2014-07-08T14:21:33Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = spur of
-| rdfs:domain = Road
-| rdfs:range = Road
-| rdfs:subPropertyOf = dul:hasCommonBoundary
-}}</text></revision></page><page><title>OntologyProperty:SpurType</title><ns>202</ns><id>1460</id><revision><id>36581</id><timestamp>2014-07-08T14:21:36Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = spur type
-| rdfs:domain = Road
-| rdfs:subPropertyOf = dul:isClassifiedBy
-}}</text></revision></page><page><title>OntologyProperty:SquadNumber</title><ns>202</ns><id>5023</id><revision><id>16591</id><timestamp>2012-01-14T19:16:55Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = squad number
-| rdfs:domain = SportsTeamMember
-| rdfs:range = xsd:nonNegativeInteger
-| rdfs:comment@en = The number that an athlete wears in a team sport.
-}}</text></revision></page><page><title>OntologyProperty:Stadium</title><ns>202</ns><id>6091</id><revision><id>36582</id><timestamp>2014-07-08T14:21:39Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|Stadium}}
-	{{label|de|Stadion}}
-	{{label|el|στάδιο}}
-| rdfs:range = Stadium
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:Staff</title><ns>202</ns><id>1461</id><revision><id>52589</id><timestamp>2017-10-31T08:56:00Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = staff
-| rdfs:label@de = Personal
-| rdfs:label@el = προσωπικό
-| rdfs:domain = Organisation
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:StarRating</title><ns>202</ns><id>2510</id><revision><id>10013</id><timestamp>2010-10-25T09:40:59Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = star rating
-| rdfs:domain = Hotel
-| rdfs:range = xsd:float
-}}</text></revision></page><page><title>OntologyProperty:Starring</title><ns>202</ns><id>1463</id><revision><id>59615</id><timestamp>2024-05-31T18:39:15Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|starring}}
-	{{label|da|skuespillere}}
-	{{label|nl|met in de hoofdrol}}
-	{{label|el|ηθοποιοί}}
-	{{label|fr|acteur}}
-    {{label|am|ተዋንያን}}
-| rdfs:domain = Work
-| rdfs:range = Actor
-| owl:equivalentProperty = schema:actor,schema:actors, wikidata:P161
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:Start</title><ns>202</ns><id>7890</id><revision><id>52455</id><timestamp>2017-10-15T19:27:09Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|start}}
-{{label|de|Start}}
-| rdfs:range = xsd:date
-| rdfs:domain = TimePeriod
-}}</text></revision></page><page><title>OntologyProperty:StartCareer</title><ns>202</ns><id>7552</id><revision><id>26764</id><timestamp>2013-07-01T14:39:14Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|start career}}
-| rdfs:domain = Person
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:StartDate</title><ns>202</ns><id>1464</id><revision><id>53709</id><timestamp>2020-09-04T15:39:35Z</timestamp><text>{{DatatypeProperty
-| labels =
-  {{label|en|start date}}
-{{label|de|Startdatum}}
-  {{label|nl|startdatum}}
-  {{label|fr|date de début}}
-  {{label|es|fecha de inicio}}
-| rdfs:domain = Event
-| rdfs:range = xsd:date
-| owl:equivalentProperty = schema:startDate, wikidata:P580, ceo:startdatum
-| rdfs:comment@en = The start date of the event.
-}}</text></revision></page><page><title>OntologyProperty:StartDateTime</title><ns>202</ns><id>10293</id><revision><id>38798</id><timestamp>2014-12-02T10:49:29Z</timestamp><text>{{DatatypeProperty
-| labels =
-  {{label|en|start date and time}}
-  {{label|nl|datum en tijd van begin}}
-| rdfs:domain = Event
-| rdfs:range = xsd:dateTime
-| rdfs:comment@en = The start date and time of the event.
-}}</text></revision></page><page><title>OntologyProperty:StartOccupation</title><ns>202</ns><id>7791</id><revision><id>27375</id><timestamp>2013-07-10T14:37:30Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|start occupation}}
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:StartPoint</title><ns>202</ns><id>1465</id><revision><id>56831</id><timestamp>2022-03-01T00:37:18Z</timestamp><text>
-{{ObjectProperty
-| labels = 
-    {{label|en|start point}}
-    {{label|fr|point de départ}}
-    {{label|de|Startpunkt}}
-    {{label|el|σημείο_αρχής}}
-| rdfs:domain = Place
-| rdfs:range = Place
-| rdfs:subPropertyOf = dul:hasCommonBoundary
-}}</text></revision></page><page><title>OntologyProperty:StartReign</title><ns>202</ns><id>7549</id><revision><id>27170</id><timestamp>2013-07-09T09:21:56Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|start reign}}
-| rdfs:domain = Person
-| rdfs:range = skos:Concept
-}}</text></revision></page><page><title>OntologyProperty:StartWct</title><ns>202</ns><id>7834</id><revision><id>27150</id><timestamp>2013-07-05T15:57:17Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|start xct}}
-| rdfs:domain = Person
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:StartWqs</title><ns>202</ns><id>7833</id><revision><id>27149</id><timestamp>2013-07-05T15:57:06Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|start wqs}}
-| rdfs:domain = Person
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:StartYear</title><ns>202</ns><id>7172</id><revision><id>34328</id><timestamp>2014-04-08T13:37:51Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|start year}}
-{{label|de|Startjahr}}
-| rdfs:range = xsd:gYear
-}}</text></revision></page><page><title>OntologyProperty:StartYearOfInsertion</title><ns>202</ns><id>1466</id><revision><id>8284</id><timestamp>2010-05-28T13:43:38Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = start year of insertion
-| rdfs:domain = AutomobileEngine
-| rdfs:range = xsd:gYear
-}}</text></revision></page><page><title>OntologyProperty:StartYearOfSales</title><ns>202</ns><id>1467</id><revision><id>8285</id><timestamp>2010-05-28T13:43:47Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = start year of sales
-| rdfs:domain = Sales
-| rdfs:range = xsd:gYear
-}}</text></revision></page><page><title>OntologyProperty:StatName</title><ns>202</ns><id>7655</id><revision><id>26912</id><timestamp>2013-07-03T12:17:17Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|stat name}}
-| rdfs:domain = owl:Thing
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:StatValue</title><ns>202</ns><id>7656</id><revision><id>26915</id><timestamp>2013-07-03T12:20:30Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|stat value}}
-| rdfs:domain = owl:Thing
-| rdfs:range = xsd:double
-}}</text></revision></page><page><title>OntologyProperty:State</title><ns>202</ns><id>1468</id><revision><id>36585</id><timestamp>2014-07-08T14:21:49Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|state}}
-	{{label|de|Staat}}
-	{{label|nl|staat}}
-	{{label|el|νομός}}
-	{{label|pl|stan}}
-| rdfs:domain = owl:Thing
-| rdfs:range = PopulatedPlace
-| rdfs:subPropertyOf = dul:hasLocation
-}}</text></revision></page><page><title>OntologyProperty:StateDelegate</title><ns>202</ns><id>2364</id><revision><id>36586</id><timestamp>2014-07-08T14:21:52Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = state delegate
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:StateOfOrigin</title><ns>202</ns><id>1469</id><revision><id>36587</id><timestamp>2014-07-08T14:21:55Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = state of origin
-| rdfs:domain = Person
-| rdfs:range = Country
-| rdfs:subPropertyOf = dul:hasLocation
-}}</text></revision></page><page><title>OntologyProperty:StateOfOriginPoint</title><ns>202</ns><id>7895</id><revision><id>27408</id><timestamp>2013-07-10T15:51:50Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|state of origin point}}
-| rdfs:range = xsd:nonNegativeInteger
-| rdfs:domain = Athlete
-}}</text></revision></page><page><title>OntologyProperty:StateOfOriginTeam</title><ns>202</ns><id>7894</id><revision><id>27407</id><timestamp>2013-07-10T15:50:48Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|state of origin team}}
-| rdfs:domain = Athlete
-| rdfs:range = SportsTeam
-}}</text></revision></page><page><title>OntologyProperty:StateOfOriginYear</title><ns>202</ns><id>7893</id><revision><id>27406</id><timestamp>2013-07-10T15:49:57Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|state of origin year}}
-| rdfs:range = xsd:string
-| rdfs:domain = Athlete
-}}</text></revision></page><page><title>OntologyProperty:StationEvaDuration</title><ns>202</ns><id>1472</id><revision><id>8286</id><timestamp>2010-05-28T13:43:55Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = station EVA duration
-| rdfs:domain = SpaceMission
-| rdfs:range = Time
-}}</text></revision></page><page><title>OntologyProperty:StationStructure</title><ns>202</ns><id>3229</id><revision><id>22266</id><timestamp>2013-01-11T00:16:45Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|station structure}}
-{{label|nl|station structuur}}
-| rdfs:domain = Station
-| rdfs:range = xsd:string
-| rdfs:comment@en = Type of station structure (underground, at-grade, or elevated).
-}}</text></revision></page><page><title>OntologyProperty:StationVisitDuration</title><ns>202</ns><id>1473</id><revision><id>8287</id><timestamp>2010-05-28T13:44:01Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = station visit duration
-| rdfs:domain = SpaceMission
-| rdfs:range = Time
-}}</text></revision></page><page><title>OntologyProperty:Statistic</title><ns>202</ns><id>7870</id><revision><id>34330</id><timestamp>2014-04-08T13:38:00Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|statistic}}
-{{label|de|statistisch}}
-| rdfs:domain = Statistic
-}}</text></revision></page><page><title>OntologyProperty:StatisticLabel</title><ns>202</ns><id>1474</id><revision><id>8907</id><timestamp>2010-05-28T16:30:01Z</timestamp><text>{{ObjectProperty
-| rdfs:label@en = statistic label
-| rdfs:domain = BaseballPlayer
-}}</text></revision></page><page><title>OntologyProperty:StatisticValue</title><ns>202</ns><id>1475</id><revision><id>34331</id><timestamp>2014-04-08T13:38:04Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = statistic value
-| rdfs:label@de = Statistikwert
-| rdfs:domain = BaseballPlayer
-| rdfs:range = xsd:float
-}}</text></revision></page><page><title>OntologyProperty:StatisticYear</title><ns>202</ns><id>1476</id><revision><id>8289</id><timestamp>2010-05-28T13:44:16Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = statistic year
-| rdfs:domain = BaseballPlayer
-| rdfs:range = xsd:date
-}}</text></revision></page><page><title>OntologyProperty:Status</title><ns>202</ns><id>1477</id><revision><id>53782</id><timestamp>2020-10-21T08:20:35Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|status}}
-{{label|de|Status}}
-{{label|nl|status}}
-{{label|fr|statut}}
-{{label|es|estatus}}
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:StatusManager</title><ns>202</ns><id>7800</id><revision><id>27102</id><timestamp>2013-07-05T13:20:53Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|status manager}}
-| rdfs:domain = Person
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:StatusYear</title><ns>202</ns><id>7299</id><revision><id>48612</id><timestamp>2015-08-06T12:17:59Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|status year}}
-| rdfs:domain = Place
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:StellarClassification</title><ns>202</ns><id>11154</id><revision><id>46538</id><timestamp>2015-03-19T08:45:39Z</timestamp><text>{{ObjectProperty
-| labels = 
-{{label|en|stellar classification}}
-{{label|nl|spectraalklasse}}
-| rdfs:domain = CelestialBody
-| rdfs:range = skos:OrderedCollection
-}}</text></revision></page><page><title>OntologyProperty:StockExchange</title><ns>202</ns><id>9373</id><revision><id>34744</id><timestamp>2014-05-09T09:24:43Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|Registered at Stock Exchange}}
-{{label|nl|beurs waaraan genoteerd}}
-| rdfs:domain = Company
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:StoryEditor</title><ns>202</ns><id>1478</id><revision><id>36588</id><timestamp>2014-07-08T14:21:58Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = story editor
-| rdfs:domain = TelevisionShow
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:Strength</title><ns>202</ns><id>1479</id><revision><id>34333</id><timestamp>2014-04-08T13:38:13Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = strength
-| rdfs:label@de = Stärke
-| rdfs:label@el = δύναμη
-| rdfs:domain = MilitaryConflict
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:StructuralSystem</title><ns>202</ns><id>1480</id><revision><id>36589</id><timestamp>2014-07-08T14:22:02Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|structural system}}
-	{{label|de|Tragsystem}}
-	{{label|nl|bouwmethode}}
-	{{label|el|κατασκευαστικό σύστημα}}
-| rdfs:domain = Building
-| rdfs:subPropertyOf = dul:hasConstituent
-}}</text></revision></page><page><title>OntologyProperty:Student</title><ns>202</ns><id>7541</id><revision><id>52001</id><timestamp>2017-03-22T16:51:09Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|student}}
-| rdfs:domain = Person
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:Style</title><ns>202</ns><id>4780</id><revision><id>27365</id><timestamp>2013-07-10T14:10:08Z</timestamp><text>{{ObjectProperty
-| rdfs:label@en = style
-| rdfs:label@de = stil
-| rdfs:label@it = stile
-| rdfs:label@es = estilo
-| rdfs:domain = Artist
-}}</text></revision></page><page><title>OntologyProperty:StylisticOrigin</title><ns>202</ns><id>1483</id><revision><id>36591</id><timestamp>2014-07-08T14:22:08Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = stylistic origin
-| rdfs:label@de = stilistische Herkunft
-| rdfs:label@pt = origens estilísticas
-| rdfs:domain = MusicGenre
-| rdfs:range = MusicGenre
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:SubClassis</title><ns>202</ns><id>9312</id><revision><id>32756</id><timestamp>2014-03-17T13:49:28Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|sub-classis}}
-{{label|nl|onderklasse}}
-| rdfs:domain = Species
-| rdfs:range = owl:Thing
-| rdfs:subPropertyOf = classis
-|comments =
-{{comment|en|a subdivision within a Species classis}}
-}}</text></revision></page><page><title>OntologyProperty:SubFamily</title><ns>202</ns><id>9328</id><revision><id>34336</id><timestamp>2014-04-08T13:38:25Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|sub-family}}
-{{label|de|Unterfamilie}}
-{{label|nl|onderfamilie}}
-| rdfs:domain = Species
-| rdfs:range = Taxon
-}}</text></revision></page><page><title>OntologyProperty:SubGenus</title><ns>202</ns><id>10211</id><revision><id>37887</id><timestamp>2014-09-24T11:18:42Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|subgenus}}
-	{{label|de|Untergattung}}
-	{{label|nl|ondergeslacht}}
-| comments =
-	{{comment|en|A rank in the classification of organisms, below genus ; a taxon at that rank}}
-| rdfs:domain = Species
-| rdfs:subPropertyOf = dul:specializes
-}}</text></revision></page><page><title>OntologyProperty:SubMunicipalityType</title><ns>202</ns><id>6573</id><revision><id>34337</id><timestamp>2014-04-08T13:38:38Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|type of municipality}}
-{{label|de|Art der Gemeinde}}
-{{label|nl|type gemeente}}
-| rdfs:domain = SubMunicipality
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:SubOrder</title><ns>202</ns><id>10212</id><revision><id>56820</id><timestamp>2022-02-28T22:58:42Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|sub-order}}
-{{label|fr|sous-ordre}}
-{{label|nl|onderorde}}
-| rdfs:domain = Species
-}}</text></revision></page><page><title>OntologyProperty:SubPrefecture</title><ns>202</ns><id>7131</id><revision><id>25664</id><timestamp>2013-05-26T15:24:48Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|subprefecture}}
-| rdfs:domain = Place
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:SubTribus</title><ns>202</ns><id>9310</id><revision><id>32753</id><timestamp>2014-03-17T10:24:57Z</timestamp><text>{{ObjectProperty
-| labels = 
-{{label|en|subtribus}}
-{{label|nl|onderstam}}
-| comments =
-| rdfs:domain = Species
-| rdfs:range = Species
-| rdfs:subPropertyOf = Tribus
-}}</text></revision></page><page><title>OntologyProperty:Subdivision</title><ns>202</ns><id>7058</id><revision><id>52292</id><timestamp>2017-10-08T19:18:00Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|subdivision}}
-| rdfs:domain = owl:Thing
-| rdfs:range = owl:Thing
-}}</text></revision></page><page><title>OntologyProperty:SubdivisionLink</title><ns>202</ns><id>7056</id><revision><id>25638</id><timestamp>2013-05-26T14:16:18Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|subdivision link}}
-| rdfs:domain = Place
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:SubdivisionName</title><ns>202</ns><id>7057</id><revision><id>36592</id><timestamp>2014-07-08T14:22:11Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|subdivision name of the island}}
-| rdfs:domain = Island
-| rdfs:range = Place
-| rdfs:subPropertyOf = dul:hasPart
-}}</text></revision></page><page><title>OntologyProperty:Subdivisions</title><ns>202</ns><id>1687</id><revision><id>56804</id><timestamp>2022-02-28T21:59:58Z</timestamp><text>{{DatatypeProperty
-| labels =
-    {{label|en|subdivisions}}
-    {{label|fr|sous-divisions}}
-| rdfs:domain = owl:Thing
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:SubjectOfPlay</title><ns>202</ns><id>3829</id><revision><id>13361</id><timestamp>2011-06-06T11:37:02Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = subject of play
-| rdfs:domain = Play
-| rdfs:range = xsd:string
-| rdfs:comment@en = The overall subject matter dealt with by the play.
-}}</text></revision></page><page><title>OntologyProperty:SubjectTerm</title><ns>202</ns><id>9127</id><revision><id>31612</id><timestamp>2014-02-10T13:59:07Z</timestamp><text>{{ DatatypeProperty
-| labels =
-{{label|en|subject term}}
-{{label|nl|onderwerpsaanduiding}}
-| rdfs:comment@en = The subject as a term, possibly a term from a formal classification
-| rdfs:domain = Work
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:SublimationPoint</title><ns>202</ns><id>2503</id><revision><id>9235</id><timestamp>2010-07-21T11:01:32Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = sublimation point
-| rdfs:range = Temperature
-}}</text></revision></page><page><title>OntologyProperty:SuborbitalFlights</title><ns>202</ns><id>1485</id><revision><id>10426</id><timestamp>2010-11-10T14:51:17Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = suborbital flights
-| rdfs:domain = YearInSpaceflight
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:Subprefecture</title><ns>202</ns><id>7017</id><revision><id>36593</id><timestamp>2014-07-08T14:22:16Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|subprefecture}}
-| rdfs:domain = Department
-| rdfs:range = PopulatedPlace
-| rdfs:subPropertyOf = dul:hasPart
-}}</text></revision></page><page><title>OntologyProperty:Subregion</title><ns>202</ns><id>1486</id><revision><id>36594</id><timestamp>2014-07-08T14:22:20Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = subregion
-| rdfs:domain = Place
-| rdfs:range = Place
-| rdfs:subPropertyOf = dul:hasPart
-}}</text></revision></page><page><title>OntologyProperty:SubsequentInfrastructure</title><ns>202</ns><id>1487</id><revision><id>36595</id><timestamp>2014-07-08T14:22:37Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|subsequent infrastructure}}
-	{{label|de|spätere Infrastruktur}}
-	{{label|nl|volgende infrastructuur}}
-| rdfs:domain = Infrastructure
-| rdfs:range = Infrastructure
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:SubsequentWork</title><ns>202</ns><id>1488</id><revision><id>57048</id><timestamp>2022-03-09T16:01:31Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|subsequent work}}
-	{{label|fr|oeuvre suivante}}
-	{{label|de|nachfolgende Arbeiten}}
-	{{label|nl|vervolg werk}}
-	{{label|el|επόμενη δημιουργία}}
-| rdfs:domain = Work
-| rdfs:range = Work
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:SubsequentWorkDate</title><ns>202</ns><id>13811</id><revision><id>57057</id><timestamp>2022-03-09T17:13:00Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|subsequent work date}}
-	{{label|fr|année de sortie oeuvre suivante}}
-| rdfs:domain = Work
-| rdfs:range = year
-| comments =
- {{comment|en|Year when subsequent work is released}}
- {{comment|fr|Année de sortie de l'oeuvre suivante}}
-}}</text></revision></page><page><title>OntologyProperty:Subsidiary</title><ns>202</ns><id>1489</id><revision><id>36597</id><timestamp>2014-07-08T14:22:43Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|subsidiary}}
-	{{label|pt|treinador}}
-	{{label|fr|filiale}}
-| rdfs:domain = Company
-| rdfs:range = Company
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:Subsystem</title><ns>202</ns><id>7144</id><revision><id>34340</id><timestamp>2014-04-08T13:38:48Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|subsystem}}
-{{label|de|Teilsystem}}
-| rdfs:domain = Place
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:SubsystemLink</title><ns>202</ns><id>7143</id><revision><id>25682</id><timestamp>2013-05-26T16:08:22Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|subsystem link}}
-| rdfs:domain = Place
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Subtitle</title><ns>202</ns><id>2299</id><revision><id>22176</id><timestamp>2013-01-10T20:57:19Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|subtitle}}
-{{label|de|Untertitel}}
-{{label|el|υπότιτλος}}
-{{label|nl|onderschrift}}
-{{label|pt|legenda}}
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:SuccessfulLaunches</title><ns>202</ns><id>1490</id><revision><id>34341</id><timestamp>2014-04-08T13:38:51Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = successful launches
-| rdfs:label@de = erfolgreiche Starts
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:Successor</title><ns>202</ns><id>1491</id><revision><id>36598</id><timestamp>2014-07-08T14:22:46Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|successor}}
-	{{label|nl|opvolger}}
-	{{label|de|Nachfolger}}
-	{{label|ja|後任者}}
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:SudocId</title><ns>202</ns><id>11043</id><revision><id>52887</id><timestamp>2018-02-13T11:00:45Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|SUDOC id}}
-| comments =
-{{comment|en|Système universitaire de documentation id (French collaborative library catalog).
-http://www.idref.fr/$1}}
-| rdfs:domain = owl:Thing
-| rdfs:range = xsd:string
-| owl:equivalentProperty = wikidata:P269
-| rdfs:subPropertyOf = code
-}}</text></revision></page><page><title>OntologyProperty:SummerAppearances</title><ns>202</ns><id>1492</id><revision><id>36599</id><timestamp>2014-07-08T14:22:49Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = summer appearances
-| rdfs:domain = OlympicResult
-| rdfs:range = OlympicResult
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:SummerTemperature</title><ns>202</ns><id>1493</id><revision><id>8294</id><timestamp>2010-05-28T13:44:53Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = summer temperature
-| rdfs:domain = Settlement
-| rdfs:range = Temperature
-}}</text></revision></page><page><title>OntologyProperty:SuperFamily</title><ns>202</ns><id>9329</id><revision><id>32898</id><timestamp>2014-03-23T20:22:12Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|super-family}}
-{{label|nl|superfamilie}}
-| rdfs:domain = Species
-| rdfs:range = Taxon
-}}</text></revision></page><page><title>OntologyProperty:SuperOrder</title><ns>202</ns><id>10213</id><revision><id>37898</id><timestamp>2014-09-24T11:53:55Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|super-order}}
-{{label|nl|bovenorde}}
-| rdfs:domain = Species
-}}</text></revision></page><page><title>OntologyProperty:SuperTribus</title><ns>202</ns><id>9311</id><revision><id>32754</id><timestamp>2014-03-17T10:25:37Z</timestamp><text>{{ObjectProperty
-| labels = 
-{{label|en|supertribus}}
-{{label|nl|bovenstam}}
-| comments =
-| rdfs:domain = Species
-| rdfs:range = Species
-| rdfs:subPropertyOf = Tribus
-}}</text></revision></page><page><title>OntologyProperty:SuperbowlWin</title><ns>202</ns><id>7686</id><revision><id>26958</id><timestamp>2013-07-04T09:29:06Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|superbowl win}}
-| rdfs:domain = Athlete
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Superintendent</title><ns>202</ns><id>1494</id><revision><id>36600</id><timestamp>2014-07-08T14:22:52Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|superintendent}}
-	{{label|de|Leiter}}
-	{{label|nl|opzichter}}
-| rdfs:domain = Organisation
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:SupplementalDraftRound</title><ns>202</ns><id>1495</id><revision><id>17476</id><timestamp>2012-04-27T22:09:22Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = supplemental draft round
-| rdfs:domain = Athlete
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:SupplementalDraftYear</title><ns>202</ns><id>1496</id><revision><id>8296</id><timestamp>2010-05-28T13:45:10Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = supplemental draft year
-| rdfs:domain = GridironFootballPlayer
-| rdfs:range = xsd:gYear
-}}</text></revision></page><page><title>OntologyProperty:Supplies</title><ns>202</ns><id>1497</id><revision><id>36601</id><timestamp>2014-07-08T14:22:56Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = supplies
-| rdfs:label@el = παροχές
-| rdfs:domain = Artery
-| rdfs:range = AnatomicalStructure
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:Supply</title><ns>202</ns><id>7097</id><revision><id>34451</id><timestamp>2014-04-08T14:38:21Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|supply}}
-| rdfs:domain = Place
-| rdfs:range = Place
-}}</text></revision></page><page><title>OntologyProperty:SuppreddedDate</title><ns>202</ns><id>1498</id><revision><id>43331</id><timestamp>2015-02-06T14:56:37Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|suppredded date}}
-{{label|nl|oppressie datum}}
-{{label|bg|дата на забраната}}
-| rdfs:domain = Saint
-| rdfs:range = xsd:date
-|rdfs:comment@en=Date when the Church forbade the veneration of this saint. 
-(I hope that's what it means, I don't know why the original author didn't document it)
-}}</text></revision></page><page><title>OntologyProperty:SurfaceArea</title><ns>202</ns><id>1499</id><revision><id>53788</id><timestamp>2020-10-23T09:44:25Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = surface area
-| rdfs:label@de = Oberfläche
-| rdfs:label@el = έκταση
-| rdfs:domain = Planet
-| rdfs:range = Area
-}}</text></revision></page><page><title>OntologyProperty:SurfaceFormOccurrenceOffset</title><ns>202</ns><id>2445</id><revision><id>9138</id><timestamp>2010-06-23T15:03:54Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = position in which a surface occurs in a text
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:SurfaceGravity</title><ns>202</ns><id>4360</id><revision><id>23663</id><timestamp>2013-02-07T07:17:00Z</timestamp><text>{{DatatypeProperty
- |rdfs:label@en=surface gravity
- |rdfs:domain=Planet
- |rdfs:range=Mass
-}}</text></revision></page><page><title>OntologyProperty:SurfaceType</title><ns>202</ns><id>11781</id><revision><id>51837</id><timestamp>2017-01-13T22:57:56Z</timestamp><text>{{DatatypeProperty
-| labels =
-   {{label|en|type of surface}}
-   {{label|fr|type de surface}}
-   {{label|es|tipo de surperficie}}
-   {{label|cs|typ povrchu}}
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:SuspectedCases</title><ns>202</ns><id>12298</id><revision><id>53609</id><timestamp>2020-04-10T06:20:32Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|Suspected Cases}}
-| rdfs:comment@en = Number of suspected cases in a pandemic
-| rdfs:domain = Outbreak
-| rdfs:range = xsd:integer
-}}</text></revision></page><page><title>OntologyProperty:SwimmingStyle</title><ns>202</ns><id>9268</id><revision><id>34346</id><timestamp>2014-04-08T13:39:13Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = Swimming style
-| rdfs:label@de = Schwimmstil
-| rdfs:label@nl = Zwemslag
-| rdfs:domain = Swimmer
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Symbol</title><ns>202</ns><id>1500</id><revision><id>57279</id><timestamp>2022-03-28T22:13:27Z</timestamp><text>{{DatatypeProperty
-| labels =
-    {{label|en|Symbol}}
-    {{label|fr|symbole}}
-    {{label|nl|symbool}}
-    {{label|de|Symbol}}
-| rdfs:comment@en = HUGO Gene Symbol
-| rdfs:domain = Biomolecule
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Symptom</title><ns>202</ns><id>11880</id><revision><id>52217</id><timestamp>2017-10-07T22:21:07Z</timestamp><text>{{ObjectProperty
-| labels = 
-{{label|de |Symptome}}
-{{label|en|symptoms}}
-{{label|el|σύμπτωμα}}
-{{label|fr |symptômes}}
-| rdfs:domain = Disease
-| rdfs:range = owl:Thing
-}}</text></revision></page><page><title>OntologyProperty:Synonym</title><ns>202</ns><id>1247</id><revision><id>57278</id><timestamp>2022-03-28T22:11:13Z</timestamp><text>{{DatatypeProperty
-| labels = 
-  {{label|en|synonym}}
-  {{label|fr|synonyme}}
-  {{label|de|Synonym}}
-  {{label|el|συνώνυμο}}
-  {{label|ja|シノニム}}
-| rdfs:range = xsd:string
-| owl:equivalentProperty=wikidata:P5973
-}}</text></revision></page><page><title>OntologyProperty:SystemOfLaw</title><ns>202</ns><id>6604</id><revision><id>36602</id><timestamp>2014-07-08T14:22:59Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|system of law}}
-	{{label|de|Rechtssystem}}
-	{{label|nl|rechtssysteem}}
-| comments =
-	{{comment|en|A referral to the relevant system of law }}
-| rdfs:domain = LegalCase
-| rdfs:range = SystemOfLaw
-| rdf:type = | rdfs:subPropertyOf     = 
-| owl:equivalentProperty = 
-| rdfs:subPropertyOf = dul:isSettingFor
-}}</text></revision></page><page><title>OntologyProperty:SystemRequirements</title><ns>202</ns><id>6411</id><revision><id>34350</id><timestamp>2014-04-08T13:39:39Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|minimum system requirements}}
-{{label|de|Mindestsystemanforderungen}}
-| rdfs:domain = owl:Thing
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Tag</title><ns>202</ns><id>7074</id><revision><id>25594</id><timestamp>2013-05-26T12:17:07Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|tag}}
-| rdfs:range = xsd:date
-}}</text></revision></page><page><title>OntologyProperty:Taoiseach</title><ns>202</ns><id>2333</id><revision><id>47445</id><timestamp>2015-04-01T15:00:29Z</timestamp><text>{{ObjectProperty
-| rdfs:label@en = taoiseach
-| rdfs:label@ga = taoiseach
-| rdfs:range = Person
-| rdfs:comment@en = head of government of Ireland
-| owl:equivalentProperty = wikidata:P6
-}}</text></revision></page><page><title>OntologyProperty:TargetAirport</title><ns>202</ns><id>1502</id><revision><id>36603</id><timestamp>2014-07-08T14:23:03Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = target airport
-| rdfs:domain = Airline
-| rdfs:range = Airport
-| rdfs:subPropertyOf = dul:hasLocation
-}}</text></revision></page><page><title>OntologyProperty:TargetSpaceStation</title><ns>202</ns><id>1471</id><revision><id>36604</id><timestamp>2014-07-08T14:23:06Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = target space station station
-| rdfs:domain = Spacecraft
-| rdfs:range = SpaceStation
-| rdfs:subPropertyOf = dul:hasLocation
-}}</text></revision></page><page><title>OntologyProperty:Taste</title><ns>202</ns><id>8914</id><revision><id>34351</id><timestamp>2014-04-08T13:39:47Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|taste or flavour}}
-{{label|de|Geschmack oder Aroma}}
-{{label|nl|smaak}}
-| rdfs:domain = Food
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Tattoo</title><ns>202</ns><id>3288</id><revision><id>56779</id><timestamp>2022-02-28T18:39:33Z</timestamp><text>{{DatatypeProperty
-| labels = 
-    {{label|en|tattoo}}
-    {{label|fr|tatouage}}
-    {{label|el|τατουάζ}}
-    {{label|de|Tätowierung}}
-    {{label|pt|tatuagem}}
-| rdfs:domain = Person
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Taxon</title><ns>202</ns><id>9309</id><revision><id>32743</id><timestamp>2014-03-15T11:01:45Z</timestamp><text>{{ObjectProperty
-| labels = 
-{{label|en|has taxon}}
-{{label|nl|taxon}}
-| rdfs:domain = Species
-| rdfs:range = Taxon
-}}</text></revision></page><page><title>OntologyProperty:TeachingStaff</title><ns>202</ns><id>3131</id><revision><id>36605</id><timestamp>2014-07-08T14:23:09Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = teaching staff
-| rdfs:domain = School
-| rdfs:subPropertyOf = dul:hasMember
-}}</text></revision></page><page><title>OntologyProperty:Team</title><ns>202</ns><id>1503</id><revision><id>51447</id><timestamp>2016-08-16T07:40:03Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|team}}
-	{{label|de|Team}}
-	{{label|nl|team}}
-	{{label|el|ομάδα}}
-	{{label|fr|équipe}}
-	{{label|ja|チーム}}
-| rdfs:range = SportsTeam
-| owl:equivalentProperty = wikidata:P54
-| rdfs:subPropertyOf = dul:isSettingFor
-}}</text></revision></page><page><title>OntologyProperty:TeamCoached</title><ns>202</ns><id>7691</id><revision><id>34353</id><timestamp>2014-04-08T13:40:05Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|team coached}}
-{{label|de|Team gecoacht}}
-| rdfs:domain = Athlete
-| rdfs:range = SportsTeam
-}}</text></revision></page><page><title>OntologyProperty:TeamManager</title><ns>202</ns><id>7799</id><revision><id>34354</id><timestamp>2014-04-08T13:40:20Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|team manager}}
-{{label|de|Team-Manager}}
-| rdfs:domain = Person
-| rdfs:range = SportsTeam
-}}</text></revision></page><page><title>OntologyProperty:TeamName</title><ns>202</ns><id>1504</id><revision><id>34810</id><timestamp>2014-05-14T11:25:22Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = team name
-| rdfs:label@de = Teamname
-| rdfs:label@el = όνομα ομάδας
-| rdfs:domain = School
-| rdfs:range = rdf:langString
-}}</text></revision></page><page><title>OntologyProperty:TeamPoint</title><ns>202</ns><id>7671</id><revision><id>26941</id><timestamp>2013-07-04T07:47:06Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|team point}}
-| rdfs:range = xsd:nonNegativeInteger
-| rdfs:domain = Athlete
-}}</text></revision></page><page><title>OntologyProperty:TeamSize</title><ns>202</ns><id>2304</id><revision><id>34356</id><timestamp>2014-04-08T13:40:26Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = team size
-| rdfs:label@de = Teamgröße
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:TeamTitle</title><ns>202</ns><id>8048</id><revision><id>28203</id><timestamp>2013-09-03T18:48:43Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|team title}}
-| rdfs:domain = Athlete
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Technique</title><ns>202</ns><id>4782</id><revision><id>47443</id><timestamp>2015-04-01T14:55:39Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = technique
-| rdfs:label@de = technisch
-| rdfs:label@el = τεχνική
-| rdfs:label@es = técnica
-| rdfs:domain = Painting
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:TelevisionSeries</title><ns>202</ns><id>6097</id><revision><id>36607</id><timestamp>2014-07-08T14:23:16Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|television series}}
-	{{label|de|Fernsehserie}}
-	{{label|el|τηλεοπτικές σειρές}}
-| rdfs:range = TelevisionShow
-| rdfs:subPropertyOf = dul:hasMember
-}}</text></revision></page><page><title>OntologyProperty:TempPlace</title><ns>202</ns><id>9174</id><revision><id>31858</id><timestamp>2014-02-13T20:17:54Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = Temporary Placement in the Music Charts
-| rdfs:label@de = vorläufige Chartplatzierung
-| rdfs:domain = ChartsPlacements
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Temperature</title><ns>202</ns><id>1507</id><revision><id>34359</id><timestamp>2014-04-08T13:40:37Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = temperature
-| rdfs:label@de = Temperatur
-| rdfs:label@el = θερμοκρασία
-| rdfs:label@fr = température
-| rdfs:range = Temperature
-}}</text></revision></page><page><title>OntologyProperty:TemplateName</title><ns>202</ns><id>11967</id><revision><id>52546</id><timestamp>2017-10-25T11:37:03Z</timestamp><text>{{DatatypeProperty
-| labels =
-	{{label|en|template name}}
-	{{label|de|Templatename}}
-| comments =
-	{{comment|en|DO NOT USE THIS PROPERTY! For internal use only.}}
-| rdfs:domain = WikimediaTemplate
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Temple</title><ns>202</ns><id>7795</id><revision><id>34360</id><timestamp>2014-04-08T13:40:41Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|temple}}
-{{label|de|Tempel}}
-| rdfs:domain = Person
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:TempleYear</title><ns>202</ns><id>7796</id><revision><id>27097</id><timestamp>2013-07-05T13:18:11Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|temple year}}
-| rdfs:domain = Person
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Tenant</title><ns>202</ns><id>1508</id><revision><id>49201</id><timestamp>2015-10-14T13:03:12Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|tenant}}
-	{{label|de|Mieter}}
-	{{label|nl|huurder}}
-	{{label|el|ενοικιαστής}}
-	{{label|fr|locataire}}
-| rdfs:domain = ArchitecturalStructure
-| rdfs:range = Organisation
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:TennisSurfaceType</title><ns>202</ns><id>6391</id><revision><id>23662</id><timestamp>2013-02-05T18:49:38Z</timestamp><text>{{DatatypeProperty
-| labels =
-   {{label|en|type of tennis surface}}
-   {{label|fr|type de surface (tennis)}}
-   {{label|es|tipo de surperficie(tennis}}
-   {{label|nl|type speelgrond}}
-| comments =
-  {{comment|en|There are five types of court surface used in professional play. Each surface is different in the speed and height of the bounce of the ball.&lt;ref&gt;http://en.wikipedia.org/wiki/Tennis#Surface&lt;/ref&gt;}}
-| rdfs:range = xsd:string
-}}
-
-== References ==
-
-&lt;references/&gt;</text></revision></page><page><title>OntologyProperty:TermOfOffice</title><ns>202</ns><id>7271</id><revision><id>34362</id><timestamp>2014-04-08T13:40:50Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|term of office}}
-{{label|de|Amtszeit}}
-| rdfs:domain = PopulatedPlace
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:TermPeriod</title><ns>202</ns><id>5937</id><revision><id>36609</id><timestamp>2014-07-08T14:23:24Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|term period}}
-	{{label|el|χρονική περίοδος}}
-| rdfs:range = TimePeriod
-| rdfs:subPropertyOf = dul:hasSetting
-}}</text></revision></page><page><title>OntologyProperty:Territory</title><ns>202</ns><id>1509</id><revision><id>56729</id><timestamp>2022-02-28T14:55:13Z</timestamp><text>{{ObjectProperty
-| labels =
-    {{label|en|territory}}
-    {{label|de|Gebiet}}
-    {{label|es|territorio}}
-    {{label|fr|territoire}}
-| rdfs:domain = MilitaryConflict, AdministrativeRegion
-| rdfs:range = PopulatedPlace
-| rdfs:subPropertyOf = dul:hasParticipant
-}}</text></revision></page><page><title>OntologyProperty:TerytCode</title><ns>202</ns><id>4204</id><revision><id>48376</id><timestamp>2015-06-16T06:18:10Z</timestamp><text>{{ObjectProperty
-| rdfs:label@en = TERYT code
-| rdfs:label@pl = kod TERYT
-| rdfs:domain = PopulatedPlace
-| rdfs:comment@en = indexing code used by the Polish National Official Register of the Territorial Division of the Country (TERYT) to identify various entities
-| rdfs:subPropertyOf = dul:isClassifiedBy
-| owl:equivalentProperty = wikidata:P1653
-}}</text></revision></page><page><title>OntologyProperty:Tessitura</title><ns>202</ns><id>7755</id><revision><id>56773</id><timestamp>2022-02-28T18:26:39Z</timestamp><text>{{DatatypeProperty
-| labels =
-    {{label|en|tessitura}}
-    {{label|fr|tessiture}}
-| rdfs:domain = Person
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Testaverage</title><ns>202</ns><id>1510</id><revision><id>8302</id><timestamp>2010-05-28T13:45:57Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = testaverage
-| rdfs:domain = School
-| rdfs:range = xsd:float
-}}</text></revision></page><page><title>OntologyProperty:Theology</title><ns>202</ns><id>6166</id><revision><id>34364</id><timestamp>2014-04-08T13:40:57Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = Theology
-| rdfs:label@de = Theologie
-| rdfs:label@el = Θεολογία
-| rdfs:domain = ChristianDoctrine
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Third</title><ns>202</ns><id>7892</id><revision><id>27397</id><timestamp>2013-07-10T15:23:39Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|third}}
-| rdfs:range = xsd:nonNegativeInteger
-| rdfs:domain = Person
-}}</text></revision></page><page><title>OntologyProperty:ThirdCommander</title><ns>202</ns><id>1511</id><revision><id>36612</id><timestamp>2014-07-08T14:23:33Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = third commander
-| rdfs:domain = MilitaryUnit
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:ThirdDriver</title><ns>202</ns><id>1512</id><revision><id>36613</id><timestamp>2014-07-08T14:23:36Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = third driver
-| rdfs:label@de = dritter Fahrer
-| rdfs:domain = GrandPrix
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:hasParticipant
-}}</text></revision></page><page><title>OntologyProperty:ThirdDriverCountry</title><ns>202</ns><id>1513</id><revision><id>36614</id><timestamp>2014-07-08T14:23:40Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = third driver country
-| rdfs:domain = GrandPrix
-| rdfs:range = Country
-| rdfs:subPropertyOf = dul:hasParticipant
-}}</text></revision></page><page><title>OntologyProperty:ThirdPlace</title><ns>202</ns><id>8080</id><revision><id>34366</id><timestamp>2014-04-08T13:41:06Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|third place}}
-{{label|de|dritter Platz}}
-| rdfs:domain = owl:Thing
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:ThirdTeam</title><ns>202</ns><id>1514</id><revision><id>36615</id><timestamp>2014-07-08T14:23:43Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|third team}}
-	{{label|de|dritte Mannschaft}}
-	{{label|el|τρίτη ομάδα}}
-| rdfs:domain = GrandPrix
-| rdfs:range = SportsTeam
-| rdfs:subPropertyOf = dul:hasParticipant
-}}</text></revision></page><page><title>OntologyProperty:ThrowingSide</title><ns>202</ns><id>1515</id><revision><id>13235</id><timestamp>2011-05-30T15:28:39Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = throwing side
-| rdfs:domain = BaseballPlayer
-| rdfs:range = xsd:string
-| rdfs:comment = The side the player throws, Left, Right, or Unknown.
-}}</text></revision></page><page><title>OntologyProperty:Thumbnail</title><ns>202</ns><id>4377</id><revision><id>38876</id><timestamp>2014-12-14T14:05:42Z</timestamp><text>{{Reserved for DBpedia}}
-
-
-{{ObjectProperty
-| labels =
-	{{label|en|thumbnail}}
-| comments =
-	{{comment|en|Reserved for DBpedia. {{Reserved for DBpedia}}}}
-| rdfs:range = Image
-| rdfs:subPropertyOf = dul:isExpressedBy
-}}</text></revision></page><page><title>OntologyProperty:ThumbnailCaption</title><ns>202</ns><id>6774</id><revision><id>27028</id><timestamp>2013-07-04T13:49:15Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|thumbnail caption}}
-| rdfs:domain = owl:Thing
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Tie</title><ns>202</ns><id>7589</id><revision><id>34464</id><timestamp>2014-04-08T14:58:11Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|tie}}
-{{label|de|Unentschieden}}
-| rdfs:domain = Boxer
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:Time</title><ns>202</ns><id>8085</id><revision><id>51510</id><timestamp>2016-09-18T10:51:49Z</timestamp><text>{{DatatypeProperty
-| labels =
-   {{label|en|time}}
-   {{label|nl|tijd}}
-   {{label|de|Zeit}}
-   {{label|el|χρόνος}}
-| comments =
-   {{comment|el|Χρόνος χαρακτηρίζεται η ακριβής μέτρηση μιας διαδικασίας από το παρελθόν στο μέλλον.}}
-| rdfs:domain = owl:Thing
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:TimeInSpace</title><ns>202</ns><id>1517</id><revision><id>56809</id><timestamp>2022-02-28T22:21:24Z</timestamp><text>{{DatatypeProperty
-| labels = 
-    {{label|en|total time person has spent in space}}
-    {{label|fr|temps total passé dans l'espace par la personne}}
-    {{label|de|Gesamtzeit welche die Person im Weltraum verbracht hat}}
-| rdfs:range = Time
-}}</text></revision></page><page><title>OntologyProperty:TimeZone</title><ns>202</ns><id>1686</id><revision><id>36617</id><timestamp>2014-07-08T14:23:50Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|ca|zona horària}}
-	{{label|en|time zone}}
-	{{label|de|Zeitzone}}
-	{{label|nl|tijdzone}}
-	{{label|pt|fuso horario}}
-	{{label|el|ζώνη_ώρας1}}
-	{{label|es|huso horario}}
-	{{label|pl|strefa czasowa}}
-	{{label|fr|fuseau horaire}}
-| rdfs:domain = Place
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:TimeshiftChannel</title><ns>202</ns><id>3212</id><revision><id>12009</id><timestamp>2011-04-06T14:53:13Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = timeshift channel
-| rdfs:domain = TelevisionStation
-| rdfs:range = xsd:string
-| rdfs:comment@en = A timeshift channel is a television channel carrying a time-delayed rebroadcast of its "parent" channel's output. (http://en.wikipedia.org/wiki/Timeshift_channel)
-}}</text></revision></page><page><title>OntologyProperty:Title</title><ns>202</ns><id>1520</id><revision><id>59219</id><timestamp>2023-02-09T10:34:28Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|title}}
-{{label|nl|titel}}
-{{label|it|denominazione}}
-{{label|de|Titel}}
-{{label|el|Τίτλος}}
-{{label|es|título}}
-{{label|ja|タイトル}}
-| rdfs:range = rdf:langString
-| owl:equivalentProperty = schema:title, foaf:title
-}}</text></revision></page><page><title>OntologyProperty:TitleDate</title><ns>202</ns><id>3351</id><revision><id>22209</id><timestamp>2013-01-10T22:16:34Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|title date}}
-{{label|nl|titel datum}}
-{{label|pt|data do titulo}}
-|rdfs:domain = Person
-|rdfs:range = xsd:date
-}}</text></revision></page><page><title>OntologyProperty:TitleDouble</title><ns>202</ns><id>7715</id><revision><id>50087</id><timestamp>2016-01-04T12:49:26Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|title double}}
-{{label|de|Doppeltitel}}
-| rdfs:domain = TennisPlayer
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:TitleLanguage</title><ns>202</ns><id>7615</id><revision><id>26852</id><timestamp>2013-07-02T13:36:00Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|title language}}
-| rdfs:domain = Film
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:TitleSingle</title><ns>202</ns><id>7712</id><revision><id>50088</id><timestamp>2016-01-04T12:49:56Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|title single}}
-{{label|de|Einzeltitel}}
-| rdfs:domain = TennisPlayer
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Toll</title><ns>202</ns><id>3428</id><revision><id>12437</id><timestamp>2011-04-26T15:05:30Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = toll
-| rdfs:label@de = Maut
-| rdfs:domain= RouteOfTransportation
-| rdfs:range = Currency
-}}</text></revision></page><page><title>OntologyProperty:TonyAward</title><ns>202</ns><id>1521</id><revision><id>36618</id><timestamp>2014-07-08T14:23:53Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = Tony Award
-| rdfs:domain = Artist
-| rdfs:range = Award
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:TopFloorHeight</title><ns>202</ns><id>6432</id><revision><id>52171</id><timestamp>2017-08-09T09:52:31Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|top floor height}}
-{{label|de|Höhe der höchsten Etage}}
-| rdfs:domain = Skyscraper
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:TopLevelDomain</title><ns>202</ns><id>3323</id><revision><id>59647</id><timestamp>2024-06-04T20:59:27Z</timestamp><text>TopLevelDomain
-{{ObjectProperty
-| rdfs:label@en = country top level (tld)
-| rdfs:label@pt = domínio de topo (tld)
-| rdfs:label@fr = domaine de premier niveau (tld)
-| rdfs:label@am = ከፍተኛ ደረጃ ዶሜን
-| rdfs:comment@am = በዶሜን ስሞች መዋቅር ውስጥ በአናት ላይ የሚገኝና የሚከተሉትን ሁሉንም ዶሜኖች ያካትታል። ለምሳሌ፣ በ "www.example.com" ውስጥ ከፍተኛ ደረጃ ዶሜን ".com" ነው።
-| rdfs:domain = Country
-| rdfs:range = TopLevelDomain
-}}</text></revision></page><page><title>OntologyProperty:TopSpeed</title><ns>202</ns><id>1522</id><revision><id>18550</id><timestamp>2012-05-19T16:21:26Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = top speed
-| rdfs:label@de = Höchstgeschwindigkeit
-| rdfs:range = Speed
-| rdf:type = owl:FunctionalProperty
-}}</text></revision></page><page><title>OntologyProperty:Topic</title><ns>202</ns><id>7277</id><revision><id>34374</id><timestamp>2014-04-08T13:41:40Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|topic}}
-{{label|de|Thema}}
-| rdfs:domain = PopulatedPlace
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:TorchBearer</title><ns>202</ns><id>1523</id><revision><id>36619</id><timestamp>2014-07-08T14:23:56Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|de|Fackelträger}}
-	{{label|en|torch bearer}}
-| rdfs:domain = Olympics
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:hasParticipant
-}}</text></revision></page><page><title>OntologyProperty:TorqueOutput</title><ns>202</ns><id>1524</id><revision><id>8307</id><timestamp>2010-05-28T13:46:39Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = torque output
-| rdfs:domain = AutomobileEngine
-| rdfs:range = Torque
-| rdf:type = owl:FunctionalProperty
-}}</text></revision></page><page><title>OntologyProperty:TotalCargo</title><ns>202</ns><id>1525</id><revision><id>8308</id><timestamp>2010-05-28T13:46:47Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = total cargo
-| rdfs:domain = Spacecraft
-| rdfs:range = Mass
-}}</text></revision></page><page><title>OntologyProperty:TotalDiscs</title><ns>202</ns><id>5142</id><revision><id>17022</id><timestamp>2012-03-23T14:39:14Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = total discs
-| rdfs:comment@en = the total number of discs contained in the album
-| rdfs:domain = Album
-| rdfs:range = xsd:integer
-}}</text></revision></page><page><title>OntologyProperty:TotalIliCases</title><ns>202</ns><id>12303</id><revision><id>53617</id><timestamp>2020-04-10T06:37:58Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|Total Pandemic Cases}}
-| rdfs:comment@en = Total number of cases in a pandemic
-| rdfs:domain = Outbreak
-| rdfs:range = xsd:integer
-}}</text></revision></page><page><title>OntologyProperty:TotalLaunches</title><ns>202</ns><id>1526</id><revision><id>10430</id><timestamp>2010-11-10T14:55:16Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = total launches
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:TotalMass</title><ns>202</ns><id>1527</id><revision><id>34375</id><timestamp>2014-04-08T13:41:44Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = total mass
-| rdfs:label@de = Gesamtmasse
-| rdfs:domain = Spacecraft
-| rdfs:range = Mass
-}}</text></revision></page><page><title>OntologyProperty:TotalPopulation</title><ns>202</ns><id>1528</id><revision><id>34376</id><timestamp>2014-04-08T13:41:49Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = total population
-| rdfs:label@de = Gesamtbevölkerung
-| rdfs:domain = EthnicGroup
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:TotalTracks</title><ns>202</ns><id>5141</id><revision><id>53767</id><timestamp>2020-10-14T17:54:05Z</timestamp><text>{{DatatypeProperty 
-| rdfs:label@en = total tracks
-| rdfs:comment@en = the total number of tracks contained in the album
-| rdfs:domain = Album
-| rdfs:range = xsd:integer
-| owl:equivalentProperty = mo:track_count
-}}</text></revision></page><page><title>OntologyProperty:TotalTravellers</title><ns>202</ns><id>1529</id><revision><id>10432</id><timestamp>2010-11-10T14:55:44Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = total travellers
-| rdfs:domain = YearInSpaceflight
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:TotalVaccinations</title><ns>202</ns><id>13113</id><revision><id>54887</id><timestamp>2021-07-26T03:51:20Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|Total Vaccinations}}
-| comments =
-	{{comment|en|VaccinationStatistics: Total vaccinations per date and country.}}
-| rdfs:domain = owl:Thing
-| rdfs:range = VaccinationStatistics
-}}</text></revision></page><page><title>OntologyProperty:TotalVaccinationsPerHundred</title><ns>202</ns><id>13117</id><revision><id>54891</id><timestamp>2021-07-26T03:57:48Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|Total Vaccinations Per Hundred}}
-| comments =
-	{{comment|en|VaccinationStatistics: vaccinations per hundred.}}
-| rdfs:domain = owl:Thing
-| rdfs:range = VaccinationStatistics
-}}</text></revision></page><page><title>OntologyProperty:TouristicSite</title><ns>202</ns><id>6931</id><revision><id>36620</id><timestamp>2014-07-08T14:23:59Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|touristic site}}
-| rdfs:domain = PopulatedPlace
-| rdfs:range = Place
-| rdfs:subPropertyOf = dul:hasPart
-}}</text></revision></page><page><title>OntologyProperty:TournamentOfChampions</title><ns>202</ns><id>8053</id><revision><id>34377</id><timestamp>2014-04-08T13:41:53Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|tournament of champions}}
-{{label|de|Turnier der Meister}}
-| rdfs:domain = Athlete
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:TournamentRecord</title><ns>202</ns><id>1530</id><revision><id>34378</id><timestamp>2014-04-08T13:41:57Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = tournament record
-| rdfs:label@de = Turnierrekord
-| rdfs:domain = CollegeCoach
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:TowerHeight</title><ns>202</ns><id>9341</id><revision><id>56832</id><timestamp>2022-03-01T00:38:47Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|tower height}}
-{{label|fr|hauteur de la tour}}
-{{label|de|Turmhöhe}}
-{{label|nl|hoogte van de toren}}
-| rdfs:domain = Building
-| rdfs:range = xsd:positiveInteger
-}}</text></revision></page><page><title>OntologyProperty:TrackLength</title><ns>202</ns><id>3595</id><revision><id>12806</id><timestamp>2011-05-16T15:54:44Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = track length
-| rdfs:label@de = Streckenlänge
-| rdfs:domain = RouteOfTransportation
-| rdfs:range = Length
-| rdfs:comment@en = Length of the track. Wikipedians usually do not differentiate between track length and line lenght.
-}}</text></revision></page><page><title>OntologyProperty:TrackNumber</title><ns>202</ns><id>1531</id><revision><id>53765</id><timestamp>2020-10-14T17:48:52Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = track number
-| rdfs:label@de = Titelnummer
-| rdfs:label@el = νούμερο τραγουδιού
-| rdfs:domain = Song
-| rdfs:range = xsd:positiveInteger
-| owl:equivalentProperty = mo:track_number
-}}</text></revision></page><page><title>OntologyProperty:TrackWidth</title><ns>202</ns><id>11445</id><revision><id>49527</id><timestamp>2015-11-14T15:18:15Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = track width
-| rdfs:label@nl = spoorbreedte
-| rdfs:domain = RouteOfTransportation
-| rdfs:range = Length
-| rdfs:comment@en = Width of the track, e.g., the track width differing in Russia from (Western and Middle) European track width
-}}</text></revision></page><page><title>OntologyProperty:TradeMark</title><ns>202</ns><id>4783</id><revision><id>56743</id><timestamp>2022-02-28T15:47:30Z</timestamp><text>{{ObjectProperty
-| rdfs:label@en = TradeMark
-| rdfs:label@es = Marca
-| rdfs:label@fr = Marque commerciale
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:TradingName</title><ns>202</ns><id>11901</id><revision><id>52283</id><timestamp>2017-10-08T18:18:03Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = trading name
-| rdfs:label@de = Handelsname
-| rdfs:domain = Company
-| rdfs:range = xsd:string
-| rdfs:comment = Trade name, doing business as, d/b/a or fictitious business name under which a company presents itself to the public. This parameter is used only when the company has a legally registered trade name that is different from the company's full, legal name.
-}}</text></revision></page><page><title>OntologyProperty:Trainer</title><ns>202</ns><id>1532</id><revision><id>36622</id><timestamp>2014-07-08T14:24:06Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|trainer}}
-	{{label|de|Trainer}}
-	{{label|el|εκπαιδευτής}}
-	{{label|fr|entraîneur}}
-	{{label|nl|trainer}}
-| rdfs:domain = Athlete
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:TrainerClub</title><ns>202</ns><id>5642</id><revision><id>36623</id><timestamp>2014-07-08T14:24:18Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = trainer club
-| rdfs:domain = SoccerPlayer
-| rdfs:range = SportsTeam
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:TrainerYears</title><ns>202</ns><id>5643</id><revision><id>22460</id><timestamp>2013-01-12T22:56:01Z</timestamp><text>{{ DatatypeProperty
-| labels =
-{{label|en|trainer years}}
-{{label|nl|trainersjaren}}
-| rdfs:domain = SoccerPlayer
-| rdfs:range = xsd:gYear
-
-}}</text></revision></page><page><title>OntologyProperty:Training</title><ns>202</ns><id>1533</id><revision><id>36624</id><timestamp>2014-07-08T14:24:20Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = training
-| rdfs:label@de = Ausbildung
-| rdfs:label@el = προπόνηση
-| rdfs:domain = Artist
-| rdfs:range = EducationalInstitution
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:TranslatedMotto</title><ns>202</ns><id>7432</id><revision><id>26471</id><timestamp>2013-06-25T10:48:04Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|translated motto}}
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Translator</title><ns>202</ns><id>1534</id><revision><id>53672</id><timestamp>2020-07-30T21:26:18Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|translator}}
-	{{label|de|Übersetzer}}
-	{{label|nl|vertaler}}
-	{{label|el|μεταφραστής}}
-	{{label|fr|traducteur}}
-| rdfs:domain = Work
-| rdfs:range = Person
-| rdfs:comment@en = Translator(s), if original not in English
-| rdfs:subPropertyOf = dul:coparticipatesWith
-| owl:equivalentProperty = schema:translator
-}}</text></revision></page><page><title>OntologyProperty:Transmission</title><ns>202</ns><id>1535</id><revision><id>34465</id><timestamp>2014-04-08T15:05:21Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = transmission
-| rdfs:label@de = Getriebe
-| rdfs:label@el = μετάδοση
-| rdfs:domain = Automobile
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Treatment</title><ns>202</ns><id>11865</id><revision><id>52202</id><timestamp>2017-10-07T14:39:06Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|treatment}}
-	{{label|fr|traitement}}
-	{{label|de|Behandlung}}
-| rdfs:domain = Disease
-| rdfs:range = owl:Thing
-}}</text></revision></page><page><title>OntologyProperty:Tree</title><ns>202</ns><id>7135</id><revision><id>34385</id><timestamp>2014-04-08T13:42:34Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|tree}}
-{{label|de|Baum}}
-{{label|el|δέντρο}}
-| rdfs:domain = Place
-| rdfs:range = Species
-}}</text></revision></page><page><title>OntologyProperty:Tribus</title><ns>202</ns><id>9286</id><revision><id>34386</id><timestamp>2014-04-08T13:42:38Z</timestamp><text>{{ObjectProperty
-| labels = 
-{{label|en|tribus}}
-{{label|de|Stämme}}
-{{label|nl|stam}}
-| comments =
-| rdfs:domain = Species
-| rdfs:range = Species
-}}</text></revision></page><page><title>OntologyProperty:Trustee</title><ns>202</ns><id>1536</id><revision><id>36626</id><timestamp>2014-07-08T14:24:27Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = trustee
-| rdfs:label@de = Treuhänder
-| rdfs:domain = Organisation
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:Tuition</title><ns>202</ns><id>1537</id><revision><id>34466</id><timestamp>2014-04-08T15:06:26Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = tuition
-| rdfs:label@de = Schulgeld  
-| rdfs:domain = School
-| rdfs:range = Currency
-}}</text></revision></page><page><title>OntologyProperty:TvComId</title><ns>202</ns><id>2104</id><revision><id>52933</id><timestamp>2018-03-01T12:35:57Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = tv.com id
-| rdfs:domain = TelevisionShow
-| rdfs:range = xsd:integer
-| rdfs:subPropertyOf = code
-}}</text></revision></page><page><title>OntologyProperty:TvShow</title><ns>202</ns><id>6828</id><revision><id>36627</id><timestamp>2014-07-08T14:24:30Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|tvShow}}
-	{{label|de|Fernsehsendung}}
-| rdfs:domain = Person
-| rdfs:range = TelevisionShow
-| rdfs:subPropertyOf = dul:isParticipantIn
-}}</text></revision></page><page><title>OntologyProperty:TwinCountry</title><ns>202</ns><id>1539</id><revision><id>36629</id><timestamp>2014-07-08T14:24:36Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = twin country
-| rdfs:label@de = Partnerland
-| rdfs:domain = Country
-| rdfs:range = Country
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:TwinTown</title><ns>202</ns><id>1538</id><revision><id>47636</id><timestamp>2015-04-03T14:53:33Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|twin city}}
-	{{label|de|Partnerstadt}}
-	{{label|nl|tweeling stad}}
-| rdfs:domain = Settlement
-| rdfs:range = Settlement
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:Type</title><ns>202</ns><id>1540</id><revision><id>51774</id><timestamp>2016-12-20T07:28:44Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|type}}
-	{{label|de|Typ}}
-	{{label|el|τύπος}}
-	{{label|es|tipo}}
-	{{label|fr|type}}
-	{{label|nl|type}}
-	{{label|hi|प्रकार}}
-| owl:equivalentProperty = &lt;!-- not wikidata:P31, see Discussion page --&gt;
-| rdfs:subPropertyOf = dul:isClassifiedBy
-}}</text></revision></page><page><title>OntologyProperty:TypeCoordinate</title><ns>202</ns><id>7208</id><revision><id>39117</id><timestamp>2015-01-09T19:00:17Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|type coordinate}}
-| comments =
-{{comment|en|Scale parameters that can be understood by Geohack, eg "type:", "scale:", "region:" "altitude:". Use "_" for several (eg "type:landmark_scale:50000"). See https://fr.wikipedia.org/wiki/Modèle:Infobox_Subdivision_administrative for examples, and https://fr.wikipedia.org/wiki/Modèle:GeoTemplate/Utilisation#La_mention_Type:... for a complete list}}
-| rdfs:domain = Place
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:TypeOfElectrification</title><ns>202</ns><id>3591</id><revision><id>36631</id><timestamp>2014-07-08T14:24:42Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = type of electrification
-| rdfs:label@de = Art der Elektrifizierung
-| rdfs:domain = RouteOfTransportation
-| rdfs:range = owl:Thing
-| rdfs:comment@en = Electrification system (e.g. Third rail, Overhead catenary).
-| rdfs:subPropertyOf = dul:isClassifiedBy
-}}</text></revision></page><page><title>OntologyProperty:TypeOfGrain</title><ns>202</ns><id>8915</id><revision><id>34393</id><timestamp>2014-04-08T13:43:18Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|type of grain (wheat etc.)}}
-{{label|de|Getreideart (Weizen usw.)}}
-{{label|nl|graansoort}}
-| rdfs:domain = Food
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:TypeOfStorage</title><ns>202</ns><id>8918</id><revision><id>34394</id><timestamp>2014-04-08T13:43:22Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|type of storage}}
-{{label|de|Art der Lagerung}}
-{{label|nl|lagering}}
-| rdfs:domain = Food
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:TypeOfYeast</title><ns>202</ns><id>8916</id><revision><id>34467</id><timestamp>2014-04-08T15:07:11Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|type of yeast}}
-{{label|de|Hefearte}}
-{{label|nl|gistsoort}}
-| rdfs:domain = Food
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:URN</title><ns>202</ns><id>3121</id><revision><id>52897</id><timestamp>2018-02-13T12:34:18Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = unique reference number (URN)
-| rdfs:comment@en = DfE unique reference number of a school in England or Wales
-| rdfs:domain = School
-| rdfs:subPropertyOf = code
-}}</text></revision></page><page><title>OntologyProperty:UciCode</title><ns>202</ns><id>7358</id><revision><id>26204</id><timestamp>2013-06-18T13:08:18Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|UCI code}}
-{{label|it|codice UCI}}
-| comments =
-{{comment|en|Official UCI code for cycling teams}}
-| rdfs:domain = CyclingTeam
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:UlanId</title><ns>202</ns><id>8427</id><revision><id>52888</id><timestamp>2018-02-13T11:02:02Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|ULAN id}}
-| comments =
-{{comment|en|Union List of Artist Names id (Getty Research Institute). ULAN has 293,000 names and other information about artists. Names in ULAN may include given names, pseudonyms, variant spellings, names in multiple languages, and names that have changed over time (e.g., married names).
-http://vocab.getty.edu/ulan/$1}}
-| rdfs:range = xsd:string
-| owl:equivalentProperty = wikidata:P245
-| rdfs:subPropertyOf = code
-}}</text></revision></page><page><title>OntologyProperty:UmbrellaTitle</title><ns>202</ns><id>5987</id><revision><id>34821</id><timestamp>2014-05-15T05:05:32Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|umbrella title}}
-{{label|nl|overkoepelende titel}}
-| rdfs:domain = MultiVolumePublication
-| rdfs:range = rdf:langString
-| rdfs:comment@en =
-}}</text></revision></page><page><title>OntologyProperty:UnNumber</title><ns>202</ns><id>12040</id><revision><id>52794</id><timestamp>2018-02-07T09:45:54Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = UN number
-| rdfs:label@de = UN Nummer
-| rdfs:label@fr = numéro ONU
-| rdfs:comment@en = four-digit numbers that identify hazardous substances, and articles in the framework of international transport
-| rdfs:domain = ChemicalSubstance
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Uncle</title><ns>202</ns><id>12293</id><revision><id>53593</id><timestamp>2020-01-30T18:46:01Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|uncle}}
-	{{label|nl|oom}}
-	{{label|de|Onkel}}
-	{{label|el|θείος}}
-	{{label|ja|おじさん}}
-	{{label|ar|اخو الام}}
-| rdfs:domain = Man
-| rdfs:range = Person
-| owl:propertyDisjointWith = Aunt
-}}</text></revision></page><page><title>OntologyProperty:UndraftedYear</title><ns>202</ns><id>1543</id><revision><id>8318</id><timestamp>2010-05-28T13:48:06Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = undrafted year
-| rdfs:domain = GridironFootballPlayer
-| rdfs:range = xsd:gYear
-}}</text></revision></page><page><title>OntologyProperty:Unesco</title><ns>202</ns><id>6983</id><revision><id>36633</id><timestamp>2014-07-08T14:24:49Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|unesco}}
-| rdfs:range = PopulatedPlace
-| rdfs:domain = Place
-| rdfs:subPropertyOf = dul:hasPart
-}}</text></revision></page><page><title>OntologyProperty:Unicode</title><ns>202</ns><id>5349</id><revision><id>34396</id><timestamp>2014-04-08T13:43:30Z</timestamp><text>{{ DatatypeProperty
-| labels =
-   {{label|en|unicode}}
-{{label|de|Unicode}}
-   {{label|el|unicode}}
-| comments =
-   {{comment|el|το διεθνές πρότυπο Unicode στοχεύει στην κωδικοποίηση όλων των συστημάτων γραφής που χρησιμοποιούνται στον πλανήτη.}}
-| rdfs:domain = Letter
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Uniprot</title><ns>202</ns><id>1544</id><revision><id>19129</id><timestamp>2012-07-31T11:14:37Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = UniProt
-| rdfs:label@ja = UniProt
-| rdfs:domain = Biomolecule
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:UnitCost</title><ns>202</ns><id>1545</id><revision><id>34397</id><timestamp>2014-04-08T13:43:43Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = unit cost
-| rdfs:label@de = Stückkosten
-| rdfs:domain = Aircraft
-| rdfs:range = Currency
-}}</text></revision></page><page><title>OntologyProperty:UnitaryAuthority</title><ns>202</ns><id>2142</id><revision><id>36634</id><timestamp>2014-07-08T14:24:54Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = unitary authority
-| rdfs:label@sr = унитарна власт
-| rdfs:domain = PopulatedPlace
-| rdfs:range = PopulatedPlace
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:UnitedStatesNationalBridgeId</title><ns>202</ns><id>1546</id><revision><id>30625</id><timestamp>2014-01-22T08:18:56Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = United States National Bridge ID
-| rdfs:label@sr = ID националног моста у Сједињеним Америчким Државама 
-| rdfs:domain = Bridge
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:University</title><ns>202</ns><id>1547</id><revision><id>52569</id><timestamp>2017-10-30T23:24:56Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|university}}
-	{{label|de|Universität}}
-	{{label|el|πανεπιστήμιο}}
-	{{label|sr|универзитет}}
-	{{label|ja|大学}}
-| comments =
-	{{comment|en|university a person goes or went to.}}
-	{{comment|el|To πανεπιστήμιο είναι εκπαιδευτικό ίδρυμα ανώτατης εκπαίδευσης και επιστημονικής έρευνας που παρέχει πτυχίο πιστοποίησης ακαδημαϊκής εκπαίδευσης.}}
-| rdfs:range = EducationalInstitution
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:UnknownOutcomes</title><ns>202</ns><id>1548</id><revision><id>30618</id><timestamp>2014-01-22T08:11:42Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = unknown outcomes
-| rdfs:label@sr = непознати исходи
-| rdfs:domain = Rocket
-| rdfs:range = xsd:nonNegativeInteger
-| rdfs:comment@en = number of launches with unknown outcomes (or in progress)
-| rdfs:comment@sr = број лансирања са непознатим исходом или број лансирања који су у току
-}}</text></revision></page><page><title>OntologyProperty:UnloCode</title><ns>202</ns><id>2438</id><revision><id>48370</id><timestamp>2015-06-16T06:01:53Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = UN/LOCODE
-| rdfs:label@sr = UN/LOCODE
-| rdfs:comment@en = UN/LOCODE, the United Nations Code for Trade and Transport Locations, is a geographic coding scheme developed and maintained by United Nations Economic Commission for Europe (UNECE), a unit of the United Nations. UN/LOCODE assigns codes to locations used in trade and transport  with functions such as seaports, rail and road terminals, airports, post offices and border crossing points.
-| rdfs:comment@sr = UN/LOCODE је код Уједињених нација за трговинске и транспортне локације. Као што су луке, железнички и путни терминали, аеродроми, поште и гранични прелази.
-| rdfs:domain = Place
-| rdfs:range = xsd:string
-| owl:equivalentProperty = wikidata:P1937
-}}</text></revision></page><page><title>OntologyProperty:Updated</title><ns>202</ns><id>5138</id><revision><id>30605</id><timestamp>2014-01-22T07:55:23Z</timestamp><text>{{DatatypeProperty 
-| rdfs:label@en   = updated
-| rdfs:label@sr = ажуриран
-| rdfs:comment@en =  The last update date of a resource
-| rdfs:comment@sr =  датум последње измене 
-| rdfs:domain = owl:Thing
-| rdfs:range  = xsd:date
-}}</text></revision></page><page><title>OntologyProperty:UpperAge</title><ns>202</ns><id>1549</id><revision><id>30597</id><timestamp>2014-01-22T07:47:48Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = upper age
-| rdfs:label@sr= горња старосна граница
-| rdfs:domain = School
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:UrbanArea</title><ns>202</ns><id>6851</id><revision><id>49219</id><timestamp>2015-10-15T07:16:22Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|urban area}}
-{{label|de|Stadtgebiet}}
-{{label|sr|урбано подручје}}
-| rdfs:domain = Settlement
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:UsOpenDouble</title><ns>202</ns><id>7725</id><revision><id>50073</id><timestamp>2016-01-04T12:34:55Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|us open double}}
-{{label|sr|US Open дубл}}
-| rdfs:domain = TennisPlayer
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:UsOpenMixed</title><ns>202</ns><id>7729</id><revision><id>50074</id><timestamp>2016-01-04T12:35:50Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|us open mixed}}
-{{label|sr|US Open микс дубл}}
-| rdfs:domain = TennisPlayer
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:UsOpenSingle</title><ns>202</ns><id>7721</id><revision><id>50089</id><timestamp>2016-01-04T12:50:44Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|us open single}}
-{{label|sr|US Open појединачно}}
-| rdfs:domain = TennisPlayer
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:UsSales</title><ns>202</ns><id>1551</id><revision><id>50967</id><timestamp>2016-04-26T14:45:15Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = US sales
-| rdfs:label@de = US-Verkäufe
-| rdfs:label@sr = продаја у САД
-| rdfs:domain = Sales
-| rdfs:range = xsd:nonNegativeInteger
-| rdfs:comment@en = Number of things (eg vehicles) sold in the US
-}}</text></revision></page><page><title>OntologyProperty:UsedInWar</title><ns>202</ns><id>1570</id><revision><id>36636</id><timestamp>2014-07-08T14:25:01Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = used in war
-| rdfs:label@de = im Krieg eingesetzt
-| rdfs:label@sr = коришћено у рату
-| rdfs:domain = Weapon
-| rdfs:range = MilitaryConflict
-| rdfs:comment@en = wars that were typical for the usage of a weapon
-| rdfs:subPropertyOf = dul:isParticipantIn
-}}</text></revision></page><page><title>OntologyProperty:Uses</title><ns>202</ns><id>6801</id><revision><id>36637</id><timestamp>2014-07-08T14:25:05Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = uses
-| rdfs:label@sr = користи
-| rdfs:domain = owl:Thing
-| rdfs:range = owl:Thing
-| rdfs:subPropertyOf = dul:isParticipantIn
-}}</text></revision></page><page><title>OntologyProperty:UsingCountry</title><ns>202</ns><id>1550</id><revision><id>36638</id><timestamp>2014-07-08T14:25:10Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = using country
-| rdfs:domain = Currency
-| rdfs:range = Country
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:Usk</title><ns>202</ns><id>6413</id><revision><id>34402</id><timestamp>2014-04-08T13:44:02Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|approved rating of the Entertainment Software Self-Regulation Body in Germany}}
-{{label|de|zugelassene Bewertung der Unterhaltungssoftware Selbstkontrolle in Deutschland}}
-{{label|sr|одобрени рејтинг од стране регулаторног тела за забавни софтвер у Немачкој }}
-| rdfs:domain = owl:Thing
-| rdfs:range = xsd:integer
-}}</text></revision></page><page><title>OntologyProperty:UsopenWins</title><ns>202</ns><id>7647</id><revision><id>30606</id><timestamp>2014-01-22T07:56:21Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|usopen wins}}
-{{label|sr|победе на US Open-у}}
-| rdfs:domain = Person
-| rdfs:range = skos:Concept
-}}</text></revision></page><page><title>OntologyProperty:Usurper</title><ns>202</ns><id>7636</id><revision><id>30575</id><timestamp>2014-01-22T07:15:48Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|usurper}}
-{{label|sr|узурпатор}}
-| rdfs:domain = Person
-| rdfs:range = Person
-}}</text></revision></page><page><title>OntologyProperty:UtcOffset</title><ns>202</ns><id>4200</id><revision><id>30574</id><timestamp>2014-01-22T07:10:27Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = UTC offset
-| rdfs:label@sr = UTC офсет
-| rdfs:domain = Place
-| rdfs:range = xsd:string
-| rdfs:comment = The UTC offset is the time offset from Coordinated Universal Time (UTC). It is mostly given as hour or hour and minute.
-| rdfs:comment = UTC офсет је временски офсет који се мери од Универзалне временске координате. Најчешће се приказује у сатима и минутима.
-}}</text></revision></page><page><title>OntologyProperty:V hb</title><ns>202</ns><id>6156</id><revision><id>20721</id><timestamp>2012-12-23T12:34:42Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = V_hb
-| rdfs:domain = Globularswarm
-| rdfs:range = xsd:integer
-}}</text></revision></page><page><title>OntologyProperty:Vaccination</title><ns>202</ns><id>13093</id><revision><id>54829</id><timestamp>2021-07-07T19:02:28Z</timestamp><text>{{ObjectProperty 
-| rdfs:label@en          = vaccination
-| rdfs:domain            = Disease
-| rdfs:range             = Vaccine
-}}</text></revision></page><page><title>OntologyProperty:Vaccine</title><ns>202</ns><id>13109</id><revision><id>56976</id><timestamp>2022-03-09T10:36:48Z</timestamp><text>{{DatatypeProperty
-| labels =
-    {{label|en|Vaccine}}
-    {{label|fr|Vaccin}}
-    {{label|zh|疫苗}}
-| rdfs:domain = owl:Thing
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Value</title><ns>202</ns><id>7907</id><revision><id>51091</id><timestamp>2016-05-14T15:28:09Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|value}}
-{{label|de|Wert}}
-{{label|fr|valeur}}
-{{label|sr|вредност}}
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:Valvetrain</title><ns>202</ns><id>1552</id><revision><id>51064</id><timestamp>2016-05-11T08:50:34Z</timestamp><text>
-{{DatatypeProperty
-| rdfs:label@en = valvetrain
-| rdfs:label@de = Ventilsteuerung
-| rdfs:label@fr = distribution (moteur)
-| rdfs:domain = AutomobileEngine
-| rdfs:range = valvetrain
-| rdfs:subPropertyOf = &lt;!-- dul:hasComponent -- defined as object property, see https://github.com/dbpedia/ontology-tracker/issues/9 --&gt;
-}}</text></revision></page><page><title>OntologyProperty:VaporPressure</title><ns>202</ns><id>11849</id><revision><id>52803</id><timestamp>2018-02-07T19:33:00Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|vapor pressure}}
-{{label|nl|dampdruk}}
-| rdfs:domain = ChemicalSubstance
-| rdfs:range = hectopascal
-}}</text></revision></page><page><title>OntologyProperty:VariantOf</title><ns>202</ns><id>1554</id><revision><id>36640</id><timestamp>2014-07-08T14:25:18Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|variant or variation}}
-	{{label|de|Variante oder Variation}}
-	{{label|sr|варијанта}}
-	{{label|nl|variant}}
-| rdfs:comment@en = variant or variation of something, for example the variant of a car
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}
-варијанта</text></revision></page><page><title>OntologyProperty:Varietals</title><ns>202</ns><id>1555</id><revision><id>36641</id><timestamp>2014-07-08T14:25:30Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = varietals
-| rdfs:label@de = Rebsorten
-| rdfs:domain = WineRegion
-| rdfs:subPropertyOf = dul:isLocationOf
-}}</text></revision></page><page><title>OntologyProperty:Vehicle</title><ns>202</ns><id>1556</id><revision><id>36642</id><timestamp>2014-07-08T14:25:33Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = vehicle
-| rdfs:label@sr = возило
-| rdfs:label@el = όχημα
-| rdfs:label@de = Vehikel
-| rdfs:range = Automobile
-| rdfs:comment@en = vehicle that uses a specific automobile platform
-| rdfs:comment@el = όχημα που χρησιμοποιεί μια συγκεκριμένη πλατφόρμα αυτοκινήτων
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:VehicleCode</title><ns>202</ns><id>2437</id><revision><id>30556</id><timestamp>2014-01-21T15:10:56Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|de|KFZ-Kennzeichen}}
-{{label|en|vehicle code}}
-{{label|sr|код возила}}
-{{label|nl|voertuig code}}
-| rdfs:comment@en = Region related vehicle code on the vehicle plates.
-| rdfs:domain = Place
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:VehiclesInFleet</title><ns>202</ns><id>11894</id><revision><id>52257</id><timestamp>2017-10-08T10:03:30Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|vehicle types in fleet}}
-	{{label|de|Fahrzeugtypen der Flotte}}
-| rdfs:domain = PublicTransitSystem
-| rdfs:range = MeanOfTransportation
-| comments =
-{{comment|en|Points out means of transport contained in the companies vehicle fleet.}}
-}}</text></revision></page><page><title>OntologyProperty:VehiclesPerDay</title><ns>202</ns><id>3429</id><revision><id>30615</id><timestamp>2014-01-22T08:09:54Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = vehicles per day
-| rdfs:label@sr = број возила по дану
-| rdfs:label@de = Fahrzeuge pro Tag
-| rdfs:domain= RouteOfTransportation
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:Vein</title><ns>202</ns><id>1557</id><revision><id>36643</id><timestamp>2014-07-08T14:25:35Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = vein
-| rdfs:label@de = Vene
-| rdfs:label@sr = вена
-| rdfs:domain = AnatomicalStructure
-| rdfs:range = Vein
-| rdfs:subPropertyOf = dul:hasCommonBoundary
-}}</text></revision></page><page><title>OntologyProperty:VeneratedIn</title><ns>202</ns><id>1558</id><revision><id>36644</id><timestamp>2014-07-08T14:25:39Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|venerated in}}
-	{{label|sr|поштован у}}
-	{{label|nl|vereerd in}}
-| rdfs:domain = Saint
-| rdfs:range = Organisation
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:Version</title><ns>202</ns><id>9133</id><revision><id>31682</id><timestamp>2014-02-10T17:26:28Z</timestamp><text>{{ObjectProperty
-| rdfs:label@en = version
-| rdfs:label@de = Version
-| rdfs:label@nl = versie
-| rdfs:domain = MeanOfTransportation
-}}</text></revision></page><page><title>OntologyProperty:ViafId</title><ns>202</ns><id>8417</id><revision><id>52889</id><timestamp>2018-02-13T11:02:59Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|VIAF Id}}
-{{label|sr|VIAF Id}}
-{{label|nl|VIAF code}}
-| comments =
-{{comment|en|Virtual International Authority File ID (operated by Online Computer Library Center, OCLC). Property range set to Agent because of corporate authors }}
-| rdfs:range = xsd:string
-| owl:equivalentProperty = wikidata:P214
-| rdfs:subPropertyOf = code
-}}</text></revision></page><page><title>OntologyProperty:ViceChancellor</title><ns>202</ns><id>1559</id><revision><id>36645</id><timestamp>2014-07-08T14:25:42Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = vice chancellor
-| rdfs:label@sr = потканцелар
-| rdfs:label@de = Vizekanzler
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:ViceLeader</title><ns>202</ns><id>3355</id><revision><id>36646</id><timestamp>2014-07-08T14:25:45Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = vice leader
-| rdfs:label@pt = vicelider
-| rdfs:domain = PopulatedPlace
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:ViceLeaderParty</title><ns>202</ns><id>3356</id><revision><id>36647</id><timestamp>2014-07-08T14:25:49Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = vice leader party
-| rdfs:label@de = stellvertretender Parteivorsitzende
-| rdfs:label@pt = partido do vicelider
-| rdfs:domain = PopulatedPlace
-| rdfs:range = PoliticalParty
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:VicePresident</title><ns>202</ns><id>2344</id><revision><id>56823</id><timestamp>2022-03-01T00:14:37Z</timestamp><text>{{ObjectProperty
-| labels = 
-    {{label|en|vice president}}
-    {{label|fr|vice président}}
-    {{label|sr|потпредседник}}
-    {{label|de|Vizepräsident}}
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:VicePrimeMinister</title><ns>202</ns><id>2345</id><revision><id>36649</id><timestamp>2014-07-08T14:25:56Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|vice prime minister}}
-	{{label|de|Vizeministerpräsident}}
-	{{label|sr|заменик премијера}}
-	{{label|nl|vice premier}}
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:VicePrincipal</title><ns>202</ns><id>1561</id><revision><id>36650</id><timestamp>2014-07-08T14:26:00Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = vice principal
-| rdfs:label@sr = заменик директора
-| rdfs:domain = School
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:VicePrincipalLabel</title><ns>202</ns><id>3117</id><revision><id>36651</id><timestamp>2014-07-08T14:26:04Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = vice principal label
-| rdfs:domain = School
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:Victim</title><ns>202</ns><id>8030</id><revision><id>51239</id><timestamp>2016-06-09T10:16:20Z</timestamp><text>{{ObjectProperty
-| labels = 
-{{label|en|victim (resource)}}
-{{label|de|das Opfer (resource)}}
-{{label|sr|жртва (resource)}}
-| rdfs:domain = owl:Thing
-| rdfs:range = owl:Thing
-| rdfs:comment@en = Specific (eg notable) person, or specific class of people (eg Romani) that are victim of a ConcentrationCamp, Criminal, SerialKiller, or some other atrocity
-}}</text></revision></page><page><title>OntologyProperty:Victims</title><ns>202</ns><id>11700</id><revision><id>51237</id><timestamp>2016-06-09T10:03:39Z</timestamp><text>{{DatatypeProperty
-| labels = 
-{{label|en|victims (string)}}
-{{label|de|die Opfer (string)}}
-{{label|sr|жртви (string)}}
-| rdfs:domain = owl:Thing
-| rdfs:range = xsd:string
-| rdfs:comment@en = Type, description, or name(s) of victims of a ConcentrationCamp, Criminal, SerialKiller, or some other atrocity
-}}</text></revision></page><page><title>OntologyProperty:Victory</title><ns>202</ns><id>7586</id><revision><id>34411</id><timestamp>2014-04-08T13:44:39Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|victory}}
-{{label|de|Sieg}}
-{{label|sr|победа}}
-| rdfs:domain = Person
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:VictoryAsMgr</title><ns>202</ns><id>7661</id><revision><id>26920</id><timestamp>2013-07-03T12:23:46Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|victory as manager}}
-| rdfs:domain = Person
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:VictoryPercentageAsMgr</title><ns>202</ns><id>7663</id><revision><id>30535</id><timestamp>2014-01-21T14:53:15Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|victory percentage as manager}}
-{{label|sr|проценат победа на месту менаџера}}
-| rdfs:domain = Person
-| rdfs:range = xsd:double
-}}</text></revision></page><page><title>OntologyProperty:VirtualChannel</title><ns>202</ns><id>3182</id><revision><id>30628</id><timestamp>2014-01-22T08:21:33Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = virtual channel
-| rdfs:label@sr = виртуелни канал
-| rdfs:label@el = εικονικό κανάλι
-| rdfs:domain = Broadcaster
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:VisitorStatisticsAsOf</title><ns>202</ns><id>3239</id><revision><id>30632</id><timestamp>2014-01-22T08:26:51Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = visitor statistics as of
-| rdfs:label@sr = статистика посетилаца од
-| rdfs:domain = ArchitecturalStructure
-| rdfs:range = xsd:gYear
-| rdfs:comment@en = Year visitor information was gathered.
-}}</text></revision></page><page><title>OntologyProperty:VisitorsPerDay</title><ns>202</ns><id>3451</id><revision><id>30529</id><timestamp>2014-01-21T14:47:28Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = visitors per day
-| rdfs:label@sr= број посетилаца по дану
-| rdfs:label@de = Besucher pro Tag
-| rdfs:domain = ArchitecturalStructure
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:VisitorsPerYear</title><ns>202</ns><id>1565</id><revision><id>30528</id><timestamp>2014-01-21T14:46:14Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|visitors per year}}
-{{label|sr|годишњи број посетилаца}}
-{{label|nl|bezoekers per jaar}}
-{{label|de|Besucher pro Jahr}}
-| rdfs:domain = ArchitecturalStructure
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:VisitorsPercentageChange</title><ns>202</ns><id>3250</id><revision><id>30525</id><timestamp>2014-01-21T14:45:07Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = visitor percentage change
-| rdfs:label@sr= промена процента посетилаца
-| rdfs:label@de = prozentuale Veränderung der Besucherzahl
-| rdfs:domain = ArchitecturalStructure
-| rdfs:range = xsd:double
-| rdfs:comment@en = Percentage increase or decrease.
-}}</text></revision></page><page><title>OntologyProperty:VisitorsTotal</title><ns>202</ns><id>1566</id><revision><id>34412</id><timestamp>2014-04-08T13:44:47Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = visitors total
-| rdfs:label@de = Gesamtbesucher
-| rdfs:label@sr= укупан број посетилаца
-| rdfs:label@el = επιβατική κίνηση
-| rdfs:domain = ArchitecturalStructure
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:Voice</title><ns>202</ns><id>1567</id><revision><id>58796</id><timestamp>2022-05-31T15:31:26Z</timestamp><text>{{ObjectProperty
-| rdfs:label@en = voice
-| rdfs:label@de = Stimme
-| rdfs:label@sr = глас
-| rdfs:comment@en = Voice artist used in a TelevisionShow, Movie, or to sound the voice of a FictionalCharacter
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:sameSettingAs
-| owl:equivalentProperty = wikidata:P990
-}}</text></revision></page><page><title>OntologyProperty:VoiceType</title><ns>202</ns><id>1568</id><revision><id>56803</id><timestamp>2022-02-28T21:58:02Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|voice type}}
-        {{label|fr|type de voix}}
-	{{label|de|Stimmlage}}
-	{{label|sr|тип гласа}}
-	{{label|nl|stemtype}}
-| rdfs:domain = Artist
-| comments =
-    {{comment|en|voice type of a singer or an actor}}
-    {{comment|fr|type de voix pour un chanteur ou un acteur}}
-| rdfs:subPropertyOf = dul:isClassifiedBy
-}}</text></revision></page><page><title>OntologyProperty:VolcanicActivity</title><ns>202</ns><id>7061</id><revision><id>57036</id><timestamp>2022-03-09T13:59:59Z</timestamp><text>{{DatatypeProperty
-| labels =
-  {{label|en|volcanic activity}}
-  {{label|fr|activité volcanique}}
-  {{label|de|vulkanische Aktivität}}
-  {{label|sr|вулканска активност}}
-| rdfs:domain = Island
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:VolcanicType</title><ns>202</ns><id>7060</id><revision><id>34416</id><timestamp>2014-04-08T13:45:07Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|volcanic type}}
-{{label|de|Vulkantyp}}
-{{label|sr|тип вулкана}}
-| rdfs:domain = Island
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:VolcanoId</title><ns>202</ns><id>7063</id><revision><id>30636</id><timestamp>2014-01-22T08:29:56Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|volcano id}}
-{{label|sr|id вулкана}}
-| rdfs:domain = Island
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:VoltageOfElectrification</title><ns>202</ns><id>3592</id><revision><id>30637</id><timestamp>2014-01-22T08:30:37Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = voltage of electrification
-| rdfs:label@de = Voltzahl der Elektrifizierung
-| rdfs:domain = RouteOfTransportation
-| rdfs:range = Voltage
-| rdfs:comment@en = Voltage of the electrification system.
-}}</text></revision></page><page><title>OntologyProperty:Volume</title><ns>202</ns><id>1569</id><revision><id>34417</id><timestamp>2014-04-08T13:45:11Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|volume}}
-{{label|de|Volumen}}
-{{label|sr|запремина}}
-{{label|nl|volume}}
-{{label|el|όγκος}}
-{{label|fr|volume}}
-| rdfs:range = Volume
-}}</text></revision></page><page><title>OntologyProperty:VolumeQuote</title><ns>202</ns><id>7095</id><revision><id>25619</id><timestamp>2013-05-26T13:35:04Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|volume quote}}
-| rdfs:domain = Place
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Volumes</title><ns>202</ns><id>5989</id><revision><id>36654</id><timestamp>2014-07-08T14:26:13Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|volumes}}
-	{{label|sr|томови}}
-	{{label|nl|delen}}
-| rdfs:domain = MultiVolumePublication
-| rdfs:range = WrittenWork
-| rdfs:comment@en = 
-| rdfs:subPropertyOf = dul:hasMember
-}}</text></revision></page><page><title>OntologyProperty:VonKlitzingConstant</title><ns>202</ns><id>9120</id><revision><id>45845</id><timestamp>2015-03-14T20:09:45Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|von Klitzing electromagnetic constant (RK)}}
-{{label|de|von Klitzing elektromagnetisch Konstant (RK)}}
-| rdfs:domain = CelestialBody
-| rdfs:range = xsd:double
-}}</text></revision></page><page><title>OntologyProperty:VotesAgainst</title><ns>202</ns><id>9130</id><revision><id>34418</id><timestamp>2014-04-08T13:45:16Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = Votes against the resolution
-| rdfs:label@de = Stimmen gegen die Resolution
-| rdfs:label@nl = Aantal stemmen tegen
-| rdfs:domain = StatedResolution
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:VotesFor</title><ns>202</ns><id>9131</id><revision><id>34419</id><timestamp>2014-04-08T13:45:20Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = Number of votes in favour of the resolution
-| rdfs:label@de = Anzahl der Stimmen für die Resolution
-| rdfs:label@nl = Aantal stemmen voor
-| rdfs:domain = StatedResolution
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:Wagon</title><ns>202</ns><id>11442</id><revision><id>49522</id><timestamp>2015-11-14T14:52:00Z</timestamp><text>{{ObjectProperty
-| rdfs:label@en = train carriage
-| rdfs:label@nl = wagon
-| rdfs:domain = Train
-| rdfs:range = TrainCarriage
-}}</text></revision></page><page><title>OntologyProperty:WaistSize</title><ns>202</ns><id>2411</id><revision><id>43314</id><timestamp>2015-02-06T12:17:27Z</timestamp><text>{{DatatypeProperty
- |rdfs:label@en=waist size
- |rdfs:label@sr=димензије струка
- |rdfs:label@de=Taillenumfang
- |rdfs:label@ja=ウエスト
- |rdfs:label@bg=размер талия
- |rdfs:domain=Person
- |rdfs:range=Length
-}}</text></revision></page><page><title>OntologyProperty:War</title><ns>202</ns><id>5659</id><revision><id>34420</id><timestamp>2014-04-08T13:45:24Z</timestamp><text>{{ DatatypeProperty
-| labels = 
-  {{label|en|wars}}
-{{label|de|Kriege}}
-  {{label|sr|ратови}}
-  {{label|el|πολέμους}}
-
-	| rdfs:domain = MilitaryPerson 
-	| rdfs:range = xsd:string
-
-}}</text></revision></page><page><title>OntologyProperty:Ward</title><ns>202</ns><id>6963</id><revision><id>30639</id><timestamp>2014-01-22T08:35:07Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|ward of a liechtenstein settlement}}
-| rdfs:domain = LiechtensteinSettlement
-| rdfs:range = xsd:string
-}}
-штићеник од Лихтенштајна насеља</text></revision></page><page><title>OntologyProperty:Water</title><ns>202</ns><id>7146</id><revision><id>57035</id><timestamp>2022-03-09T13:58:20Z</timestamp><text>{{DatatypeProperty
-| labels =
-  {{label|en|water}}
-  {{label|fr|eau}}
-  {{label|de|Wasser}}
-  {{label|sr|вода}}
-| rdfs:domain = Place
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:WaterArea</title><ns>202</ns><id>7039</id><revision><id>30505</id><timestamp>2014-01-21T14:10:57Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|area of water}}
-{{label|sr|површина воде}}
-| rdfs:domain = Place
-| rdfs:range = Area
-| owl:equivalentProperty = area
-}}</text></revision></page><page><title>OntologyProperty:WaterPercentage</title><ns>202</ns><id>7040</id><revision><id>34422</id><timestamp>2014-04-08T13:45:32Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|water percentage of a place}}
-{{label|de|Wasseranteil von einem Ort}}
-{{label|sr|проценат воде неког места}}
-| rdfs:domain = Place
-| rdfs:range = xsd:float
-}}</text></revision></page><page><title>OntologyProperty:Watercourse</title><ns>202</ns><id>7279</id><revision><id>34423</id><timestamp>2014-04-08T13:45:36Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|watercourse}}
-{{label|de|Wasserlauf}}
-{{label|sr|водоток}}
-| rdfs:domain = PopulatedPlace
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Watershed</title><ns>202</ns><id>1571</id><revision><id>34424</id><timestamp>2014-04-08T13:45:45Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|watershed}}
-{{label|de|Wasserscheide}}
-{{label|nl|waterscheiding}}
-{{label|es|cuenca hidrográfica}}
-{{label|el|λεκάνη_απορροής}}
-| rdfs:domain = Stream
-| rdfs:range = Area
-}}</text></revision></page><page><title>OntologyProperty:WaterwayThroughTunnel</title><ns>202</ns><id>3432</id><revision><id>36655</id><timestamp>2014-07-08T14:26:16Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = waterway through tunnel
-| rdfs:label@sr = пловни пут кроз тунел
-| rdfs:label@de = Wasserweg durch Tunnel
-| rdfs:domain = WaterwayTunnel
-| rdfs:range = owl:Thing
-| rdfs:comment@en = Waterway that goes through the tunnel.
-| rdfs:subPropertyOf = dul:hasCommonBoundary
-}}</text></revision></page><page><title>OntologyProperty:Wavelength</title><ns>202</ns><id>2192</id><revision><id>34425</id><timestamp>2014-04-08T13:45:54Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = wavelength
-| rdfs:label@de = Wellenlänge
-| rdfs:label@sr= таласна дужина
-| rdfs:label@fr = longueur d'onde
-| rdfs:range = Length
-| rdfs:domain = Colour
-}}</text></revision></page><page><title>OntologyProperty:Weapon</title><ns>202</ns><id>6817</id><revision><id>52867</id><timestamp>2018-02-13T10:28:11Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|weapon}}
-{{label|de|Waffe}}
-{{label|sr|оружје}}
-{{label|nl|wapen}}
-{{label|fr|arme}}
-| rdfs:domain = MilitaryConflict , Attack
-| rdfs:range = Weapon
-}}</text></revision></page><page><title>OntologyProperty:Webcast</title><ns>202</ns><id>3089</id><revision><id>36656</id><timestamp>2014-07-08T14:26:19Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|webcast}}
-	{{label|de|webcast}}
-	{{label|nl|webcast}}
-| rdfs:domain = owl:Thing
-| rdfs:range = owl:Thing
-| rdfs:comment@en = The URL to the webcast of the Thing.
-| rdfs:subPropertyOf = dul:isClassifiedBy
-}}</text></revision></page><page><title>OntologyProperty:WebsiteLabel</title><ns>202</ns><id>6932</id><revision><id>34852</id><timestamp>2014-05-15T05:20:03Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|label of a website}}
-| rdfs:range = rdf:langString
-}}</text></revision></page><page><title>OntologyProperty:WeddingParentsDate</title><ns>202</ns><id>3350</id><revision><id>56774</id><timestamp>2022-02-28T18:29:37Z</timestamp><text>{{DatatypeProperty
-| labels = 
-    {{label|en|Parents Wedding Date}} 
-    {{label|fr|date de marriage des parents}} 
-    {{label|sr|датум венчања родитеља}}
-    {{label|de|Hochzeitstag der Eltern}}
-    {{label|pt|data do casamento dos pais}}
-|rdfs:domain = Person
-|rdfs:range = xsd:date
-}}</text></revision></page><page><title>OntologyProperty:Weight</title><ns>202</ns><id>1572</id><revision><id>52778</id><timestamp>2018-01-23T15:03:37Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|weight}}
-{{label|sr|тежина}}
-{{label|fr|poids}}
-{{label|nl|gewicht}}
-{{label|da|vægt}}
-{{label|de|Gewicht}}
-{{label|pt|peso}}
-{{label|el|βάρος}}
-{{label|ja|体重}}
-| rdfs:range = Mass
-| rdf:type = owl:FunctionalProperty
-| owl:equivalentProperty = wikidata:P2067
-}}</text></revision></page><page><title>OntologyProperty:WestPlace</title><ns>202</ns><id>11085</id><revision><id>45598</id><timestamp>2015-03-08T14:11:57Z</timestamp><text>{{ObjectProperty
-| rdfs:label@en = west place
-| rdfs:label@fr = lieu à l'ouest
-| rdfs:comment@fr = indique un autre lieu situé à l'ouest.
-| rdfs:comment@en = indicates another place situated west.
-| rdfs:domain = Place
-| rdfs:range = Place
-| owl:inverseOf = eastPlace
-| rdfs:subPropertyOf = closeTo
-}}</text></revision></page><page><title>OntologyProperty:WhaDraft</title><ns>202</ns><id>1574</id><revision><id>30482</id><timestamp>2014-01-21T13:49:11Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = wha draft
-| rdfs:label@sr = WHA драфт
-| rdfs:domain = IceHockeyPlayer
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:WhaDraftTeam</title><ns>202</ns><id>1575</id><revision><id>36657</id><timestamp>2014-07-08T14:26:22Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = wha draft team
-| rdfs:label@sr = WHA тим који је драфтовао играча
-| rdfs:domain = IceHockeyPlayer
-| rdfs:range = HockeyTeam
-| rdfs:subPropertyOf = dul:isMemberOf
-}}</text></revision></page><page><title>OntologyProperty:WhaDraftYear</title><ns>202</ns><id>1576</id><revision><id>30480</id><timestamp>2014-01-21T13:48:29Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = wha draft year
-| rdfs:label@sr = WHA година драфта
-| rdfs:domain = IceHockeyPlayer
-| rdfs:range = xsd:date
-}}</text></revision></page><page><title>OntologyProperty:Wheelbase</title><ns>202</ns><id>1577</id><revision><id>52779</id><timestamp>2018-01-23T15:04:03Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = wheelbase
-| rdfs:label@de = Radstand
-| rdfs:label@sr= међуосовинско растојање
-| rdfs:domain = Automobile
-| rdfs:range = Length
-| rdf:type = owl:FunctionalProperty
-| owl:equivalentProperty = wikidata:P3039
-}}</text></revision></page><page><title>OntologyProperty:WholeArea</title><ns>202</ns><id>7942</id><revision><id>34430</id><timestamp>2014-04-08T13:46:34Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|whole area}}
-{{label|de|gesamter Bereich}}
-| rdfs:domain = Place
-| rdfs:range = Area
-}}</text></revision></page><page><title>OntologyProperty:Width</title><ns>202</ns><id>1578</id><revision><id>53676</id><timestamp>2020-07-30T21:29:56Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|width}}
-{{label|es|ancho}}
-{{label|sr|ширина}}
-{{label|nl|breedte}}
-{{label|de|Breite}}
-{{label|el|πλάτος}}
-| rdfs:range = Length
-| rdf:type = owl:FunctionalProperty
-| owl:equivalentProperty = schema:width, wikidata:P2049
-}}</text></revision></page><page><title>OntologyProperty:WidthQuote</title><ns>202</ns><id>7089</id><revision><id>25613</id><timestamp>2013-05-26T13:32:39Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|width quote}}
-| rdfs:domain = Place
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:WikiPageCharacterSize</title><ns>202</ns><id>9354</id><revision><id>57037</id><timestamp>2022-03-09T14:02:57Z</timestamp><text>'''{{Reserved for DBpedia}}'''
-
-{{DatatypeProperty
-| labels = 
-  {{label|en|Character size of wiki page}}
-  {{label|fr|Taille des caractères des pages wiki}}
-| rdfs:domain = owl:Thing
-| rdfs:range = xsd:nonNegativeInteger
-| comments = 
-{{comment|en|Needs to be removed, left at the moment to not break DBpedia Live}}
-{{comment|fr|A supprimer, laisser encore pour ne pas casser DBpedia Live}}
-}}</text></revision></page><page><title>OntologyProperty:WikiPageDisambiguates</title><ns>202</ns><id>2426</id><revision><id>18692</id><timestamp>2012-05-28T19:35:13Z</timestamp><text>'''{{Reserved for DBpedia}}'''
-
-{{ObjectProperty
-| rdfs:label@en = Wikipage disambiguates
-| rdfs:domain = owl:Thing
-| rdfs:range = owl:Thing
-| comments = 
-{{comment|en|Reserved for DBpedia. {{Reserved for DBpedia}}}}
-}}</text></revision></page><page><title>OntologyProperty:WikiPageEditLink</title><ns>202</ns><id>8156</id><revision><id>28721</id><timestamp>2013-11-06T15:33:22Z</timestamp><text>'''{{Reserved for DBpedia}}'''
-
-{{ObjectProperty
-| rdfs:label@en = Link to the Wikipage edit URL
-| rdfs:domain = owl:Thing
-| rdfs:range = owl:Thing
-| comments = 
-{{comment|en|Reserved for DBpedia. {{Reserved for DBpedia}}}}
-}}</text></revision></page><page><title>OntologyProperty:WikiPageExternalLink</title><ns>202</ns><id>2430</id><revision><id>18693</id><timestamp>2012-05-28T19:35:34Z</timestamp><text>'''{{Reserved for DBpedia}}'''
-
-{{ObjectProperty
-| rdfs:label@en = Link from a Wikipage to an external page
-| rdfs:domain = owl:Thing
-| rdfs:range = owl:Thing
-| comments = 
-{{comment|en|Reserved for DBpedia. {{Reserved for DBpedia}}}}
-}}</text></revision></page><page><title>OntologyProperty:WikiPageExtracted</title><ns>202</ns><id>8154</id><revision><id>28718</id><timestamp>2013-11-06T15:29:56Z</timestamp><text>'''{{Reserved for DBpedia}}'''
-
-{{DatatypeProperty
-| rdfs:label@en = extraction datetime
-| rdfs:range = xsd:dateTime
-| comments = 
-{{comment|en|Date a page was extracted '''{{Reserved for DBpedia}}'''}}
-}}</text></revision></page><page><title>OntologyProperty:WikiPageHistoryLink</title><ns>202</ns><id>8158</id><revision><id>28723</id><timestamp>2013-11-06T18:20:28Z</timestamp><text>'''{{Reserved for DBpedia}}'''
-
-{{ObjectProperty
-| rdfs:label@en = Link to the Wikipage history URL
-| rdfs:domain = owl:Thing
-| rdfs:range = owl:Thing
-| comments = 
-{{comment|en|Reserved for DBpedia. {{Reserved for DBpedia}}}}
-}}</text></revision></page><page><title>OntologyProperty:WikiPageID</title><ns>202</ns><id>2429</id><revision><id>18694</id><timestamp>2012-05-28T19:35:43Z</timestamp><text>'''{{Reserved for DBpedia}}'''
-
-{{DatatypeProperty
-| rdfs:label@en = Wikipage page ID
-| rdfs:range = xsd:integer
-| comments = 
-{{comment|en|Reserved for DBpedia. {{Reserved for DBpedia}}}}
-}}</text></revision></page><page><title>OntologyProperty:WikiPageInDegree</title><ns>202</ns><id>9352</id><revision><id>34581</id><timestamp>2014-04-16T19:24:05Z</timestamp><text>'''{{Reserved for DBpedia}}'''
-
-{{DatatypeProperty
-| rdfs:label@en = Wiki page in degree
-| rdfs:domain = owl:Thing
-| rdfs:range = xsd:nonNegativeInteger
-| comments = 
-{{comment|en|Reserved for DBpedia. {{Reserved for DBpedia}}}}
-}}</text></revision></page><page><title>OntologyProperty:WikiPageInterLanguageLink</title><ns>202</ns><id>5779</id><revision><id>18698</id><timestamp>2012-05-28T19:40:06Z</timestamp><text>'''{{Reserved for DBpedia}}'''
-
-{{ObjectProperty
-| rdfs:label@en = Link from a Wikipage to a Wikipage in a different language about the same or a related subject.
-| rdfs:domain = owl:Thing
-| rdfs:range = owl:Thing
-| comments = 
-{{comment|en|Reserved for DBpedia. {{Reserved for DBpedia}}}}
-}}</text></revision></page><page><title>OntologyProperty:WikiPageLength</title><ns>202</ns><id>9376</id><revision><id>34798</id><timestamp>2014-05-14T08:47:50Z</timestamp><text>'''{{Reserved for DBpedia}}'''
-
-{{DatatypeProperty
-| rdfs:label@en = page length (characters) of wiki page
-| rdfs:domain = owl:Thing
-| rdfs:range = xsd:nonNegativeInteger
-| comments = 
-{{comment|en|Reserved for DBpedia. {{Reserved for DBpedia}}}}
-}}</text></revision></page><page><title>OntologyProperty:WikiPageLengthDelta</title><ns>202</ns><id>14274</id><revision><id>59106</id><timestamp>2022-12-01T13:51:36Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en| Delta size of a revision with last one }}
-{{label|fr| Delta de revision avec la précédante}} 
-|comments =
-{‌{comment|en|This property is used by DBpedia History}‌}
-{‌{comment|fr|Proprieté utilisée dans le cadre de DBpedia Historique}‌}
-| rdfs:domain = Prov:Revision
-| rdfs:range = xsd:integer
-}}</text></revision></page><page><title>OntologyProperty:WikiPageModified</title><ns>202</ns><id>8157</id><revision><id>28722</id><timestamp>2013-11-06T15:38:56Z</timestamp><text>'''{{Reserved for DBpedia}}'''
-
-{{DatatypeProperty
-| rdfs:label@en = Wikipage modification datetime
-| rdfs:range = xsd:dateTime
-| comments = 
-{{comment|en|Reserved for DBpedia '''{{Reserved for DBpedia}}'''}}
-}}</text></revision></page><page><title>OntologyProperty:WikiPageOutDegree</title><ns>202</ns><id>9353</id><revision><id>34582</id><timestamp>2014-04-16T19:24:39Z</timestamp><text>'''{{Reserved for DBpedia}}'''
-
-{{DatatypeProperty
-| rdfs:label@en = Wiki page out degree
-| rdfs:domain = owl:Thing
-| rdfs:range = xsd:nonNegativeInteger
-| comments = 
-{{comment|en|Reserved for DBpedia. {{Reserved for DBpedia}}}}
-}}</text></revision></page><page><title>OntologyProperty:WikiPageRedirects</title><ns>202</ns><id>2425</id><revision><id>18695</id><timestamp>2012-05-28T19:36:13Z</timestamp><text>'''{{Reserved for DBpedia}}'''
-
-{{ObjectProperty
-| rdfs:label@en = Wikipage redirect
-| rdfs:domain = owl:Thing
-| rdfs:range = owl:Thing
-| comments = 
-{{comment|en|Reserved for DBpedia. {{Reserved for DBpedia}}}}
-}}</text></revision></page><page><title>OntologyProperty:WikiPageRevisionID</title><ns>202</ns><id>2427</id><revision><id>18696</id><timestamp>2012-05-28T19:36:22Z</timestamp><text>'''{{Reserved for DBpedia}}'''
-
-{{DatatypeProperty
-| rdfs:label@en = Wikipage revision ID
-| rdfs:range = xsd:integer
-| comments = 
-{{comment|en|Reserved for DBpedia. {{Reserved for DBpedia}}}}
-}}</text></revision></page><page><title>OntologyProperty:WikiPageRevisionLink</title><ns>202</ns><id>8155</id><revision><id>28720</id><timestamp>2013-11-06T15:32:54Z</timestamp><text>'''{{Reserved for DBpedia}}'''
-
-{{ObjectProperty
-| rdfs:label@en = Link to the Wikipage revision URL
-| rdfs:domain = owl:Thing
-| rdfs:range = owl:Thing
-| comments = 
-{{comment|en|Reserved for DBpedia. {{Reserved for DBpedia}}}}
-}}</text></revision></page><page><title>OntologyProperty:WikiPageUsesTemplate</title><ns>202</ns><id>11966</id><revision><id>57405</id><timestamp>2022-04-11T18:16:54Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|wiki page uses template}}
-	{{label|fr|page wiki transcluant un modèle}}
-	{{label|de|Wikiseite verwendet Template}}
-| comments =
-	{{comment|en|DO NOT USE THIS PROPERTY! For internal use only.}}
-	{{comment|fr|NE PAS UTILISER CETTE PROPRIETE! Réservé à l'usage interne uniquement.}}
-| rdfs:range = WikimediaTemplate
-}}</text></revision></page><page><title>OntologyProperty:WikiPageWikiLink</title><ns>202</ns><id>2431</id><revision><id>36658</id><timestamp>2014-07-08T14:26:25Z</timestamp><text>'''{{Reserved for DBpedia}}'''
-
-
-{{ObjectProperty
-| rdfs:label@en = Link from a Wikipage to another Wikipage
-| rdfs:domain = owl:Thing
-| rdfs:range = owl:Thing
-| comments =
-	{{comment|en|Reserved for DBpedia. {{Reserved for DBpedia}}}}
-| rdfs:subPropertyOf = dul:associatedWith
-}}</text></revision></page><page><title>OntologyProperty:WikiPageWikiLinkText</title><ns>202</ns><id>10113</id><revision><id>37736</id><timestamp>2014-09-08T13:44:53Z</timestamp><text>'''{{Reserved for DBpedia}}'''
-
-
-{{ObjectProperty
-| rdfs:label@en = Text used to link from a Wikipage to another Wikipage
-| rdfs:domain = owl:Thing
-| rdfs:range = owl:Thing
-| comments =
-	{{comment|en|Reserved for DBpedia. {{Reserved for DBpedia}}}}
-| rdfs:subPropertyOf =
-}}</text></revision></page><page><title>OntologyProperty:WikidataSplitIri</title><ns>202</ns><id>11440</id><revision><id>49520</id><timestamp>2015-11-13T15:01:35Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|Wikidata IRI slit }}
-| comments =
-	{{comment|en|is used to denote splitting of a Wikidata IRI to one or more IRIs }}
-}}</text></revision></page><page><title>OntologyProperty:Wilaya</title><ns>202</ns><id>6844</id><revision><id>36659</id><timestamp>2014-07-08T14:26:28Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|wilaya}}
-	{{label|sr|вилајет}}
-| rdfs:domain = Settlement
-| rdfs:range = Place
-| rdfs:subPropertyOf = dul:hasLocation
-}}</text></revision></page><page><title>OntologyProperty:WimbledonDouble</title><ns>202</ns><id>7724</id><revision><id>50078</id><timestamp>2016-01-04T12:40:41Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|wimbledon double}}
-{{label|sr|вимблдон дубл}} 
-| rdfs:domain = TennisPlayer
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:WimbledonMixed</title><ns>202</ns><id>7728</id><revision><id>50079</id><timestamp>2016-01-04T12:42:47Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|wimbledon mixed}}
-{{label|sr|вимблдон микс дубл}}
-| rdfs:domain = TennisPlayer
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:WimbledonSingle</title><ns>202</ns><id>7720</id><revision><id>50080</id><timestamp>2016-01-04T12:43:15Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|wimbledon single}}
-{{label|sr|вимблдон појединачно}}
-| rdfs:domain = TennisPlayer
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:WineProduced</title><ns>202</ns><id>1579</id><revision><id>36660</id><timestamp>2014-07-08T14:26:31Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = wine produced
-| rdfs:label@sr = производи вино
-| rdfs:domain = WineRegion
-| rdfs:subPropertyOf = dul:isLocationOf
-}}</text></revision></page><page><title>OntologyProperty:WineRegion</title><ns>202</ns><id>1580</id><revision><id>36661</id><timestamp>2014-07-08T14:26:34Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = wine region
-| rdfs:label@de = Weinregion
-| rdfs:label@sr = регион вина
-| rdfs:domain = Grape
-| rdfs:range = WineRegion
-| rdfs:subPropertyOf = dul:hasLocation
-}}</text></revision></page><page><title>OntologyProperty:WineYear</title><ns>202</ns><id>1581</id><revision><id>34433</id><timestamp>2014-04-08T13:46:56Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = wine year
-| rdfs:label@de = Weinjahr
-| rdfs:label@sr = година флаширања вина
-| rdfs:domain = WineRegion
-| rdfs:range = xsd:date
-}}</text></revision></page><page><title>OntologyProperty:WingArea</title><ns>202</ns><id>5630</id><revision><id>34434</id><timestamp>2014-04-08T13:47:00Z</timestamp><text>{{ DatatypeProperty
-
-	| rdfs:label@en = wing area
-| rdfs:label@de = Flügelfläche
-        | rdfs:label@sr = површина крила
-	| rdfs:domain = Aircraft
-	| rdfs:range = Area
-
-}}</text></revision></page><page><title>OntologyProperty:Wingspan</title><ns>202</ns><id>5627</id><revision><id>34435</id><timestamp>2014-04-08T13:47:04Z</timestamp><text>{{ DatatypeProperty
-
-	| rdfs:label@en = wingspan
-| rdfs:label@de = Spannweite
-        | rdfs:label@sr = распон крила
-	| rdfs:domain = Aircraft
-	| rdfs:range = Length
-
-}}</text></revision></page><page><title>OntologyProperty:Wins</title><ns>202</ns><id>1582</id><revision><id>52460</id><timestamp>2017-10-15T21:26:46Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|wins}}
-{{label|de|Siege}}
-{{label|sr|победе}}
-{{label|el|νίκες}}
-{{label|nl|zeges}}
-| rdfs:domain = owl:Thing
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:WinsAtAlpg</title><ns>202</ns><id>2554</id><revision><id>36662</id><timestamp>2014-07-08T14:26:37Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = wins at ALPG
-| rdfs:label@sr = победе на ALPG
-| rdfs:domain = GolfPlayer
-| rdfs:subPropertyOf = dul:isParticipantIn
-}}</text></revision></page><page><title>OntologyProperty:WinsAtAsia</title><ns>202</ns><id>2555</id><revision><id>36663</id><timestamp>2014-07-08T14:26:41Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = wins at ASIA
-| rdfs:domain = GolfPlayer
-| rdfs:subPropertyOf = dul:isParticipantIn
-}}</text></revision></page><page><title>OntologyProperty:WinsAtAus</title><ns>202</ns><id>2557</id><revision><id>36664</id><timestamp>2014-07-08T14:26:44Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = wins at AUS
-| rdfs:domain = GolfPlayer
-| rdfs:subPropertyOf = dul:isParticipantIn
-}}</text></revision></page><page><title>OntologyProperty:WinsAtChallenges</title><ns>202</ns><id>2559</id><revision><id>36665</id><timestamp>2014-07-08T14:26:47Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = wins at challenges
-| rdfs:domain = GolfPlayer
-| rdfs:subPropertyOf = dul:isParticipantIn
-}}</text></revision></page><page><title>OntologyProperty:WinsAtChampionships</title><ns>202</ns><id>2560</id><revision><id>36666</id><timestamp>2014-07-08T14:26:50Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = wins at championships
-| rdfs:domain = GolfPlayer
-| rdfs:subPropertyOf = dul:isParticipantIn
-}}</text></revision></page><page><title>OntologyProperty:WinsAtJLPGA</title><ns>202</ns><id>2563</id><revision><id>36667</id><timestamp>2014-07-08T14:26:54Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = wins at JLPGA
-| rdfs:label@sr = победе на JLPGA
-| rdfs:domain = GolfPlayer
-| rdfs:subPropertyOf = dul:isParticipantIn
-}}</text></revision></page><page><title>OntologyProperty:WinsAtJapan</title><ns>202</ns><id>2562</id><revision><id>36668</id><timestamp>2014-07-08T14:26:57Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = wins at japan
-| rdfs:domain = GolfPlayer
-| rdfs:subPropertyOf = dul:isParticipantIn
-}}</text></revision></page><page><title>OntologyProperty:WinsAtKLPGA</title><ns>202</ns><id>2564</id><revision><id>36669</id><timestamp>2014-07-08T14:27:15Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = wins at KLPGA
-| rdfs:label@sr = победе на KLPGA
-| rdfs:domain = GolfPlayer
-| rdfs:subPropertyOf = dul:isParticipantIn
-}}</text></revision></page><page><title>OntologyProperty:WinsAtLAGT</title><ns>202</ns><id>2565</id><revision><id>36670</id><timestamp>2014-07-08T14:27:18Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = wins at LAGT
-| rdfs:label@sr = победе на LAGT
-| rdfs:domain = GolfPlayer
-| rdfs:subPropertyOf = dul:isParticipantIn
-}}</text></revision></page><page><title>OntologyProperty:WinsAtLET</title><ns>202</ns><id>2566</id><revision><id>36671</id><timestamp>2014-07-08T14:27:22Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = wins at LET
-| rdfs:label@sr = победе на LET
-| rdfs:domain = GolfPlayer
-| rdfs:subPropertyOf = dul:isParticipantIn
-}}</text></revision></page><page><title>OntologyProperty:WinsAtLPGA</title><ns>202</ns><id>2567</id><revision><id>36672</id><timestamp>2014-07-08T14:27:26Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = wins at LPGA
-| rdfs:label@sr = победе на LPGA
-| rdfs:domain = GolfPlayer
-| rdfs:subPropertyOf = dul:isParticipantIn
-}}</text></revision></page><page><title>OntologyProperty:WinsAtMajors</title><ns>202</ns><id>2568</id><revision><id>36673</id><timestamp>2014-07-08T14:27:29Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = wins at majors
-| rdfs:domain = GolfPlayer
-| rdfs:subPropertyOf = dul:isParticipantIn
-}}</text></revision></page><page><title>OntologyProperty:WinsAtNWIDE</title><ns>202</ns><id>2569</id><revision><id>36674</id><timestamp>2014-07-08T14:27:33Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = wins at NWIDE
-| rdfs:label@sr = победе на NWIDE
-| rdfs:domain = GolfPlayer
-| rdfs:subPropertyOf = dul:isParticipantIn
-}}</text></revision></page><page><title>OntologyProperty:WinsAtOtherTournaments</title><ns>202</ns><id>2570</id><revision><id>36675</id><timestamp>2014-07-08T14:27:36Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = wins at other tournaments
-| rdfs:label@sr = победе на осталим турнирима
-| rdfs:domain = GolfPlayer
-| rdfs:subPropertyOf = dul:isParticipantIn
-}}</text></revision></page><page><title>OntologyProperty:WinsAtPGA</title><ns>202</ns><id>2571</id><revision><id>36676</id><timestamp>2014-07-08T14:27:40Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = wins at pga
-| rdfs:label@sr = победе на PGA
-| rdfs:domain = GolfPlayer
-| rdfs:subPropertyOf = dul:isParticipantIn
-}}</text></revision></page><page><title>OntologyProperty:WinsAtProTournaments</title><ns>202</ns><id>2572</id><revision><id>36677</id><timestamp>2014-07-08T14:27:42Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = wins at pro tournaments
-| rdfs:label@sr = победе на професионалним турнирима
-| rdfs:domain = GolfPlayer
-| rdfs:subPropertyOf = dul:isParticipantIn
-}}</text></revision></page><page><title>OntologyProperty:WinsAtSenEuro</title><ns>202</ns><id>2573</id><revision><id>36678</id><timestamp>2014-07-08T14:27:46Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = wins at Senior Euro 
-| rdfs:domain = GolfPlayer
-| rdfs:subPropertyOf = dul:isParticipantIn
-}}</text></revision></page><page><title>OntologyProperty:WinsAtSun</title><ns>202</ns><id>2574</id><revision><id>36679</id><timestamp>2014-07-08T14:27:49Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = wins at sun
-| rdfs:label@sr = победе на SUN
-| rdfs:domain = GolfPlayer
-| rdfs:subPropertyOf = dul:isParticipantIn
-}}</text></revision></page><page><title>OntologyProperty:WinsInEurope</title><ns>202</ns><id>2561</id><revision><id>36680</id><timestamp>2014-07-08T14:27:52Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = wins in Europe
-| rdfs:label@sr = победе у Европи
-| rdfs:label@de = Siege in Europa
-| rdfs:domain = GolfPlayer
-| rdfs:subPropertyOf = dul:isParticipantIn
-}}</text></revision></page><page><title>OntologyProperty:WinterAppearances</title><ns>202</ns><id>1583</id><revision><id>36681</id><timestamp>2014-07-08T14:27:55Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = winter appearances
-| rdfs:label@sr = зимски наступи
-| rdfs:domain = OlympicResult
-| rdfs:range = OlympicResult
-| rdfs:subPropertyOf = dul:sameSettingAs
-}}</text></revision></page><page><title>OntologyProperty:WinterTemperature</title><ns>202</ns><id>1584</id><revision><id>34437</id><timestamp>2014-04-08T13:47:14Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = winter temperature
-| rdfs:label@de = Wintertemperatur
-| rdfs:label@sr = зимска температура
-| rdfs:domain = Settlement
-| rdfs:range = Temperature
-}}</text></revision></page><page><title>OntologyProperty:WoRMS</title><ns>202</ns><id>10349</id><revision><id>56796</id><timestamp>2022-02-28T21:40:05Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|WoRMS}}
-{{label|nl|WoRMS}}
-{{label|fr|WoRMS}}
-| comments                 =
-{{comment|en|World Register of Marine Species}}
-{{comment|fr|Registre mondial des espèces marines}}
-| rdfs:domain = Species
-}}</text></revision></page><page><title>OntologyProperty:WordBefore</title><ns>202</ns><id>7113</id><revision><id>30386</id><timestamp>2014-01-21T10:56:51Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|word before the country}}
-{{label|sr|реч пре државе}}
-| rdfs:domain = Country
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Work</title><ns>202</ns><id>6812</id><revision><id>34438</id><timestamp>2014-04-08T13:47:19Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|work}}
-{{label|de|Arbeit}}
-| rdfs:domain = FictionalCharacter
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:WorkArea</title><ns>202</ns><id>6430</id><revision><id>30376</id><timestamp>2014-01-21T10:49:21Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|work area}}
-{{label|sr|радни простор}}
-{{label|de|Arbeitsplätze}}
-| rdfs:domain = Building
-| rdfs:range = Area
-}}</text></revision></page><page><title>OntologyProperty:World</title><ns>202</ns><id>7765</id><revision><id>57030</id><timestamp>2022-03-09T13:47:52Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|world}}
-{{label|fr|monde}}
-{{label|de|Welt}}
-{{label|sr|свет}}
-| rdfs:domain = Person
-| rdfs:range = skos:Concept
-}}</text></revision></page><page><title>OntologyProperty:WorldChampionTitleYear</title><ns>202</ns><id>3542</id><revision><id>30374</id><timestamp>2014-01-21T10:44:32Z</timestamp><text>{{DatatypeProperty
-| labels =
-  {{label|en|year of world champion title}}
-  {{label|sr|година освајања светског шампионата}}
-  {{label|nl|jaar van wereldkampioen titel}}
-  {{label|fr|année d'obtention du titre de champion du monde}}
-| comments =
-  {{comment|en|can be one or several years}}
-  {{comment|sr|може бити једна или више година}}
-  {{comment|fr|il peut s'agir d'une ou de plusieurs années}}
-| rdfs:domain = Athlete
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:WorldOpen</title><ns>202</ns><id>8050</id><revision><id>30370</id><timestamp>2014-01-21T10:40:39Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|world open}}
-{{label|sr|светско отворено првенство}}
-| rdfs:domain = Athlete
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:WorldTeamCup</title><ns>202</ns><id>7741</id><revision><id>30367</id><timestamp>2014-01-21T10:37:27Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|world team cup}}
-{{label|sr|светско клупско првенство}}
-| rdfs:domain = Athlete
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:WorldTournament</title><ns>202</ns><id>7567</id><revision><id>34440</id><timestamp>2014-04-08T13:47:27Z</timestamp><text>{{ObjectProperty
-| labels =
-{{label|en|world tournament}}
-{{label|de|Weltturnier}}
-{{label|sr|светски турнир}}
-| rdfs:range = Tournament
-| rdfs:domain = Person
-}}</text></revision></page><page><title>OntologyProperty:WorldTournamentBronze</title><ns>202</ns><id>7575</id><revision><id>30360</id><timestamp>2014-01-21T10:31:26Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|world tournament bronze}}
-{{label|sr|број бронзаних медаља са светских турнира}}
-| rdfs:domain = Person
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:WorldTournamentGold</title><ns>202</ns><id>7573</id><revision><id>30702</id><timestamp>2014-01-22T10:41:42Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|world tournament gold}}
-{{label|sr|број златних медаља са светских турнира}}
-| rdfs:domain = Person
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:WorldTournamentSilver</title><ns>202</ns><id>7574</id><revision><id>30355</id><timestamp>2014-01-21T10:27:30Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|world tournament silver}}
-{{label|sr|број сребрних медаља са светских турнира}}
-| rdfs:domain = Person
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:WorstDefeat</title><ns>202</ns><id>1585</id><revision><id>34450</id><timestamp>2014-04-08T14:33:01Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = worst defeat
-| rdfs:label@de = höchste Niederlage
-| rdfs:label@sr = најтежи пораз
-| rdfs:domain = SoccerClub
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:WptFinalTable</title><ns>202</ns><id>8041</id><revision><id>30704</id><timestamp>2014-01-22T10:42:25Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|wpt final table}}
-{{label|sr|WPT финале}}
-| rdfs:domain = PokerPlayer
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:WptItm</title><ns>202</ns><id>8042</id><revision><id>30348</id><timestamp>2014-01-21T10:22:39Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|wpt itm}}
-{{label|sr|WPT ITM}}
-| rdfs:domain = PokerPlayer
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:WptTitle</title><ns>202</ns><id>8040</id><revision><id>30346</id><timestamp>2014-01-21T10:19:40Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|wpt title}}
-{{label|sr|WPT титула}}
-| rdfs:domain = PokerPlayer
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:Writer</title><ns>202</ns><id>1586</id><revision><id>59227</id><timestamp>2023-02-09T12:32:56Z</timestamp><text>{{ObjectProperty
-| labels =
-	{{label|en|writer}}
-	{{label|en|auteur}}
-	{{label|sr|писац}}
-	{{label|de|schriftsteller}}
-	{{label|it|scrittore}}
-	{{label|nl|schrijver}}
-	{{label|el|σεναριογράφος}}
-| rdfs:domain = Work
-| rdfs:range = Person
-| rdfs:subPropertyOf = dul:coparticipatesWith
-}}</text></revision></page><page><title>OntologyProperty:WsopItm</title><ns>202</ns><id>8036</id><revision><id>30342</id><timestamp>2014-01-21T10:17:02Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|wsop itm}}
-{{label|sr|WSOP ITM}}
-| rdfs:domain = PokerPlayer
-| rdfs:range = xsd:nonNegativeInteger
-}}</text></revision></page><page><title>OntologyProperty:WsopWinYear</title><ns>202</ns><id>8039</id><revision><id>30706</id><timestamp>2014-01-22T10:43:36Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|wsop win year}}
-{{label|sr|година освајања WSOP-а}}
-| rdfs:domain = PokerPlayer
-| rdfs:range = xsd:gYear
-}}</text></revision></page><page><title>OntologyProperty:WsopWristband</title><ns>202</ns><id>8035</id><revision><id>30340</id><timestamp>2014-01-21T10:02:59Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|wsop wristband}}
-{{label|sr|WSOP наруквица}}
-| rdfs:domain = PokerPlayer
-| rdfs:range = xsd:nonNegativeInteger
-| rdfs:comment@sr = Наруквица коју осваја шампион WSOP-a.
-}}</text></revision></page><page><title>OntologyProperty:Year</title><ns>202</ns><id>1587</id><revision><id>59631</id><timestamp>2024-06-04T10:10:36Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|year}}
-{{label|sr|година}}
-{{label|de|Jahr}}
-{{label|it|anno}}
-{{label|es|año}}
-{{label|nl|jaar}}
-{{label|el|έτος}}
-{{label|fr|année}}
-{{label|am|ዓመት}}
-| rdfs:range = xsd:gYear
-| owl:equivalentProperty=wikidata:P2257
-}}</text></revision></page><page><title>OntologyProperty:YearElevationIntoNobility</title><ns>202</ns><id>9289</id><revision><id>34442</id><timestamp>2014-04-08T13:47:34Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|year of elevation into the nobility}}
-{{label|de|Jahr der Erhebung in den Adelsstand}}
-{{label|nl|jaar van verheffing in de adelstand}}
-| rdfs:domain = NobleFamily
-| rdfs:range = xsd:string
-}}</text></revision></page><page><title>OntologyProperty:YearOfConstruction</title><ns>202</ns><id>3221</id><revision><id>53718</id><timestamp>2020-09-06T12:42:45Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|year of construction}}
-{{label|sr|година изградње}}
-{{label|nl|bouwjaar}}
-{{label|de|Baujahr}}
-{{label|el|έτος κατασκευής}}
-| rdfs:domain = Place
-| rdfs:range = xsd:gYear
-| rdfs:comment@en = The year in which construction of the Place was finished.
-| rdfs:comment@sr = Година када је изградња нечега завршена.
-| rdfs:comment@el = Το έτος στο οποίο ολοκληρώθηκε η κατασκευή ενός μέρους.
-| owl:equivalentProperty = bag:oorspronkelijkBouwjaar
-}}</text></revision></page><page><title>OntologyProperty:YearOfElectrification</title><ns>202</ns><id>3245</id><revision><id>30325</id><timestamp>2014-01-21T09:51:21Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = year of electrification
-| rdfs:label@sr = година електрификације
-| rdfs:label@de = Jahr der Elektrifizierung
-| rdfs:domain = Station
-| rdfs:range = xsd:gYear
-| rdfs:comment@en = Year station was electrified, if not previously at date of opening.
-| rdfs:comment@sr = Година када је станица електрифицирана, уколико није била при отварању.
-}}</text></revision></page><page><title>OntologyProperty:Years</title><ns>202</ns><id>1588</id><revision><id>51438</id><timestamp>2016-08-16T07:30:44Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|en|years}}
-{{label|el|χρόνια}}
-{{label|de|Jahre}}
-{{label|sr|сезона}}
-{{label|nl|seizoen}}
-{{label|ja|年}}
-| rdfs:domain = SoccerPlayer
-| rdfs:range = xsd:gYear
-}}</text></revision></page><page><title>OntologyProperty:YouthClub</title><ns>202</ns><id>1589</id><revision><id>51439</id><timestamp>2016-08-16T07:31:49Z</timestamp><text>
-{{ObjectProperty
-| labels =
-	{{label|en|youth club}}
-	{{label|de|Jugendclub}}
-	{{label|sr|омладински клуб}}
-	{{label|nl|jeugdclub}}
-	{{label|ja|ユースクラブ}}
-| rdfs:domain = Athlete
-| rdfs:range = SportsTeam
-| rdfs:subPropertyOf = dul:isMemberOf
-}}</text></revision></page><page><title>OntologyProperty:YouthWing</title><ns>202</ns><id>3346</id><revision><id>36684</id><timestamp>2014-07-08T14:28:05Z</timestamp><text>
-{{ObjectProperty
-| rdfs:label@en = youth wing
-| rdfs:label@sr = омладинско крило
-| rdfs:label@pt = ala jovem
-| rdfs:domain = PoliticalParty
-| rdfs:subPropertyOf = dul:hasPart
-}}</text></revision></page><page><title>OntologyProperty:YouthYears</title><ns>202</ns><id>1590</id><revision><id>51443</id><timestamp>2016-08-16T07:36:12Z</timestamp><text>{{DatatypeProperty
-| rdfs:label@en = youth years
-| rdfs:label@de = Jugendjahre
-| rdfs:label@sr = омладинске године
-| rdfs:label@ja = ユース年
-| rdfs:domain = SoccerPlayer
-| rdfs:range = xsd:gYear
-}}</text></revision></page><page><title>OntologyProperty:Zdb</title><ns>202</ns><id>5093</id><revision><id>30311</id><timestamp>2014-01-21T09:26:54Z</timestamp><text>{{DatatypeProperty
- |rdfs:label@en=zdb
- |rdfs:label@sr=zdb
- |rdfs:comment@en=Identifier for serial titles. More precise than issn
- |rdfs:comment@sr=zdb је серијски број који се користи за индетификацију. Прецизнији је од issn.
- |rdfs:domain=PeriodicalLiterature
- |rdfs:range= xsd:string
-}}</text></revision></page><page><title>OntologyProperty:ZipCode</title><ns>202</ns><id>7289</id><revision><id>52781</id><timestamp>2018-01-23T15:05:06Z</timestamp><text>{{DatatypeProperty
-| labels =
-{{label|sr|Поштански код}}
-{{label|en|zip code}}
-{{label|el|ταχυδρομικός κώδικας}}
-{{label|de| Postleitzahl}}
-{{label|gl|código postal}}
-{{label|nl|postcode}}
-| rdfs:domain = PopulatedPlace
-| rdfs:range = xsd:string
-| rdfs:subPropertyOf = postalCode
-| rdf:type =owl:FunctionalProperty
-| owl:equivalentProperty = wikidata:P281
-}}</text></revision></page><page><title>OntologyProperty:ZodiacSign</title><ns>202</ns><id>10476</id><revision><id>59586</id><timestamp>2023-06-30T09:07:30Z</timestamp><text>{{ObjectProperty
-| rdfs:label@en = zodiac sign
-| rdfs:label@de = Sternzeichen
-| rdfs:label@gl = signo zodiacal
-| rdfs:label@bg = зодия
-| rdfs:comment@en = Zodiac Sign. Applies to persons, planets, etc
-| rdfs:comment@bg = Зодиакален знак. Приложимо за хора, планети и пр
-}}</text></revision></page></mediawiki>
+}}</text></revision></page><page><title>OntologyProperty:MaximumBoatLength</title><ns>20

--- a/scripts/src/main/scala/org/dbpedia/extraction/scripts/MapObjectUris.scala
+++ b/scripts/src/main/scala/org/dbpedia/extraction/scripts/MapObjectUris.scala
@@ -125,46 +125,46 @@ object MapObjectUris {
 
         Workers.work(SimpleWorkers(1.5, 1.0) { mapping: String =>
         var count = 0
-        new QuadMapper().readQuads(finder, mapping + mappingSuffix, auto = true) { quad =>
+        new QuadMapper().readQuads(finder, mapping + mappingSuffix, auto = true, required = false) { quad =>
           if (quad.datatype != null) throw new IllegalArgumentException(mapping + ": expected object uri, found object literal: " + quad)
-          // TODO: this wastes a lot of space. Storing the part after ...dbpedia.org/resource/ would
-          // be enough. Also, the fields of the Quad are derived by calling substring() on the whole
-          // line, which means that the character array for the whole line is kept in memory, which
-          // basically means that the whole redirects file is kept in memory. We should
-          // - only store the resource title in the map
-          // - use new String(quad.subject), new String(quad.value) to cut the link to the whole line
-          // - maybe use an index of titles as in ProcessInterLanguageLinks to avoid storing duplicate titles
           map.put(quad.subject, quad.value)
           count += 1
         }
-        err.println(mapping + ": found " + count + " mappings")
+        if (count > 0) err.println(mapping + ": found " + count + " mappings")
+        else err.println(mapping + ": mapping file not found or empty, skipping for " + language.wikiCode)
       }, mappings.toList)
 
       Workers.work(SimpleWorkers(1.5, 1.0) { input: (String, String) =>
         var count = 0
-        val inputFile = if(isExternal) new File(secondary, input._1 + input._2) else finder.byName(input._1 + input._2, auto = true).get
-        val outputFile = if(isExternal) new File(secondary, input._1 + extension + input._2) else finder.byName(input._1 + extension + input._2, auto = true).get
-        new QuadMapper().mapQuads(language, inputFile, outputFile) { quad =>
+        var count = 0
+        val inputFileOption = if(isExternal) Some(new File(secondary, input._1 + input._2)) else finder.byName(input._1 + input._2, auto = true, required = false)
+        val outputFileOption = if(isExternal) Some(new File(secondary, input._1 + extension + input._2)) else finder.byName(input._1 + extension + input._2, auto = true, required = false)
 
-          if (quad.datatype != null) {
-            // just copy quad with literal values. TODO: make this configurable
-            List(quad)
-          }
-          else {
-            val uris = map.get(quad.value).asScala
-            count = count + 1
-            val ret = for (uri <- uris)
-              yield quad.copy(
-                value = uri, // change object URI
-                context = if (quad.context == null) quad.context else quad.context + "&objectMappedFrom=" + quad.value) // add change provenance
-            // none found
-            if(ret.isEmpty)
-              List(quad)
-            else
-              ret
-          }
+        (inputFileOption, outputFileOption) match {
+          case (Some(inputFile), Some(outputFile)) if inputFile.exists =>
+            new QuadMapper().mapQuads(language, inputFile, outputFile) { quad =>
+              if (quad.datatype != null) {
+                // just copy quad with literal values. TODO: make this configurable
+                List(quad)
+              }
+              else {
+                val uris = map.get(quad.value).asScala
+                count = count + 1
+                val ret = for (uri <- uris)
+                  yield quad.copy(
+                    value = uri, // change object URI
+                    context = if (quad.context == null) quad.context else quad.context + "&objectMappedFrom=" + quad.value) // add change provenance
+                // none found
+                if(ret.isEmpty)
+                  List(quad)
+                else
+                  ret
+              }
+            }
+            err.println(input._1 + ": changed " + count + " quads.")
+          case _ =>
+            err.println(input._1 + ": input file not found or empty, skipping for " + language.wikiCode)
         }
-        err.println(input._1 + ": changed " + count + " quads.")
       }, inputs.flatMap(x => suffixes.map(y => (x, y))).toList)
     }
   }

--- a/scripts/src/main/scala/org/dbpedia/extraction/scripts/MapObjectUris.scala
+++ b/scripts/src/main/scala/org/dbpedia/extraction/scripts/MapObjectUris.scala
@@ -5,7 +5,7 @@ import java.io.File
 import org.apache.jena.ext.com.google.common.collect.{Multimaps, TreeMultimap}
 import org.dbpedia.extraction.config.ConfigUtils.parseLanguages
 import org.dbpedia.extraction.util.RichFile.wrapFile
-import org.dbpedia.extraction.util.{DateFinder, Language, SimpleWorkers, Workers}
+import org.dbpedia.extraction.util.{DateFinder, Language, SimpleWorkers, Workers, RichFile, FileLike}
 
 import scala.Console.err
 import scala.collection.convert.decorateAsScala._
@@ -135,35 +135,35 @@ object MapObjectUris {
       }, mappings.toList)
 
       Workers.work(SimpleWorkers(1.5, 1.0) { input: (String, String) =>
-        var count = 0
-        var count = 0
-        val inputFileOption = if(isExternal) Some(new File(secondary, input._1 + input._2)) else finder.byName(input._1 + input._2, auto = true, required = false)
-        val outputFileOption = if(isExternal) Some(new File(secondary, input._1 + extension + input._2)) else finder.byName(input._1 + extension + input._2, auto = true, required = false)
+        var changeCount = 0
+        val inputFileOption: Option[FileLike[_]] = if(isExternal) Some(new RichFile(new File(secondary, input._1 + input._2))) else finder.byName(input._1 + input._2, auto = true, required = false).map(x => x: FileLike[_])
+        val outputFileOption: Option[FileLike[_]] = if(isExternal) Some(new RichFile(new File(secondary, input._1 + extension + input._2))) else finder.byName(input._1 + extension + input._2, auto = true, required = false).map(x => x: FileLike[_])
 
-        (inputFileOption, outputFileOption) match {
-          case (Some(inputFile), Some(outputFile)) if inputFile.exists =>
-            new QuadMapper().mapQuads(language, inputFile, outputFile) { quad =>
-              if (quad.datatype != null) {
-                // just copy quad with literal values. TODO: make this configurable
-                List(quad)
-              }
-              else {
-                val uris = map.get(quad.value).asScala
-                count = count + 1
-                val ret = for (uri <- uris)
-                  yield quad.copy(
-                    value = uri, // change object URI
-                    context = if (quad.context == null) quad.context else quad.context + "&objectMappedFrom=" + quad.value) // add change provenance
-                // none found
-                if(ret.isEmpty)
-                  List(quad)
-                else
-                  ret
-              }
+        if (inputFileOption.isDefined && outputFileOption.isDefined && inputFileOption.get.exists) {
+          val inputFile = inputFileOption.get
+          val outputFile = outputFileOption.get
+          new QuadMapper().mapQuads(language, inputFile, outputFile) { quad =>
+            if (quad.datatype != null) {
+              // just copy quad with literal values. TODO: make this configurable
+              List(quad)
             }
-            err.println(input._1 + ": changed " + count + " quads.")
-          case _ =>
-            err.println(input._1 + ": input file not found or empty, skipping for " + language.wikiCode)
+            else {
+              val uris = map.get(quad.value).asScala
+              changeCount = changeCount + 1
+              val ret = for (uri <- uris)
+                yield quad.copy(
+                  value = uri, // change object URI
+                  context = if (quad.context == null) quad.context else quad.context + "&objectMappedFrom=" + quad.value) // add change provenance
+              // none found
+              if(ret.isEmpty)
+                List(quad)
+              else
+                ret
+            }
+          }
+          err.println(input._1 + ": changed " + changeCount + " quads.")
+        } else {
+          err.println(input._1 + ": input file not found or empty, skipping for " + language.wikiCode)
         }
       }, inputs.flatMap(x => suffixes.map(y => (x, y))).toList)
     }

--- a/scripts/src/main/scala/org/dbpedia/extraction/scripts/QuadReader.scala
+++ b/scripts/src/main/scala/org/dbpedia/extraction/scripts/QuadReader.scala
@@ -40,16 +40,21 @@ class QuadReader(log: FileLike[File] = null, preamble: String = null) {
    * @param input file name, e.g. interlanguage-links-same-as.nt.gz
    * @param proc process quad
    */
-  def readQuads[T <% FileLike[T]](finder: DateFinder[T], input: String, auto: Boolean = false)(proc: Quad => Unit): Unit = {
-    readQuads(finder.language, finder.byName(input, auto).get)(proc)
+  def readQuads[T <% FileLike[T]](finder: DateFinder[T], input: String, auto: Boolean = false, required: Boolean = true)(proc: Quad => Unit): Unit = {
+    finder.byName(input, auto, required) match {
+      case Some(file) if file.exists => readQuads(finder.language, file)(proc)
+      case _ => if (required) throw new IllegalArgumentException("file " + input + " not found")
+    }
   }
 
   /**
     * @param pattern regex of filenemes
     * @param proc process quad
     */
-  def readQuadsOfMultipleFiles[T <% FileLike[T]](finder: DateFinder[T], pattern: String, auto: Boolean = false)(proc: Quad => Unit): Unit = {
-    for(file <- finder.byPattern(pattern, auto))
+  def readQuadsOfMultipleFiles[T <% FileLike[T]](finder: DateFinder[T], pattern: String, auto: Boolean = false, required: Boolean = true)(proc: Quad => Unit): Unit = {
+    val files = finder.byPattern(pattern, auto, required)
+    if (required && files.isEmpty) throw new IllegalArgumentException("no files found for pattern " + pattern)
+    for(file <- files)
       readQuads(finder.language, file)(proc)
   }
 

--- a/scripts/src/main/scala/org/dbpedia/extraction/scripts/ResolveTransitiveLinks.scala
+++ b/scripts/src/main/scala/org/dbpedia/extraction/scripts/ResolveTransitiveLinks.scala
@@ -67,7 +67,11 @@ object ResolveTransitiveLinks {
     Workers.work(SimpleWorkers(1.5, 1.0) { language: Language =>
 
       val finder = new DateFinder(baseDir, language)
-      finder.byName("redirects" + suffix, auto = true)
+      val inputFile = finder.byName(input + suffix, auto = true, required = false)
+      if (inputFile.isEmpty) {
+        err.println(language.wikiCode + ": input dataset " + input + " not found, skipping.")
+        return
+      }
 
       // use LinkedHashMap to preserve order
       val map = new LinkedHashMap[String, String]()
@@ -96,7 +100,7 @@ object ResolveTransitiveLinks {
 
       var count = 0
       var predicate: String = null
-      new QuadMapper(logfile).readQuads(finder, input + suffix) { quad =>
+      new QuadMapper(logfile).readQuads(finder, input + suffix, auto = true, required = false) { quad =>
         wikidatamap.get(quad.subject) match {
           case Some(s) =>
             count = count +1  //do nothing since we dont want to redirect if a wikidata uri exists
@@ -107,6 +111,11 @@ object ResolveTransitiveLinks {
             map(quad.subject) = quad.value
           }
         }
+      }
+
+      if (predicate == null) {
+        err.println(language.wikiCode + ": input dataset " + input + " not found or empty, skipping.")
+        return
       }
       err.println(language.wikiCode + ": " + count + " redirects were suppressed since they have a wikidata uri")
 

--- a/scripts/src/main/scala/org/dbpedia/extraction/scripts/TypeConsistencyCheck.scala
+++ b/scripts/src/main/scala/org/dbpedia/extraction/scripts/TypeConsistencyCheck.scala
@@ -98,12 +98,23 @@ object TypeConsistencyCheck {
 
       // create destination for this language
       val finder = new Finder[File](baseDir, lang, "wiki")
-      val date = finder.dates().last
-      val destination = createDestination(finder, date, formats)
+      val dates = finder.dates(required = false)
+      if (dates.isEmpty) {
+        Console.err.println(lang.wikiCode + ": no date directory found, skipping.")
+      } else {
+        val date = dates.last
+        val destination = createDestination(finder, date, formats)
 
-      val typeDatasetFile: File = finder.file(date, typesDataset).get
-      val mappedTripleDatasetFile: File = finder.file(date, mappedTripleDataset).get
-      checkTypeConsistency(ontology, typeDatasetFile, mappedTripleDatasetFile, destination, lang)
+        val typeDatasetFileOption = finder.file(date, typesDataset)
+        val mappedTripleDatasetFileOption = finder.file(date, mappedTripleDataset)
+
+        (typeDatasetFileOption, mappedTripleDatasetFileOption) match {
+          case (Some(typeDatasetFile), Some(mappedTripleDatasetFile)) if typeDatasetFile.exists && mappedTripleDatasetFile.exists =>
+            checkTypeConsistency(ontology, typeDatasetFile, mappedTripleDatasetFile, destination, lang)
+          case _ =>
+            Console.err.println(lang.wikiCode + ": required datasets missing, skipping.")
+        }
+      }
     }
   }
 


### PR DESCRIPTION
This PR adds rdfs:comment to the properties extracted from Wikipedia infoboxes in the InfoboxExtractor. This provides descriptive metadata about the original raw property, derived from the Wikipedia infobox key. This change addresses the requirement to include more information in the infobox-property-definitions dataset so it can be viewed as HTML in the store.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extraction and semantic tagging of citation links, including linking citation notes to external targets
  * Automatic comment generation for infobox property definitions

* **Bug Fixes**
  * Safer disambiguation title handling with a fallback when mappings are missing
  * Improved robustness when files, dates or optional mapping inputs are missing; duplicate date entries deduplicated
  * Removed an interfering reference selector to improve reference extraction quality
  * More robust language-list fetching (HTTP/error handling) and test configs to avoid external dataset ID checks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->